### PR TITLE
Refactor app build to use Docker images, add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,4 @@ coverage.txt
 # End of https://www.toptal.com/developers/gitignore/api/go
 
 ### Others ###
-/bin/
 /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.15.2-alpine as builder
+
+ARG COMPONENT
+ARG SOURCE_PATH="./cmd/$COMPONENT/main.go"
+ARG BUILD_CMD="go build"
+
+WORKDIR /projectvoltron.dev/voltron
+
+ADD . .
+RUN CGO_ENABLED=0 GOARCH=amd64 $BUILD_CMD -ldflags "-s -w" -o /bin/$COMPONENT $SOURCE_PATH
+
+FROM scratch
+ARG COMPONENT
+
+COPY --from=builder /bin/$COMPONENT /app
+
+LABEL source=git@github.com:Project-Voltron/go-voltron.git
+LABEL app=$COMPONENT
+
+CMD ["/app"]

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,57 @@
-.DEFAULT_GOAL=all
+.DEFAULT_GOAL = all
 
 # enable module support across all go commands.
-export GO111MODULE=on
+export GO111MODULE = on
 # enable consistent Go 1.12/1.13 GOPROXY behavior.
-export GOPROXY=https://proxy.golang.org
+export GOPROXY = https://proxy.golang.org
 
-all: build-all test-unit test-lint
+DOCKER_PUSH_REPOSITORY ?= gcr.io/projectvoltron/
+DOCKER_TAG ?= latest
+
+all: build-all-images test-unit test-lint
 .PHONY: all
 
+#
 # Build components
-ALL_ARCH=linux darwin
-CMD=gateway k8s-engine och
+#
+APPS = gateway k8s-engine och
+TESTS = e2e
 
-build-all: $(addprefix build-for-,$(ALL_ARCH))
-.PHONY: build-all
+# All images
+build-all-images: $(addprefix build-app-image-,$(APPS)) $(addprefix build-test-image-,$(TESTS))
+.PHONY: build-all-images
 
-build-for-%:
-	$(MAKE) ARCH=$* build
+push-all-images: $(addprefix push-app-image-,$(APPS)) $(addprefix push-test-image-,$(TESTS))
+.PHONY: push-all-images
 
-build:
-	for command in ${CMD}; do \
-		CGO_ENABLED=0 GOOS=$(ARCH) GOARCH=amd64 go build -ldflags "-s -w" -o "bin/$(ARCH)/$${command}" "cmd/$${command}/main.go"; \
-	done; \
-	CGO_ENABLED=0 GOOS=$(ARCH) GOARCH=amd64 go test -v -c -o "bin/$(ARCH)/e2e_test" ./test/e2e/e2e_test.go;
-.PHONY: build
+# App images
+build-app-image-%:
+	$(eval APP := $*)
+	docker build --build-arg COMPONENT=$(APP) -t $(DOCKER_PUSH_REPOSITORY)$(APP):$(DOCKER_TAG) .
+.PHONY: build-app-image-%
 
+push-app-image-%:
+	$(eval APP := $*)
+	docker push $(DOCKER_PUSH_REPOSITORY)$(APP):$(DOCKER_TAG)
+.PHONY: push-apps-images-%
 
+# Test images
+build-test-image-%:
+	$(eval APP := $*)
+	docker build --build-arg COMPONENT=$(APP) \
+		--build-arg BUILD_CMD="go test -v -c" \
+		--build-arg SOURCE_PATH="./test/$(APP)/$(APP)_test.go" \
+		-t $(DOCKER_PUSH_REPOSITORY)$(APP)_test:$(DOCKER_TAG) .
+.PHONY: build-test-image
+
+push-test-image-%:
+	$(eval APP := $*)
+	docker push $(DOCKER_PUSH_REPOSITORY)$(APP)_test:$(DOCKER_TAG)
+.PHONY: push-test-image
+
+#
 # Test
+#
 test-unit:
 	./hack/run-test-unit.sh
 .PHONY: test-unit

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains the Go codebase for the Voltron project.
 
-### Project structure
+## Project structure
 
 The repository has the following structure:
 
@@ -20,7 +20,7 @@ The repository has the following structure:
   │
   ├── pkg                       # Component related logic.
   │ ├── db-populator            # Populates Voltron entities to graph database.
