### PR TITLE
Make devenv start more stable

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -176,6 +176,7 @@ jobs:
         env:
           BUILD_IMAGES: "false"
           ARTIFACTS: "output/"
+          DISABLE_MONITORING_INSTALLATION: "true"
         run: |
           make test-integration
       - name: Upload artifacts

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -207,6 +207,7 @@ jobs:
         env:
           BUILD_IMAGES: "false"
           ARTIFACTS: "output/"
+          DISABLE_MONITORING_INSTALLATION: "true"
         run: |
           make test-integration
       - name: Upload artifacts

--- a/deploy/kubernetes/charts/voltron/charts/och-local/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-local/templates/deployment.yaml
@@ -54,19 +54,23 @@ spec:
               protocol: TCP
           {{- if .Values.global.mockOCHGraphQL }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8082
           readinessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8082
           {{- else }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8080
           readinessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8080

--- a/deploy/kubernetes/charts/voltron/charts/och-local/values.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-local/values.yaml
@@ -53,3 +53,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+probe:
+  initialDelaySeconds: 60

--- a/deploy/kubernetes/charts/voltron/charts/och-public/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-public/templates/deployment.yaml
@@ -55,18 +55,22 @@ spec:
           {{- if .Values.global.mockOCHGraphQL }}
           livenessProbe:
             httpGet:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
               path: /healthz
               port: 8082
           readinessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8082
           {{- else }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8080
           readinessProbe:
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
             httpGet:
               path: /healthz
               port: 8080

--- a/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
@@ -53,3 +53,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+probe:
+  initialDelaySeconds: 60

--- a/hack/kind/overrides.voltron.yaml
+++ b/hack/kind/overrides.voltron.yaml
@@ -2,4 +2,4 @@ global:
   domainName: "voltron.local"
 
 integrationTest:
-  expectedNumberOfRunningPods: 17
+  expectedNumberOfRunningPods: 11

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -308,13 +308,19 @@ voltron::install_upgrade::kubed() {
 }
 
 voltron::install_upgrade::neo4j() {
-    # not waiting as Helm Charts installation takes additional ~5 minutes.
     shout "- Installing Neo4j Helm chart..."
 
     helm upgrade neo4j "${K8S_DEPLOY_DIR}/charts/neo4j" \
         --install \
         --create-namespace \
-        --namespace="neo4j"
+        --namespace="neo4j" \
+        --wait
+
+    echo -e "\n- Waiting for Neo4j database to be ready...\n"
+    kubectl wait --namespace neo4j \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/component=core \
+      --timeout=300s
 }
 
 voltron::install_upgrade::ingress_controller() {


### PR DESCRIPTION
**Description**

On slower envs (like my laptop) our devenv may randomly fail. Here are some improvements which make it more stable. These changes shouldn't slow down other envs.

Changes proposed in this pull request:

- Wait for neo4j db so OCH pods don't crash that often
- Disable Monitoring charts on CI. There would be no space for anything else.
- Add `initialDelaySeconds` to OCH containers, so they can always initialize properly before restarting because of failed readiness probes.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
