### PR TITLE
Mock local OCH GraphQL API

### DIFF
--- a/cmd/och/main.go
+++ b/cmd/och/main.go
@@ -51,6 +51,9 @@ func main() {
 	hsvr := healthz.NewHTTPServer(logger, cfg.HealthzAddr, cfg.OCHMode.String())
 
 	// GraphQL server
+	if cfg.MockGraphQL {
+		logger.Info("Using mocked version of OCH API", zap.String("OCH mode", string(cfg.OCHMode)))
+	}
 	gsvr := graphqlutil.NewHTTPServer(
 		logger,
 		och.GraphQLSchema(cfg.OCHMode, cfg.MockGraphQL),

--- a/deploy/kubernetes/charts/voltron/Chart.yaml
+++ b/deploy/kubernetes/charts/voltron/Chart.yaml
@@ -13,3 +13,17 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 0.0.1
+
+dependencies:
+- name: engine
+  version: "0.0.1"
+  repository: "file://charts/engine"
+- name: gateway
+  version: "0.0.1"
+  repository: "file://charts/gateway"
+- name: och-local
+  version: "0.0.1"
+  repository: "file://charts/och-local"
+- name: och-public
+  version: "0.0.1"
+  repository: "file://charts/och-public"

--- a/deploy/kubernetes/charts/voltron/charts/och-local/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-local/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: "local"
             - name: APP_LOGGER_DEV_MODE
               value: "true"
+            - name: APP_MOCKGRAPHQL
+              value: "{{ .Values.global.mockGraphQL }}"
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/charts/voltron/charts/och-public/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-public/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: APP_LOGGER_DEV_MODE
               value: "true"
             - name: APP_MOCKGRAPHQL
-              value: {{ .Values.mockGraphQL | quote }}
+              value: "{{ .Values.global.mockGraphQL }}"
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
@@ -53,5 +53,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-mockGraphQL: true

--- a/deploy/kubernetes/charts/voltron/values.yaml
+++ b/deploy/kubernetes/charts/voltron/values.yaml
@@ -5,6 +5,7 @@ global:
     # Overrides the image tag for all Voltron component. Default is the sub-chart appVersion.
     overrideTag: "latest"
   domainName: "dev.cluster.projectvoltron.dev"
+  mockGraphQL: "true"
 
 integrationTest:
   image:

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,6 +123,7 @@ You can export the following environment variables to configure the script:
 - To disable monitoring stack installation, use `DISABLE_MONITORING_INSTALLATION=true`.
 - To disable `/etc/hosts` update with all Voltron subdomain, use `DISABLE_HOSTS_UPDATE=true`.
 - To disable setting self-signed TLS certificate for `*.voltron.local` as trusted, use `DISABLE_ADDING_TRUSTED_CERT=true`.
+- To enable mocked version of GraphQL APIs (Engine, Local OCH, Public OCH) use `MOCK_GRAPHQL=true`
 
 ### Rebuild Docker images and update cluster
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
 	github.com/google/go-cmp v0.5.1 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.6.1
 	github.com/iancoleman/strcase v0.1.2
 	github.com/nautilus/gateway v0.1.9

--- a/hack/ci/cluster-components-install.sh
+++ b/hack/ci/cluster-components-install.sh
@@ -20,6 +20,7 @@ main() {
     export REPO_DIR=$REPO_ROOT_DIR
     export CLUSTER_TYPE="GKE"
     export DOCKER_TAG=${OVERRIDE_DOCKER_TAG:-${DOCKER_TAG}}
+    export MOCK_GRAPHQL=${MOCK_GRAPHQL:-${VOLTRON_MOCK_GRAPHQL}}
     voltron::install::charts
 }
 

--- a/hack/dev-cluster-create.sh
+++ b/hack/dev-cluster-create.sh
@@ -33,6 +33,8 @@ main() {
     export DOCKER_REPOSITORY="local"
     export CLUSTER_TYPE="KIND"
     voltron::update::images_on_kind
+
+    export MOCK_GRAPHQL=${MOCK_GRAPHQL:-${VOLTRON_MOCK_GRAPHQL}}
     voltron::install::charts
 
     if [[ "${DISABLE_HOSTS_UPDATE:-"false"}" == "true" ]]; then

--- a/hack/dev-cluster-update.sh
+++ b/hack/dev-cluster-update.sh
@@ -26,6 +26,8 @@ main() {
     export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-${KIND_DEV_CLUSTER_NAME}}
     export CLUSTER_TYPE="KIND"
     voltron::update::images_on_kind
+
+    export MOCK_GRAPHQL=${MOCK_GRAPHQL:-${VOLTRON_MOCK_GRAPHQL}}
     voltron::install::charts
 
     shout "Development local cluster updated successfully."

--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -35,3 +35,9 @@ readonly DEFAULT_OCF_VERSION="0.0.1"
 
 readonly JSON_GO_GEN_IMAGE_VERSION="0.1.1"
 readonly GRAPHQL_SCHEMA_LINTER_IMAGE_VERSION="0.1.0"
+
+#
+# Development
+#
+
+readonly VOLTRON_MOCK_GRAPHQL="false"

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -230,6 +230,7 @@ docker::delete_images() {
 #  - VOLTRON_NAMESPACE
 #  - VOLTRON_RELEASE_NAME
 #  - CLUSTER_TYPE
+#  - MOCK_GRAPHQL - if set to true then predifined values are used in graphql
 #
 # Optional envs:
 #  - UPDATE - if specified then, Helm charts are updated
@@ -264,6 +265,7 @@ voltron::install::charts() {
         --namespace="${VOLTRON_NAMESPACE}" \
         --set global.containerRegistry.path="$DOCKER_REPOSITORY" \
         --set global.containerRegistry.overrideTag="$DOCKER_TAG" \
+        --set global.mockGraphQL="$MOCK_GRAPHQL" \
         -f "${VOLTRON_OVERRIDES}" \
         --wait
 }

--- a/hack/mock/local/typeInstances.json
+++ b/hack/mock/local/typeInstances.json
@@ -1,0 +1,76 @@
+[
+  {
+    "metadata": {
+      "id": "00000000-ab4a-4fbf-a312-f96f11b07d0b",
+      "Tags": [
+        {
+          "path": "cap.core.type.platform.kubernetes",
+          "revision": "0.1.0"
+        }
+      ]
+    },
+    "resourceVersion": 1,
+    "spec": {
+      "typeRef": {
+        "path": "cap.type.productivity.jira.config",
+        "revision": "0.1.0"
+      },
+      "value": {
+        "hostname": "jira.svc.cluster.local"
+      },
+      "instrumentation": {
+        "metrics": {
+          "endpoint": "https://jira.svc.cluster.local:2112",
+          "regex": "^(go_gc_duration_seconds|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes)$",
+          "dashboards": [
+            {
+              "url": "https://grafana.foo.bar/d/foo/bar"
+            },
+            {
+              "url": "https://grafana.foo.bar/d/foo/poo"
+            }
+          ]
+        },
+        "health": {
+          "url": "https://jira.svc.cluster.local/healthz",
+          "method": "GET",
+          "status": "READY"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "id": "11111111-ab4a-4fbf-a312-f96f11b07d0b"
+    },
+    "resourceVersion": 4,
+    "spec": {
+      "typeRef": {
+        "path": "cap.type.productivity.jira.install-input",
+        "revision": "0.1.0"
+      },
+      "value": {
+        "hostname": "jira.svc.cluster.local"
+      },
+      "instrumentation": {
+        "metrics": {
+          "endpoint": "https://jira.svc.cluster.local:2112",
+          "regex": "^(go_gc_duration_seconds|go_goroutines|go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes)$",
+          "dashboards": [
+            {
+              "url": "https://grafana.foo.bar/d/foo/bar"
+            },
+            {
+              "url": "https://grafana.foo.bar/d/foo/poo"
+            }
+          ]
+        },
+        "health": {
+          "url": "https://jira.svc.cluster.local/healthz",
+          "method": "GET",
+          "status": "READY"
+        }
+      }
+    }
+  }
+]

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -77,6 +77,7 @@ main() {
     fi
 
     export CLUSTER_TYPE="KIND"
+    export MOCK_GRAPHQL=${MOCK_GRAPHQL:-${VOLTRON_MOCK_GRAPHQL}}
     voltron::install::charts
 
     voltron::test::execute

--- a/internal/och/graphql/local/mocked-resolver/mockeddata.go
+++ b/internal/och/graphql/local/mocked-resolver/mockeddata.go
@@ -1,0 +1,25 @@
+package mockedresolver
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+
+	gqllocalapi "projectvoltron.dev/voltron/pkg/och/api/graphql/local"
+)
+
+const MocksPath = "./mock/local"
+
+func MockedTypeInstances() ([]*gqllocalapi.TypeInstance, error) {
+	buff, err := ioutil.ReadFile(path.Join(MocksPath, "typeInstances.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	i := []*gqllocalapi.TypeInstance{}
+	err = json.Unmarshal(buff, &i)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}

--- a/internal/och/graphql/local/mocked-resolver/typeinstance/type_instance.go
+++ b/internal/och/graphql/local/mocked-resolver/typeinstance/type_instance.go
@@ -1,0 +1,152 @@
+package typeinstance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	mockedresolver "projectvoltron.dev/voltron/internal/och/graphql/local/mocked-resolver"
+	gqllocalapi "projectvoltron.dev/voltron/pkg/och/api/graphql/local"
+)
+
+type TypeInstanceResolver struct {
+	typeInstances []*gqllocalapi.TypeInstance
+}
+
+func NewResolver() *TypeInstanceResolver {
+	return &TypeInstanceResolver{}
+}
+
+// init() is called in every method as there is no better place to call it
+// NewResolver() does not return error so it cannot be used there
+func (r *TypeInstanceResolver) init() error {
+	if r.typeInstances != nil {
+		return nil
+	}
+	typeInstances, err := mockedresolver.MockedTypeInstances()
+	if err != nil {
+		return err
+	}
+	r.typeInstances = append(r.typeInstances, typeInstances...)
+	return nil
+}
+
+func (r *TypeInstanceResolver) TypeInstances(ctx context.Context, filter *gqllocalapi.TypeInstanceFilter) ([]*gqllocalapi.TypeInstance, error) {
+	err := r.init()
+	if err != nil {
+		return []*gqllocalapi.TypeInstance{}, err
+	}
+
+	return r.typeInstances, nil
+}
+
+func (r *TypeInstanceResolver) TypeInstance(ctx context.Context, id string) (*gqllocalapi.TypeInstance, error) {
+	err := r.init()
+	if err != nil {
+		return nil, err
+	}
+	for _, typeInstance := range r.typeInstances {
+		if typeInstance.Metadata.ID == id {
+			return typeInstance, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *TypeInstanceResolver) CreateTypeInstance(ctx context.Context, in *gqllocalapi.CreateTypeInstanceInput) (*gqllocalapi.TypeInstance, error) {
+	err := r.init()
+	if err != nil {
+		return nil, err
+	}
+	var revision string
+	if in.TypeRef.Revision != nil {
+		revision = *in.TypeRef.Revision
+	} else {
+		revision = ""
+	}
+
+	tags := []*gqllocalapi.TagReference{}
+	for _, tag := range in.Tags {
+		var revision string
+		if tag.Revision != nil {
+			revision = *tag.Revision
+		} else {
+			revision = ""
+		}
+
+		tags = append(tags, &gqllocalapi.TagReference{
+			Path:     tag.Path,
+			Revision: revision,
+		})
+	}
+
+	newTypeInstance := &gqllocalapi.TypeInstance{
+		Metadata: &gqllocalapi.TypeInstanceMetadata{
+			ID:   uuid.New().String(),
+			Tags: tags,
+		},
+		Spec: &gqllocalapi.TypeInstanceSpec{
+			TypeRef: &gqllocalapi.TypeReference{
+				Path:     in.TypeRef.Path,
+				Revision: revision,
+			},
+			Value: in.Value,
+		},
+		ResourceVersion: 1,
+	}
+
+	r.typeInstances = append(r.typeInstances, newTypeInstance)
+	return newTypeInstance, nil
+}
+
+func (r *TypeInstanceResolver) UpdateTypeInstance(ctx context.Context, id string, in *gqllocalapi.UpdateTypeInstanceInput) (*gqllocalapi.TypeInstance, error) {
+	err := r.init()
+	if err != nil {
+		return nil, err
+	}
+	var typeInstance *gqllocalapi.TypeInstance
+	for _, typeInstance = range r.typeInstances {
+		if typeInstance.Metadata.ID == id {
+			break
+		}
+	}
+	if typeInstance == nil {
+		return nil, fmt.Errorf("No TypeInstance with Id %s", id)
+	}
+	if typeInstance.ResourceVersion != in.ResourceVersion {
+		return nil, fmt.Errorf("Wrong ResourceVersion for TypeInstance with Id %s, please use latest revision", id)
+	}
+	typeInstance.ResourceVersion++
+	if in.TypeRef != nil {
+		typeInstance.Spec.TypeRef.Path = in.TypeRef.Path
+		if in.TypeRef.Revision != nil {
+			typeInstance.Spec.TypeRef.Revision = *in.TypeRef.Revision
+		}
+	}
+	typeInstance.Spec.Value = in.Value
+	return typeInstance, nil
+}
+
+func (r *TypeInstanceResolver) DeleteTypeInstance(ctx context.Context, id string) (*gqllocalapi.TypeInstance, error) {
+	err := r.init()
+	if err != nil {
+		return nil, err
+	}
+
+	index := -1
+	var typeInstance *gqllocalapi.TypeInstance
+	var i int
+	for i, typeInstance = range r.typeInstances {
+		if typeInstance.Metadata.ID == id {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return nil, nil
+	}
+	r.typeInstances[index] = r.typeInstances[len(r.typeInstances)-1]
+	r.typeInstances[len(r.typeInstances)-1] = nil
+	r.typeInstances = r.typeInstances[:len(r.typeInstances)-1]
+	return typeInstance, nil
+}

--- a/internal/och/graphql/local/mocked_root_resolver.go
+++ b/internal/och/graphql/local/mocked_root_resolver.go
@@ -1,0 +1,29 @@
+package local
+
+import (
+	"projectvoltron.dev/voltron/internal/och/graphql/local/mocked-resolver/typeinstance"
+	gqllocalapi "projectvoltron.dev/voltron/pkg/och/api/graphql/local"
+)
+
+var _ gqllocalapi.ResolverRoot = &MockedRootResolver{}
+
+type MockedRootResolver struct {
+	mutationResolver gqllocalapi.MutationResolver
+	queryResolver    gqllocalapi.QueryResolver
+}
+
+func NewMockedRootResolver() *RootResolver {
+	instanceResolver := typeinstance.NewResolver()
+	return &RootResolver{
+		mutationResolver: instanceResolver,
+		queryResolver:    instanceResolver,
+	}
+}
+
+func (r MockedRootResolver) Mutation() gqllocalapi.MutationResolver {
+	return r.mutationResolver
+}
+
+func (r MockedRootResolver) Query() gqllocalapi.QueryResolver {
+	return r.queryResolver
+}

--- a/internal/och/schema.go
+++ b/internal/och/schema.go
@@ -24,8 +24,14 @@ func GraphQLSchema(mode Mode, useMockedResolver bool) graphql.ExecutableSchema {
 		}
 		return gqlpublicapi.NewExecutableSchema(cfg)
 	case LocalMode:
+		var rootResolver gqllocalapi.ResolverRoot
+		if useMockedResolver {
+			rootResolver = gqllocaldomain.NewMockedRootResolver()
+		} else {
+			rootResolver = gqllocaldomain.NewRootResolver()
+		}
 		cfg := gqllocalapi.Config{
-			Resolvers: gqllocaldomain.NewRootResolver(),
+			Resolvers: rootResolver,
 		}
 		return gqllocalapi.NewExecutableSchema(cfg)
 	}

--- a/pkg/och/api/graphql/local/models_gen.go
+++ b/pkg/och/api/graphql/local/models_gen.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CreateTypeInstanceInput struct {
-	TypeRef string               `json:"typeRef"`
+	TypeRef *TypeReferenceInput  `json:"typeRef"`
 	Tags    []*TagReferenceInput `json:"tags"`
 	Value   interface{}          `json:"value"`
 }
@@ -86,8 +86,14 @@ type TypeReference struct {
 	Revision string `json:"revision"`
 }
 
+type TypeReferenceInput struct {
+	Path string `json:"path"`
+	// If not provided, latest revision for a given Type is used
+	Revision *string `json:"revision"`
+}
+
 type UpdateTypeInstanceInput struct {
-	TypeRef         string               `json:"typeRef"`
+	TypeRef         *TypeReferenceInput  `json:"typeRef"`
 	Tags            []*TagReferenceInput `json:"tags"`
 	Value           interface{}          `json:"value"`
 	ResourceVersion int                  `json:"resourceVersion"`

--- a/pkg/och/api/graphql/local/schema.graphql
+++ b/pkg/och/api/graphql/local/schema.graphql
@@ -14,16 +14,25 @@ Version in semantic versioning, e.g. 1.1.0
 scalar Version
 
 input CreateTypeInstanceInput {
-  typeRef: String!
+  typeRef: TypeReferenceInput!
   tags: [TagReferenceInput!]
   value: Any
 }
 
 input UpdateTypeInstanceInput {
-  typeRef: String!
+  typeRef: TypeReferenceInput!
   tags: [TagReferenceInput!]
   value: Any
   resourceVersion: Int!
+}
+
+input TypeReferenceInput {
+    path: NodePath!
+
+    """
+    If not provided, latest revision for a given Type is used
+    """
+    revision: Version
 }
 
 type TypeInstance {

--- a/pkg/och/api/graphql/local/schema_gen.go
+++ b/pkg/och/api/graphql/local/schema_gen.go
@@ -414,16 +414,25 @@ Version in semantic versioning, e.g. 1.1.0
 scalar Version
 
 input CreateTypeInstanceInput {
-  typeRef: String!
+  typeRef: TypeReferenceInput!
   tags: [TagReferenceInput!]
   value: Any
 }
 
 input UpdateTypeInstanceInput {
-  typeRef: String!
+  typeRef: TypeReferenceInput!
   tags: [TagReferenceInput!]
   value: Any
   resourceVersion: Int!
+}
+
+input TypeReferenceInput {
+    path: NodePath!
+
+    """
+    If not provided, latest revision for a given Type is used
+    """
+    revision: Version
 }
 
 type TypeInstance {
@@ -2770,7 +2779,7 @@ func (ec *executionContext) unmarshalInputCreateTypeInstanceInput(ctx context.Co
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("typeRef"))
-			it.TypeRef, err = ec.unmarshalNString2string(ctx, v)
+			it.TypeRef, err = ec.unmarshalNTypeReferenceInput2ᚖprojectvoltronᚗdevᚋvoltronᚋpkgᚋochᚋapiᚋgraphqlᚋlocalᚐTypeReferenceInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -2920,6 +2929,34 @@ func (ec *executionContext) unmarshalInputTypeRefFilterInput(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTypeReferenceInput(ctx context.Context, obj interface{}) (TypeReferenceInput, error) {
+	var it TypeReferenceInput
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "path":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+			it.Path, err = ec.unmarshalNNodePath2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "revision":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revision"))
+			it.Revision, err = ec.unmarshalOVersion2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateTypeInstanceInput(ctx context.Context, obj interface{}) (UpdateTypeInstanceInput, error) {
 	var it UpdateTypeInstanceInput
 	var asMap = obj.(map[string]interface{})
@@ -2930,7 +2967,7 @@ func (ec *executionContext) unmarshalInputUpdateTypeInstanceInput(ctx context.Co
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("typeRef"))
-			it.TypeRef, err = ec.unmarshalNString2string(ctx, v)
+			it.TypeRef, err = ec.unmarshalNTypeReferenceInput2ᚖprojectvoltronᚗdevᚋvoltronᚋpkgᚋochᚋapiᚋgraphqlᚋlocalᚐTypeReferenceInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -3866,6 +3903,11 @@ func (ec *executionContext) marshalNTypeReference2ᚖprojectvoltronᚗdevᚋvolt
 		return graphql.Null
 	}
 	return ec._TypeReference(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTypeReferenceInput2ᚖprojectvoltronᚗdevᚋvoltronᚋpkgᚋochᚋapiᚋgraphqlᚋlocalᚐTypeReferenceInput(ctx context.Context, v interface{}) (*TypeReferenceInput, error) {
+	res, err := ec.unmarshalInputTypeReferenceInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNVersion2string(ctx context.Context, v interface{}) (string, error) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Mock getting TypeInstance 

***Usage***
```graphql
{
  typeInstances {
    metadata {
      id
        tags {
          path
           revision
        }
      
    }
    spec{
      typeRef {path, revision}
      value 
      instrumentation {
        metrics {
          endpoint
          dashboards {
            url
          }
          regex
        }
      }
    }
  }
}
```

```graphql
{
  typeInstance(id:"11111111-ab4a-4fbf-a312-f96f11b07d0b") {
    metadata {
      id
    }
    spec{
      typeRef {path}
    }
  }
}
```

```graphql
mutation{
  deleteTypeInstance(id: "00000000-ab4a-4fbf-a312-f96f11b07d0b"){
    metadata{id}
  }
}
```

```graphql
mutation {
  updateTypeInstance(
    id: "11111111-ab4a-4fbf-a312-f96f11b07d0b"
    in: {
      value: { hostname: "google.pl" }
      resourceVersion: 4
      typeRef: { path: "cap.type.productivity.jira.install-input" }
    }
  ) {
    metadata {
      id
    }
    spec {
      value
    }
    resourceVersion
  }
}
```

```graphql
mutation {
  createTypeInstance(
    in: {
      value: { hostname: "google.pl" }
      typeRef: { path: "cap.type.productivity.jira.install-input" }
    }
  ) {
    metadata {
      id
    }
    spec {
      value
    }
    resourceVersion
  }
}
```
**Related issue(s)**

Fixes SV-26