### PR TITLE
Prepare argo-actions binary and docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: generate build-all-images test-ocf-manifests test-unit test-lint
 # Building #
 ############
 
-APPS = gateway k8s-engine och och-js argo-runner helm-runner cloudsql-runner populator terraform-runner
+APPS = gateway k8s-engine och och-js argo-runner helm-runner cloudsql-runner populator terraform-runner argo-actions
 TESTS = e2e
 INFRA = json-go-gen graphql-schema-linter
 

--- a/cmd/argo-actions/README.md
+++ b/cmd/argo-actions/README.md
@@ -1,0 +1,42 @@
+# argo-actions
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Development](#development)
+
+## Overview
+
+argo-actions is intended to be run as an Argo Workflow step which downloads, uploads, updates and deletes Type Instances.
+
+## Prerequisites
+
+- [Go](https://golang.org)
+
+### Running
+
+To run it locally you need to enable port forwarding for Local OCH:
+```bash
+kubectl -n voltron-system port-forward svc/voltron-och-local --address 0.0.0.0 8888:80
+```
+
+For downloading at least one Type Instance needs to exist. Passing structs using environment variables looks like this: {field1,field2}. For example APP_DOWNLOAD_CONFIG="{ID,path}"
+
+```bash
+RUNNER_ACTION=DownloadAction RUNNER_DOWNLOAD_CONFIG="{2282814e-7571-4708-9279-717aea3c6d08,/tmp/action.yaml}" RUNNER_LOCAL_OCH_ENDPOINT=http://localhost:8888/graphql ./argo-actions
+```
+
+## Configuration
+
+The following environment variables can be set:
+
+| Name                     | Required | Default                                         | Description                                            |
+|--------------------------|----------|-------------------------------------------------|--------------------------------------------------------|
+| APP_ACTION               | yes      |                                                 | Defines action to perform |
+| APP_LOCAL_OCH_ENDPOINT   | no       | https://voltron-och-local.voltron.local/graphql | Defines local OCH Endpoint |
+| APP_DOWNLOAD_CONFIG      | no       |                                                 | For download action defines Type Instances to download |
+
+## Development
+
+To read more about development, see the [`development.md`](../../docs/development.md) document.

--- a/cmd/argo-actions/main.go
+++ b/cmd/argo-actions/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/machinebox/graphql"
+	"github.com/vrischmann/envconfig"
+	argoactions "projectvoltron.dev/voltron/pkg/argo-actions"
+	"projectvoltron.dev/voltron/pkg/httputil"
+	"projectvoltron.dev/voltron/pkg/och/client/local"
+)
+
+type Config struct {
+	Action           string
+	DownloadConfig   []argoactions.DownloadConfig
+	LocalOCHEndpoint string `envconfig:"default=https://voltron-och-local.voltron.local/graphql"`
+}
+
+func main() {
+	var cfg Config
+	var action argoactions.Action
+
+	err := envconfig.InitWithPrefix(&cfg, "APP")
+	exitOnError(err, "while loading configuration")
+
+	client := NewOCHLocalClient(cfg.LocalOCHEndpoint)
+
+	if cfg.Action == argoactions.DownloadAction {
+		action = argoactions.NewDownloadAction(client, cfg.DownloadConfig)
+	} else {
+		err := fmt.Errorf("Invalid action: %s", cfg.Action)
+		exitOnError(err, "while selecting action")
+	}
+
+	ctx := context.Background()
+	err = action.Do(ctx)
+	exitOnError(err, "while executing action")
+}
+
+func NewOCHLocalClient(endpoint string) *local.Client {
+	httpClient := httputil.NewClient(
+		30*time.Second,
+		true,
+	)
+	clientOpt := graphql.WithHTTPClient(httpClient)
+	client := graphql.NewClient(endpoint, clientOpt)
+
+	return local.NewClient(client)
+}
+
+func exitOnError(err error, context string) {
+	if err != nil {
+		log.Fatalf("%s: %v", context, err)
+	}
+}

--- a/hack/ci/setup-env.sh
+++ b/hack/ci/setup-env.sh
@@ -34,7 +34,7 @@ fi
 
 # TODO: Read components to build in automated way, e.g. from directory structure
 cat <<EOT >> "$GITHUB_ENV"
-APPS=name=matrix::{"include":[{"APP":"gateway"},{"APP":"k8s-engine"},{"APP":"och"},{"APP":"och-js"},{"APP":"argo-runner"},{"APP":"helm-runner"},{"APP":"cloudsql-runner"},{"APP":"populator"},{"APP":"terraform-runner"}]}
+APPS=name=matrix::{"include":[{"APP":"gateway"},{"APP":"k8s-engine"},{"APP":"och"},{"APP":"och-js"},{"APP":"argo-runner"},{"APP":"helm-runner"},{"APP":"cloudsql-runner"},{"APP":"populator"},{"APP":"terraform-runner"},{"APP":"argo-actions"}]}
 TESTS=name=matrix::{"include":[{"TEST":"e2e"}]}
 INFRAS=name=matrix::{"include":[{"INFRA":"json-go-gen"},{"INFRA":"graphql-schema-linter"}]}
 TOOLS=name=matrix::{"include":[{"TOOL":"ocftool"}]}

--- a/pkg/argo-actions/actions.go
+++ b/pkg/argo-actions/actions.go
@@ -1,0 +1,7 @@
+package argoactions
+
+import "context"
+
+type Action interface {
+	Do(context.Context) error
+}

--- a/pkg/argo-actions/download_type_instances.go
+++ b/pkg/argo-actions/download_type_instances.go
@@ -1,0 +1,52 @@
+package argoactions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"projectvoltron.dev/voltron/pkg/och/client/local"
+	"projectvoltron.dev/voltron/pkg/runner"
+	"sigs.k8s.io/yaml"
+)
+
+const DownloadAction = "DownloadAction"
+
+type DownloadConfig struct {
+	ID   string
+	Path string
+}
+
+type Download struct {
+	cfg    []DownloadConfig
+	client *local.Client
+}
+
+func NewDownloadAction(client *local.Client, cfg []DownloadConfig) Action {
+	return &Download{
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+func (d *Download) Do(ctx context.Context) error {
+	for _, config := range d.cfg {
+		typeInstance, err := d.client.GetTypeInstance(context.TODO(), config.ID)
+		if err != nil {
+			return err
+		}
+		if typeInstance == nil {
+			return fmt.Errorf("failed to find TypeInstance %s", config.ID)
+		}
+
+		data, err := yaml.Marshal(typeInstance.Spec.Value)
+		if err != nil {
+			return errors.Wrap(err, "while marshaling TypeInstance to YAML")
+		}
+		err = runner.SaveToFile(config.Path, data)
+		if err != nil {
+			return errors.Wrapf(err, "while saving TypeInstance(%s) to file %s", config.ID, config.Path)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Prepare argo-actions binary and docker image

**Testing**

1. Create a TypeInstance using for example such query:
```graphql
mutation{
createTypeInstance(in:{
  typeRef:{path:"cap.core.x.x.x", revision:"0.0.1"}
  value: {key:"value"}}
){
  spec{
    typeRef{
      path
      revision
    }
    value
  }
 }
}
```
2. Get ID of TypeInstance
3. Enable port forwarding for local-och
```shell
kubectl -n voltron-system port-forward svc/voltron-och-local --address 0.0.0.0 8888:80
```
4. Run the binary:
```shell
APP_ACTION=DownloadAction APP_DOWNLOAD_CONFIG="{ID_TO_REPLACE,/tmp/action.yaml}" RAPP_LOCAL_OCH_ENDPOINT=http://localhost:8888/graphql ./argo-actions
```
5. Check file `/tmp/action` it should have a following content:
```yaml
key: value
```