### PR TITLE
Mock graphql k8s-engine API

### DIFF
--- a/deploy/kubernetes/charts/voltron/charts/engine/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/engine/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.gateway.username }}
             - name: APP_GRAPHQLGATEWAY_PASSWORD
               value: "{{ .Values.gateway.password }}"
+            - name: APP_MOCKGRAPHQL
+              value: "{{ .Values.global.mockGraphQL }}"
           ports:
             - name: http
               containerPort: 8080

--- a/hack/mock/engine/actions.json
+++ b/hack/mock/engine/actions.json
@@ -1,0 +1,258 @@
+[
+  {
+    "name": "Jira installation",
+    "createdAt": "2020-11-22T19:42:31+07:00",
+    "input": {
+      "paramters": {
+        "val": "1"
+      },
+      "artifacts": [
+        {
+          "name": "db-config",
+          "typeInstanceID": "123-sss-1132-12"
+        }
+      ],
+      "parameters": "{\"key\": \"val\"}"
+    },
+    "output": {
+      "paramters": "{\"val\":1}",
+      "artifacts": [
+        {
+          "name": "artifact1",
+          "typeInstanceID": "c6079f69-ab4a-4fbf-a312-f96f11b07d0b",
+          "typePath": "cap.type.productivity.jira.config"
+        }
+      ]
+    },
+    "path": "cap.implementation.attlasian.jira.install",
+    "renderedAction": {
+      "steps": [
+        {
+          "step1": "install me"
+        },
+        {
+          "step2": "install it"
+        }
+      ]
+    },
+    "renderedActionOverride": {
+      "steps": [
+        {
+          "step2": "install it2"
+        }
+      ]
+    },
+    "renderingAdvancedMode": {
+      "enabled": false,
+      "artifactsForRenderingIteration": []
+    },
+    "run": true,
+    "status": {
+      "condition": "SUCCEEDED",
+      "timestamp": "2020-11-22T21:42:31+07:00",
+      "message": "Jira Installed",
+      "runner": {
+        "interface": "cap.type.runner.argo",
+        "status": {
+          "argoWorklfowRef": "default/WorkflowRun01"
+        }
+      },
+      "createdBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {}
+      },
+      "runBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {
+          "par1": "val2"
+        }
+      }
+    }
+  },
+  {
+    "name": "Jira update",
+    "createdAt": "2020-11-22T21:42:31+07:00",
+    "input": {
+      "paramters": {
+        "val": "1"
+      },
+      "artifacts": [
+        {
+          "name": "db-config",
+          "typeInstanceID": "123-sss-1132-12"
+        }
+      ]
+    },
+    "output": {
+      "paramters": "{\"val\":1}",
+      "artifacts": [
+        {
+          "name": "artifact1",
+          "typeInstanceID": "c6079f69-ab4a-4fbf-a312-f96f11b07d0b",
+          "typePath": "cap.type.productivity.jira.config"
+        }
+      ]
+    },
+    "path": "cap.implementation.attlasian.jira.update",
+    "renderAction": {
+      "steps": [
+        {
+          "name": "step1"
+        }
+      ]
+    },
+    "renderingAdvancedMode": {
+      "enabled": false
+    },
+    "run": true,
+    "status": {
+      "condition": "FAILED",
+      "timestamp": "2020-11-22T21:42:31+07:00",
+      "message": "Jira update failed",
+      "runner": {
+        "interface": "cap.type.runner.argo",
+        "status": {
+          "argoWorklfowRef": "default/WorkflowRun01"
+        }
+      },
+      "createdBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {}
+      },
+      "runBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {
+          "par1": "val2"
+        }
+      }
+    }
+  },
+  {
+    "name": "Jira reinstall",
+    "createdAt": "2020-11-22T19:42:31+07:00",
+    "input": {
+      "paramters": {
+        "val": "1"
+      },
+      "artifacts": [
+        {
+          "name": "db-config",
+          "typeInstanceID": "123-sss-1132-12"
+        }
+      ]
+    },
+    "output": {
+      "paramters": "{\"val\":1}",
+      "artifacts": [
+        {
+          "name": "artifact1",
+          "typeInstanceID": "c6079f69-ab4a-4fbf-a312-f96f11b07d0b",
+          "typePath": "cap.type.productivity.jira.config"
+        }
+      ]
+    },
+    "path": "cap.implementation.attlasian.jira.install",
+    "renderAction": {},
+    "renderingAdvancedMode": {
+      "enabled": false,
+      "artifactsForRenderingIteration": []
+    },
+    "run": true,
+    "cancel": true,
+    "status": {
+      "condition": "CANCELED",
+      "timestamp": "2020-11-22T21:42:31+07:00",
+      "message": "Jira Installed",
+      "runner": {
+        "interface": "cap.type.runner.argo",
+        "status": {
+          "argoWorklfowRef": "default/WorkflowRun01"
+        }
+      },
+      "createdBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {}
+      },
+      "runBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {
+          "par1": "val2"
+        }
+      },
+      "cancelledBy": {
+        "username": "voltron1",
+        "groups": [
+          "users"
+        ],
+        "extra": {}
+      }
+    }
+  },
+  {
+    "name": "Jira advanced update",
+    "createdAt": "2020-11-22T19:42:31+07:00",
+    "input": {
+      "paramters": {
+        "val": "1"
+      },
+      "artifacts": [
+        {
+          "name": "db-config",
+          "typeInstanceID": "123-sss-1132-12"
+        }
+      ]
+    },
+    "output": {
+      "paramters": "{\"val\":1}",
+      "artifacts": [
+        {
+          "name": "artifact1",
+          "typeInstanceID": "c6079f69-ab4a-4fbf-a312-f96f11b07d0b",
+          "typePath": "cap.type.productivity.jira.config"
+        }
+      ]
+    },
+    "path": "cap.implementation.attlasian.jira.install",
+    "renderAction": {},
+    "renderingAdvancedMode": {
+      "enabled": true,
+      "artifactsForRenderingIteration": []
+    },
+    "status": {
+      "condition": "ADVANCED_MODE_RENDERING_ITERATION",
+      "timestamp": "2020-11-22T21:42:31+07:00",
+      "message": "Waiting for artifacts from user",
+      "runner": {
+        "interface": "cap.type.runner.argo",
+        "status": {
+          "argoWorklfowRef": "default/WorkflowRun01"
+        }
+      }
+    },
+    "createdBy": {
+      "username": "voltron1",
+      "groups": [
+        "users"
+      ],
+      "extra": {}
+    }
+  }
+]

