### PR TITLE
set USE_TEST_MANIFESTS env var to use test manifests on integration cluster

### DIFF
--- a/hack/ci/cluster-components-install-upgrade.sh
+++ b/hack/ci/cluster-components-install-upgrade.sh
@@ -20,6 +20,7 @@ main() {
     export REPO_DIR=$REPO_ROOT_DIR
     export CLUSTER_TYPE="GKE"
     export DOCKER_TAG=${OVERRIDE_DOCKER_TAG:-${DOCKER_TAG}}
+    export USE_TEST_MANIFESTS="true"
     voltron::install_upgrade::charts
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use test manifests from `test/och-content` on the GKE integration cluster

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
