### PR TITLE
Add proper no of exp Pods on CI and long-running clusters

### DIFF
--- a/deploy/kubernetes/charts/voltron/templates/tests/test-e2e.yaml
+++ b/deploy/kubernetes/charts/voltron/templates/tests/test-e2e.yaml
@@ -16,6 +16,8 @@ spec:
           value: "http://voltron-engine-graphql.{{.Release.Namespace}}.svc.cluster.local/healthz,http://voltron-gateway.{{.Release.Namespace}}.svc.cluster.local/healthz,http://voltron-och-local.{{.Release.Namespace}}.svc.cluster.local/healthz,http://voltron-och-public.{{.Release.Namespace}}.svc.cluster.local/healthz"
         - name: IGNORED_PODS_NAMES
           value: "{{ .Release.Namespace}}/{{ include "voltron.fullname" . }}-test-e2e"
+        - name: EXPECTED_NUMBER_OF_RUNNING_PODS
+          value: "{{ .Values.integrationTest.expectedNumberOfRunningPods }}"
       command:
         - /app
       args:

--- a/deploy/kubernetes/charts/voltron/values.yaml
+++ b/deploy/kubernetes/charts/voltron/values.yaml
@@ -12,3 +12,4 @@ integrationTest:
   image:
     name: e2e-test
     pullPolicy: IfNotPresent
+  expectedNumberOfRunningPods: 21

--- a/hack/kind/overrides.voltron.yaml
+++ b/hack/kind/overrides.voltron.yaml
@@ -1,2 +1,5 @@
 global:
   domainName: "voltron.local"
+
+integrationTest:
+  expectedNumberOfRunningPods: 17


### PR DESCRIPTION
**Description**

Currently, the [e2e tests are failing on long-running cluster](https://github.com/Project-Voltron/go-voltron/runs/1704034507?check_suite_focus=true). There were two problems:
- the `kube-system` was included in reports
- on long-running cluster the cert-manager is installed and on `kind` the local-path-provisioner is installed which make a difference

Changes proposed in this pull request:

- set different expectation for CI cluster and long-running cluster
- exclude the `kube-system` namespace