--- a/internal/k8s-engine/graphql/mocked-resolver/action/action.go
+++ b/internal/k8s-engine/graphql/mocked-resolver/action/action.go
@@ -1,0 +1,326 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"path"
+	"time"
+
+	"projectvoltron.dev/voltron/pkg/engine/api/graphql"
+)
+
+var stateChangeWaitTime = 10 * time.Second
+
+type isConditionPossible func(a *graphql.Action) bool
+
+func canBeRun(a *graphql.Action) bool {
+	return a.Run
+}
+
+type conditionsGraphNode struct {
+	condition      graphql.ActionStatusCondition
+	conditionValid isConditionPossible
+}
+
+var conditionsGraph = map[graphql.ActionStatusCondition][]conditionsGraphNode{
+	graphql.ActionStatusConditionInitial: {
+		{condition: graphql.ActionStatusConditionBeingRendered},
+	},
+	graphql.ActionStatusConditionBeingRendered: {
+		{condition: graphql.ActionStatusConditionReadyToRun},
+	},
+	graphql.ActionStatusConditionAdvancedModeRenderingIteration: {
+		{condition: graphql.ActionStatusConditionReadyToRun},
+		{condition: graphql.ActionStatusConditionAdvancedModeRenderingIteration},
+	},
+	graphql.ActionStatusConditionReadyToRun: {
+		{
+			condition:      graphql.ActionStatusConditionRunning,
+			conditionValid: canBeRun,
+		},
+	},
+	graphql.ActionStatusConditionRunning: {
+		{condition: graphql.ActionStatusConditionSucceeded},
+		{condition: graphql.ActionStatusConditionFailed},
+	},
+
+	graphql.ActionStatusConditionBeingCancelled: {
+		{condition: graphql.ActionStatusConditionCancelled},
+	},
+	graphql.ActionStatusConditionCancelled: {},
+	graphql.ActionStatusConditionSucceeded: {},
+	graphql.ActionStatusConditionFailed:    {},
+}
+
+var conditionMessages = map[graphql.ActionStatusCondition]string{
+	graphql.ActionStatusConditionInitial:                        "Action initialized",
+	graphql.ActionStatusConditionBeingRendered:                  "Action is being rendered",
+	graphql.ActionStatusConditionAdvancedModeRenderingIteration: "Action in advanced rendering mode",
+	graphql.ActionStatusConditionReadyToRun:                     "Action is ready to run",
+	graphql.ActionStatusConditionRunning:                        "Action is running",
+	graphql.ActionStatusConditionBeingCancelled:                 "Action is being canceled",
+	graphql.ActionStatusConditionCancelled:                      "Action canceled",
+	graphql.ActionStatusConditionSucceeded:                      "Action succeeded",
+	graphql.ActionStatusConditionFailed:                         "Action failed",
+}
+
+// proceedAction simulates engine. It waits `stateChangeWaitTime`
+// and randomly moves to the next possibly state
+func proceedAction(action *graphql.Action) {
+	rand.Seed(time.Now().Unix())
+	for {
+		time.Sleep(stateChangeWaitTime)
+
+		nextConditions := conditionsGraph[action.Status.Condition]
+		if len(nextConditions) == 0 {
+			break
+		}
+
+		possibleConditions := []graphql.ActionStatusCondition{}
+		for _, conditionNode := range nextConditions {
+			if conditionNode.conditionValid != nil && !conditionNode.conditionValid(action) {
+				continue
+			}
+			possibleConditions = append(possibleConditions, conditionNode.condition)
+		}
+		if len(possibleConditions) == 0 {
+			continue
+		}
+
+		// #nosec G404
+		newCondition := possibleConditions[rand.Intn(len(possibleConditions))]
+		message := conditionMessages[newCondition]
+
+		action.Status.Condition = newCondition
+		action.Status.Message = &message
+	}
+}
+
+var mockUser = &graphql.UserInfo{
+	Username: "user",
+	Groups:   []string{"mocks"},
+}
+
+type ActionResolver struct {
+	actions []*graphql.Action
+}
+
+func NewResolver() *ActionResolver {
+	return &ActionResolver{}
+}
+
+func (a *ActionResolver) init() error {
+	if a.actions != nil {
+		return nil
+	}
+	actions, err := mockedActions()
+	if err != nil {
+		return err
+	}
+	a.actions = append(a.actions, actions...)
+	return nil
+}
+
+func (a *ActionResolver) getAction(name string) (int, *graphql.Action, error) {
+	err := a.init()
+	if err != nil {
+		return -1, nil, err
+	}
+	for i, action := range a.actions {
+		if action.Name == name {
+			return i, action, nil
+		}
+	}
+	return -1, nil, fmt.Errorf("Failed to get action with id %s", name)
+}
+
+func (a *ActionResolver) Action(ctx context.Context, name string) (*graphql.Action, error) {
+	_, action, err := a.getAction(name)
+	if err != nil {
+		return nil, err
+	}
+	return action, nil
+}
+
+func (a *ActionResolver) Actions(ctx context.Context, filter []*graphql.ActionFilter) ([]*graphql.Action, error) {
+	err := a.init()
+	if err != nil {
+		return []*graphql.Action{}, err
+	}
+	return a.actions, nil
+}
+
+func (a *ActionResolver) CreateAction(ctx context.Context, in *graphql.ActionDetailsInput) (*graphql.Action, error) {
+	message := conditionMessages[graphql.ActionStatusConditionInitial]
+	newAction := &graphql.Action{
+		Name:      in.Name,
+		Path:      in.Action,
+		CreatedAt: graphql.Timestamp(time.Now()),
+		Input:     &graphql.ActionInput{},
+
+		Status: &graphql.ActionStatus{
+			CreatedBy: mockUser,
+			Condition: graphql.ActionStatusConditionInitial,
+			Message:   &message,
+			Timestamp: graphql.Timestamp(time.Now()),
+			Runner: &graphql.RunnerStatus{
+				Interface: "cap.type.runner.argo",
+			},
+		},
+	}
+	updateAction(newAction, in)
+
+	if in.AdvancedRendering != nil {
+		newAction.RenderingAdvancedMode = &graphql.ActionRenderingAdvancedMode{Enabled: *in.AdvancedRendering}
+	}
+	if in.RenderedActionOverride != nil {
+		newAction.RenderedActionOverride = *in.RenderedActionOverride
+	}
+	a.actions = append(a.actions, newAction)
+
+	go proceedAction(newAction)
+
+	return newAction, nil
+}
+
+func (a *ActionResolver) RunAction(ctx context.Context, name string) (*graphql.Action, error) {
+	_, action, err := a.getAction(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if action.Status.Condition != graphql.ActionStatusConditionReadyToRun &&
+		action.Status.Condition != graphql.ActionStatusConditionInitial &&
+		action.Status.Condition != graphql.ActionStatusConditionAdvancedModeRenderingIteration &&
+		action.Status.Condition != graphql.ActionStatusConditionBeingRendered {
+		return action, fmt.Errorf("action is not ready to be run, current condition: %s", action.Status.Condition)
+	}
+	action.Run = true
+
+	action.Status.RunBy = mockUser
+	action.Status.Timestamp = graphql.Timestamp(time.Now())
+
+	return action, nil
+}
+
+func (a *ActionResolver) CancelAction(ctx context.Context, id string) (*graphql.Action, error) {
+	_, action, err := a.getAction(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if action.Status.Condition != graphql.ActionStatusConditionRunning {
+		return action, fmt.Errorf("Action which is not running cannot be canceled")
+	}
+	action.Cancel = true
+
+	message := conditionMessages[graphql.ActionStatusConditionBeingCancelled]
+
+	action.Status.CancelledBy = mockUser
+	action.Status.Condition = graphql.ActionStatusConditionBeingCancelled
+	action.Status.Message = &message
+	action.Status.Timestamp = graphql.Timestamp(time.Now())
+
+	return action, nil
+}
+
+func (a *ActionResolver) UpdateAction(ctx context.Context, in graphql.ActionDetailsInput) (*graphql.Action, error) {
+	_, action, err := a.getAction(in.Name)
+	if err != nil {
+		return nil, err
+	}
+	updateAction(action, &in)
+	return action, nil
+}
+
+func (a *ActionResolver) ContinueAdvancedRendering(ctx context.Context, id string, in graphql.AdvancedModeContinueRenderingInput) (*graphql.Action, error) {
+	_, action, err := a.getAction(id)
+	if err != nil {
+		return nil, err
+	}
+	if action.RenderingAdvancedMode == nil || !action.RenderingAdvancedMode.Enabled {
+		return action, errors.New("Rendering in advanced mode is disabled")
+	}
+	artifacts := []*graphql.InputArtifact{}
+	for _, artifact := range in.Artifacts {
+		artifacts = append(artifacts,
+			&graphql.InputArtifact{
+				TypeInstanceID: artifact.TypeInstanceID,
+			})
+	}
+	action.RenderingAdvancedMode.ArtifactsForRenderingIteration = artifacts
+	message := conditionMessages[graphql.ActionStatusConditionBeingRendered]
+
+	action.Status.Condition = graphql.ActionStatusConditionBeingRendered
+	action.Status.Message = &message
+	action.Status.Timestamp = graphql.Timestamp(time.Now())
+
+	go proceedAction(action)
+
+	return action, nil
+}
+
+func (a *ActionResolver) DeleteAction(ctx context.Context, name string) (*graphql.Action, error) {
+	index, action, err := a.getAction(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if index == -1 {
+		return nil, nil
+	}
+	a.actions[index] = a.actions[len(a.actions)-1]
+	a.actions[len(a.actions)-1] = nil
+	a.actions = a.actions[:len(a.actions)-1]
+	return action, nil
+}
+
+func mockedActions() ([]*graphql.Action, error) {
+	mocksPath := "./mock/engine"
+	buff, err := ioutil.ReadFile(path.Join(mocksPath, "actions.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	types := []*graphql.Action{}
+	err = json.Unmarshal(buff, &types)
+	if err != nil {
+		return nil, err
+	}
+	return types, nil
+}
+
+func updateAction(action *graphql.Action, in *graphql.ActionDetailsInput) {
+	if in == nil {
+		return
+	}
+
+	artifacts := []*graphql.InputArtifact{}
+	var parameters interface{}
+	if in.Input != nil {
+		if action.Input == nil {
+			action.Input = &graphql.ActionInput{}
+		}
+
+		for _, a := range in.Input.Artifacts {
+			artifact := &graphql.InputArtifact{
+				TypeInstanceID: a.TypeInstanceID,
+			}
+			artifacts = append(artifacts, artifact)
+		}
+		parameters = in.Input.Parameters
+	}
+	action.Input.Parameters = parameters
+	action.Input.Artifacts = artifacts
+
+	if in.AdvancedRendering != nil {
+		action.RenderingAdvancedMode = &graphql.ActionRenderingAdvancedMode{Enabled: *in.AdvancedRendering}
+	}
+	if in.RenderedActionOverride != nil {
+		action.RenderedActionOverride = *in.RenderedActionOverride
+	}
+}

--- a/internal/k8s-engine/graphql/mocked_root_resolver.go
+++ b/internal/k8s-engine/graphql/mocked_root_resolver.go
@@ -1,0 +1,29 @@
+package graphql
+
+import (
+	"projectvoltron.dev/voltron/internal/k8s-engine/graphql/mocked-resolver/action"
+	"projectvoltron.dev/voltron/pkg/engine/api/graphql"
+)
+
+var _ graphql.ResolverRoot = &MockedRootResolver{}
+
+type MockedRootResolver struct {
+	mutationResolver graphql.MutationResolver
+	queryResolver    graphql.QueryResolver
+}
+
+func NewMockedRootResolver() *MockedRootResolver {
+	actionResolver := action.NewResolver()
+	return &MockedRootResolver{
+		mutationResolver: actionResolver,
+		queryResolver:    actionResolver,
+	}
+}
+
+func (r MockedRootResolver) Mutation() graphql.MutationResolver {
+	return r.mutationResolver
+}
+
+func (r MockedRootResolver) Query() graphql.QueryResolver {
+	return r.queryResolver
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds option to mock GraphQL engine API
- Every 10 seconds moves mocked Action to the next possible condition

Usage

List all actions
```graphql
{
  actions {
    name
    createdAt
    input {
      artifacts {
        name
        typePath
        typeInstanceID
        optional
      }
      parameters
    }
    output {
      artifacts {
        name
        typePath
        typeInstanceID
      }
    }
    path
    run
    cancel
    renderedAction
    renderingAdvancedMode {
      enabled
      artifactsForRenderingIteration {
        name
        typePath
        typeInstanceID
        optional
      }
    }
    renderedActionOverride
    status {
      condition
      timestamp
      message
      runner {
        interface
        status
      }
      runBy {
        username
        groups
        extra
      }
      cancelledBy {
        username
        groups
        extra
      }
      createdBy {
        username
        groups
        extra
      }
    }
  }
}
```

Create a new action
```graphql
mutation {
  createAction(
    in: {
      action: "cap.implementation.attlasian.jira.update"
      name: "update jira"
      input: {
        parameters: "{}"
        artifacts: [{ name: "config", typeInstanceID: "aaa-xxx-aa" }]
      }
    }
  ) {
    name
    createdAt
    path
    input {
      parameters
      artifacts {
        name
        typeInstanceID
      }
    }
    renderingAdvancedMode {
      enabled
    }
    renderedActionOverride
  }
}
```

Get the action. **status.condition** will eventually move to **READY_TO_RUN**
```graphql
{
  action(name: "update jira"){
    name
    path
    status{
      condition
    }
  }
}
```

Run the action. **status.condition** will eventually move to **SUCCEEDED** or **FAILED**
```graphql
mutation{
  runAction(name: "update jira"){
    name
    status{
      condition
    }
  }
}
```

Cancel action. **status.condition** will eventually move to **CANCELED** 
```graphql
mutation{
  cancelAction(name: "update jira"){
    name
    status{condition}
  }
}
```

Delete action
```graphql
mutation{
  deleteAction(name:"update jira"){
    status{condition}
  }
}
```

Continue Advanced Rendering. There is a pre-created action waiting for this call.
```graphql
mutation {
  continueAdvancedRendering(
    actionName: "Jira advanced update"
    in: { artifacts: [{ name: "extraConfig", typeInstanceID: "rrr-ttt-a" }] }
  ) {
    name
    status {
      condition
      message
      timestamp
    }
  }
}
```

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
