### PR TITLE
Fix jinja2 OCH manifests

### DIFF
--- a/och-content/implementation/atlassian/jira/install.yaml
+++ b/och-content/implementation/atlassian/jira/install.yaml
@@ -65,7 +65,7 @@ spec:
       methods:
         - name: install
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.jinja2
+    - interfaceGroupPath: cap.interface.templating.jinja2
       alias: jinja2
       methods:
         - name: template

--- a/och-content/implementation/bitnami/postgresql/install.yaml
+++ b/och-content/implementation/bitnami/postgresql/install.yaml
@@ -50,7 +50,7 @@ spec:
       methods:
         - name: run
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.jinja2
+    - interfaceGroupPath: cap.interface.templating.jinja2
       alias: jinja2
       methods:
         - name: template

--- a/och-content/implementation/gcp/cloudsql/postgresql/install.yaml
+++ b/och-content/implementation/gcp/cloudsql/postgresql/install.yaml
@@ -54,7 +54,7 @@ spec:
       methods:
         - name: run
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.jinja2
+    - interfaceGroupPath: cap.interface.templating.jinja2
       alias: jinja2
       methods:
         - name: template

--- a/och-content/implementation/templating/jinja2/template.yaml
+++ b/och-content/implementation/templating/jinja2/template.yaml
@@ -2,7 +2,7 @@ ocfVersion: 0.0.1
 revision: 0.1.0
 kind: Implementation
 metadata:
-  prefix: cap.implementation.jinja2
+  prefix: cap.implementation.templating.jinja2
   name: template
   license:
     name: "Apache 2.0"
@@ -18,7 +18,7 @@ spec:
   appVersion: "1.x.x"
 
   implements:
-    - path: cap.interface.jinja2.template
+    - path: cap.interface.templating.jinja2.template
       revision: 0.1.0
 
   action:

--- a/och-content/interface/templating/jinja2.yaml
+++ b/och-content/interface/templating/jinja2.yaml
@@ -1,0 +1,17 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: InterfaceGroup
+metadata:
+  prefix: cap.interface.templating # Computed during fetching the manifest
+  name: jinja2
+  displayName: "Jinja Templating"
+  description: "Jinja is a modern and designer-friendly templating language for Python, modelled after Django’s templates"
+  documentationURL: https://jinja.palletsprojects.com/en/2.11.x/
+  supportURL: https://jinja.palletsprojects.com/en/2.11.x/
+  maintainers:
+    - email: team-dev@projectvoltron.dev
+      name: Voltron Dev Team
+      url: https://projectvoltron.dev
+
+signature:
+  och: eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9

--- a/och-content/interface/templating/jinja2/template.yaml
+++ b/och-content/interface/templating/jinja2/template.yaml
@@ -2,11 +2,12 @@ ocfVersion: 0.0.1
 revision: 0.1.0
 kind: Interface
 metadata:
-  prefix: cap.interface.jinja2 # Computed during fetching the manifest
+  prefix: cap.interface.templating.jinja2 # Computed during fetching the manifest
   name: template
   displayName: Jinja2 Template
   description: Generate output using Jinja2 template engine
   documentationURL: https://jinja.palletsprojects.com/en/2.11.x/
+  supportURL: https://jinja.palletsprojects.com/en/2.11.x/
   iconURL: https://raw.githubusercontent.com/pallets/jinja/5f79ba633db0e6f56fc2d13cfc78547495f3d395/artwork/jinjalogo.svg
   maintainers:
     - email: team-dev@projectvoltron.dev


### PR DESCRIPTION
**Description**

Currently, the Interface for Jinja is not uploaded to the database because we do not have the InterfaceGroup manifest for it.


Changes proposed in this pull request:

- Add InterfaceGroup for jinja
- Add additional grouping directory to follow our conventions

