### PR TITLE
Fix db-populator execution

### DIFF
--- a/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/och-public/values.yaml
@@ -66,4 +66,4 @@ populator:
   updateOnGitCommit: true
   # sshkey is a base64 encoded private key used by populator to download manifests. It has read only access
   manifestsPath: "git@github.com:Project-Voltron/go-voltron.git?sshkey=LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNDSTNEQmpXQjhTT1cvS3pjTWwyWm1ZTmtKRXZQcW5QRDY1RGVhQ0lrMDZjZ0FBQUpBVHIyOHJFNjl2Ckt3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDQ0kzREJqV0I4U09XL0t6Y01sMlptWU5rSkV2UHFuUEQ2NURlYUNJazA2Y2cKQUFBRURJTk51VHg3dG1oUVY1dFFxRFVpbDVxOTZwWFE2ak5TdnR2bEVBRmowWUNJamNNR05ZSHhJNWI4ck53eVhabVpnMgpRa1M4K3FjOFBya041b0lpVFRweUFBQUFESE5zYlVCemJHMHRaR1ZzYkFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K"
-  args: ["while true; do /app $(MANIFESTS_PATH); sleep 600;done"]
+  args: ["while true; do /app $MANIFESTS_PATH; sleep 600;done"]


### PR DESCRIPTION
**Description**
Currently we cannot set both `sshkey` and `ref` for our db-populator, example:

```bash
helm upgrade voltron ./deploy/kubernetes/charts/voltron -n voltron-system --reuse-values --set och-public.populator.manifestsPath="git@github.com:Project-Voltron/go-voltron.git?sshkey=LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNDSTNEQmpXQjhTT1cvS3pjTWwyWm1ZTmtKRXZQcW5QRDY1RGVhQ0lrMDZjZ0FBQUpBVHIyOHJFNjl2Ckt3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDQ0kzREJqV0I4U09XL0t6Y01sMlptWU5rSkV2UHFuUEQ2NURlYUNJazA2Y2cKQUFBRURJTk51VHg3dG1oUVY1dFFxRFVpbDVxOTZwWFE2ak5TdnR2bEVBRmowWUNJamNNR05ZSHhJNWI4ck53eVhabVpnMgpRa1M4K3FjOFBya041b0lpVFRweUFBQUFESE5zYlVCemJHMHRaR1ZzYkFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K&ref=SV-233"
```

doesn't use the SV-233 branch as expected.

The root cause was a wrong brackets when calling db-populator app.