-  │ ├── engine                  # Voltron platform agnostic engine.
+  │ ├── engine                  # Voltron platform-agnostic engine.
   │ ├── gateway                 # GraphQL Gateway
   │ ├── och                     # Open Capability Hub server 
   │ ├── runner                  # Voltron runners, e.g. Argo Workflow runner, Helm runner etc.
@@ -28,5 +28,97 @@ The repository has the following structure:
   │
   │── test                      # Cross-functional test suites
   │
-  └── go.mod                    # Manages Go dependency. There is a single dependency management across all components in this monorepo.
+  ├── Dockerfile                # Dockerfile template to build applications and tests images
+  │
+  └── go.mod                    # Manages Go dependency. There is single dependency management across all components in this monorepo.
 ```
+
+## Development
+
+Read this document to learn how to develop the project.
+
+### Prerequisites
+
+* [Go](https://golang.org/dl/) at least 1.15
+* [Docker](https://www.docker.com/)
+* Make
+
+### Install dependencies
+
+This project uses `go modules` as a dependency manager. To install all required dependencies, use the following command:
+
+```bash
+go mod download
+```
+
+### Run tests
+
+To run all unit and lint tests, execute the following command:
+
+```bash
+make test-unit
+make test-lint
+```
+
+### Verify the code
+
+To check if the code is correct and you can push it, use the `make` command. It builds the application, runs tests, checks the status of the vendored libraries, runs the static code analysis, and checks if the formatting of the code is correct.
+
+### Test coverage
+
+To generate the unit test coverage HTML report, execute the following command: 
+
+    make cover-html
+
+> **NOTE:** The default browser with the generated report opens automatically.
+
+### Build and push Docker images
+
+If you want to build all Docker images with your changes and push them to a registry, follow these steps:
+
+1. Build all Docker images:
+    
+    ```bash
+    make build-all-images 
+    ```
+
+2. Configure environment variables pointing to your registry, for example:
+
+    ```bash
+    export DOCKER_PUSH_REPOSITORY=gcr.io/projectvoltron/
+    export DOCKER_TAG=latest
+    ```
+
+3. Push the Docker images to registry:
+
+    ```bash
+    make push-all-images
+    ```
+
+If you want to build Docker images and push it for a single component, follow these steps:
+
+1. Build a specific Docker image:
+    
+    For application defined under [cmd](./cmd) package use it names, e.g. for `och`:
+    ```bash
+    make build-app-image-och
+    ```
+
+    For tests defined under [test](./test) package use it names, e.g. for `e2e`:
+    ```bash
+    make build-test-image-e2e
+    ```
+
+3. Push build Docker image to registry:
+
+    For application defined under [cmd](./cmd) package use it names, e.g. for `och`:
+    ```bash
+    make push-app-image-och
+    ```
+
+    For tests defined under [test](./test) package use it names, e.g. for `e2e`:
+    ```bash
+    make push-test-image-e2e
+    ```
+
+> **NOTE:** Registry can be configured exactly in the same way as specified in the previous section.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add single Dockerfile that can be used for all apps and integration tests 
- Replace building binary locally with building Docker images 
- Add functionality to push Docker images to a given registry
- Add devguide

---
NOTE: alternatively we can use `for loops` instead of `addprefix` makefile func:

```makefile
# Docker images
build-images:
	for app in ${APPS}; do \
		docker build --build-arg COMPONENT=$${app} -t $${app} . ;\
	done; \


	for app in ${TESTS}; do \
		docker build --build-arg COMPONENT=$${app} --build-arg BUILD_CMD="go test -v -c" --build-arg SOURCE_PATH=./test/$${app}/$${app}_test.go -t $${app}_test .; \
	done
.PHONY: build-images


push-images:
	for img in ${APPS} ; do \
		docker tag $${img} $(DOCKER_PUSH_REPOSITORY)$${img}:$(TAG) ; \
		docker push $(DOCKER_PUSH_REPOSITORY)$${img}:$(TAG) ; \
	done; \

	for img in ${TESTS} ; do \
		docker tag $${img}_test $(DOCKER_PUSH_REPOSITORY)$${img}_test:$(TAG) ; \
		docker push $(DOCKER_PUSH_REPOSITORY)$${img}_test:$(TAG) ; \
	done
.PHONY: push-images
````

but IMO it is worst, the same as defining each target separately but I'm open for other suggestions :)