### PR TITLE
Use revision when resolving action path from imports

### DIFF
--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -331,9 +331,14 @@ func (*dedicatedRenderer) resolveActionPathFromImports(imports []*ochpublicapi.I
 			if i.Alias == nil || *i.Alias != alias {
 				continue
 			}
-			return &ochpublicapi.InterfaceReference{
-				Path:     fmt.Sprintf("%s.%s", i.InterfaceGroupPath, name),
-				Revision: stringOrEmpty(i.AppVersion),
+			for _, method := range i.Methods {
+				if name != method.Name {
+					continue
+				}
+				return &ochpublicapi.InterfaceReference{
+					Path:     fmt.Sprintf("%s.%s", i.InterfaceGroupPath, name),
+					Revision: stringOrEmpty(method.Revision),
+				}
 			}
 		}
 		return nil

--- a/pkg/sdk/renderer/argo/dedicated_renderer_test.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer_test.go
@@ -1,0 +1,73 @@
+package argo
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+	ochpublicapi "projectvoltron.dev/voltron/pkg/och/api/graphql/public"
+)
+
+func TestResolveActionFromImports(t *testing.T) {
+	d := dedicatedRenderer{}
+	name := "helm"
+	appVersion := "3.x.x"
+	revision1 := "0.1.0"
+
+	tests := []struct {
+		name       string
+		shouldFail bool
+
+		imports   []*ochpublicapi.ImplementationImport
+		actionRef string
+
+		reference ochpublicapi.InterfaceReference
+	}{
+		{
+			name:       "missing imports",
+			shouldFail: true,
+			imports:    []*ochpublicapi.ImplementationImport{},
+			actionRef:  "helm.run",
+			reference:  ochpublicapi.InterfaceReference{},
+		},
+		{
+			name: "correct revision",
+			imports: []*ochpublicapi.ImplementationImport{
+				{
+					InterfaceGroupPath: "cap.interface.runner.helm",
+					Alias:              &name,
+					AppVersion:         &appVersion,
+					Methods: []*ochpublicapi.ImplementationImportMethod{
+						{
+							Name:     "run",
+							Revision: &revision1,
+						},
+					},
+				},
+			},
+			actionRef: "helm.run",
+			reference: ochpublicapi.InterfaceReference{
+				Path:     "cap.interface.runner.helm.run",
+				Revision: revision1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			reference, err := d.resolveActionPathFromImports(test.imports, test.actionRef)
+			fmt.Println(err, reference, test.reference)
+			if test.shouldFail {
+				if err == nil {
+					t.Fatal("test should fail, but did not")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("test retuned error %v", err)
+				}
+				assert.Equal(t, test.reference, *reference)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix issue when resolving action path


When I was running action with ref `cap.interface.productivity.jira.install` I've got an error 
```
'Cannot render given action: while rendering Action: while processing step:
    helm-run: No ImplementationRevision found for Interface "cap.interface.runner.helm.run"
    in revision "3.x.x" (giving up - exceeded 15 retries)'
```
`3.x.x` is an Spec.AppVersion not revision