### PR TITLE
Add documentation sanity checks as GitHub Action for PRs

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -41,12 +41,12 @@ jobs:
           make test-generated
 
   documentation-sanity:
-    if: github.event_name == 'pull_request'
-    name: runner / languagetool (github-pr-check)
+    name: Check documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run LanguageTool
+        # This image was build from this branch https://github.com/mszostok/action-languagetool/tree/update-lang-tool
         uses: docker://gcr.io/projectvoltron/infra/action-languagetool:1.5.0
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add documentation checks as the GitHub Action for our PRs:
  - LanguageTool
  - misspell

**Testing**

Test cases: https://github.com/mszostok/voltron/pulls

Final test case: https://github.com/mszostok/voltron/pull/9

**Highlights**
- LanguageTool:
  - it executes the LangaugeTool Java application in version 5.2 using Docker image.
  - check run takes around 1min
  - [it recognizes when the new content is pushed](https://github.com/mszostok/voltron/pull/9#issuecomment-763897305) and only that new content is checked
- Misspell
  - it generates fewer false positive errors that LanguageTool with `TYPOS` enabled.
  - [it recognizes when the new content is pushed](https://github.com/mszostok/voltron/pull/9#issuecomment-763897305) and only that new content is checked

More detailed status can be checked in task comments.

_Before review, ping me, so I will add you to fork version where tests were executed._