### PR TITLE
Move from github.com/ghodss/yaml to sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/argoproj/argo v0.0.0-20201118180151-53195ed56029
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/fatih/color v1.10.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
 	github.com/google/go-cmp v0.5.1 // indirect

--- a/pkg/runner/cloudsql/creds.go
+++ b/pkg/runner/cloudsql/creds.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
+	"sigs.k8s.io/yaml"
 )
 
 type GCPConfig struct {

--- a/pkg/runner/helm/install.go
+++ b/pkg/runner/helm/install.go
@@ -7,13 +7,13 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
+	"sigs.k8s.io/yaml"
 )
 
 type renderer interface {

--- a/pkg/sdk/apis/0.0.1/types/types_test.go
+++ b/pkg/sdk/apis/0.0.1/types/types_test.go
@@ -7,9 +7,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"projectvoltron.dev/voltron/pkg/sdk/apis/0.0.1/types"
 )

--- a/pkg/sdk/dbpopulator/loader.go
+++ b/pkg/sdk/dbpopulator/loader.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // Order in which manifests will be loaded into DB

--- a/pkg/sdk/manifest/validation.go
+++ b/pkg/sdk/manifest/validation.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"sort"
 
-	"github.com/ghodss/yaml"
 	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
+	"sigs.k8s.io/yaml"
 )
 
 type Validator interface {

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/Knetic/govaluate"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // dedicatedRenderer is dedicated for rendering a given workflow and it is not thread safe as it stores the

--- a/pkg/sdk/renderer/argo/renderer_test.go
+++ b/pkg/sdk/renderer/argo/renderer_test.go
@@ -9,10 +9,10 @@ import (
 	"projectvoltron.dev/voltron/pkg/sdk/apis/0.0.1/types"
 	"projectvoltron.dev/voltron/pkg/sdk/renderer"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/golden"
+	"sigs.k8s.io/yaml"
 )
 
 // TestRenderHappyPath tests that renderer generates valid Argo Workflows.

--- a/pkg/sdk/renderer/argo/typeinstance_handler.go
+++ b/pkg/sdk/renderer/argo/typeinstance_handler.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"projectvoltron.dev/voltron/pkg/sdk/apis/0.0.1/types"
+	"sigs.k8s.io/yaml"
 )
 
 // TypeInstanceHandler provides functionality to handle TypeInstance operations such as


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

sigs.k8s.io/yaml is a permanet fork of github.com/ghodss/yaml which is
not maintained anymore

In some places we are using github.com/ghodss/yaml  and in others sigs.k8s.io/yaml. 
The last one is the correct one