### PR TITLE
Change limits for minio both locally and on GKE

### DIFF
--- a/deploy/kubernetes/charts/argo/values.yaml
+++ b/deploy/kubernetes/charts/argo/values.yaml
@@ -16,3 +16,8 @@ argo:
     defaultBucket:
       enabled: true
       name: argo-artifacts
+    resources:
+      requests:
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/hack/kind/overrides.argo.yaml
+++ b/hack/kind/overrides.argo.yaml
@@ -1,5 +1,0 @@
-argo:
-  minio:
-    resources:
-      requests:
-        memory: 256Mi

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -304,17 +304,9 @@ voltron::install::argo() {
     # not waiting as other components do not need it during installation
     shout "- Installing Argo Helm chart [wait: false]..."
 
-    if [[ "${CLUSTER_TYPE}" == "KIND" ]]; then
-      readonly ARGO_OVERRIDES="${REPO_DIR}/hack/kind/overrides.argo.yaml"
-      echo -e "- Applying overrides from ${ARGO_OVERRIDES}\n"
-    else # currently, only KIND needs custom settings
-      readonly ARGO_OVERRIDES=""
-    fi
-
     helm "$(voltron::install::detect_command)" argo "${K8S_DEPLOY_DIR}/charts/argo" \
         --create-namespace \
-        --namespace="argo" \
-        -f "${ARGO_OVERRIDES}"
+        --namespace="argo"
 }
 
 # Updates /etc/hosts with all Voltron subdomains.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the limit both on local and GKE cluster to avoid such problems:
```
Normal   NotTriggerScaleUp  3m54s (x29 over 9m)  cluster-autoscaler  pod didn’t trigger scale-up (it wouldn’t fit if a new node is added): 3 max cluster cpu, memory limit reached
Warning  FailedScheduling   6s (x7 over 9m3s)    default-scheduler   0/3 nodes are available: 1 Insufficient memory, 2 node(s) had volume node affinity conflict.
```

Rest will be done in: https://cshark.atlassian.net/browse/SV-140