### PR TITLE
Engine: increase memory limit and set GOGC to 50

### DIFF
--- a/deploy/kubernetes/charts/voltron/charts/engine/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/engine/templates/deployment.yaml
@@ -58,8 +58,6 @@ spec:
               value: {{.Release.Namespace}}
             - name: APP_OCH_ACTIONS_IMAGE
               value: "{{ .Values.global.containerRegistry.path }}/{{ .Values.argoActions.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
-            - name: GOGC
-              value: "50"
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/charts/voltron/charts/engine/values.yaml
+++ b/deploy/kubernetes/charts/voltron/charts/engine/values.yaml
@@ -39,10 +39,10 @@ service:
 resources:
    limits:
      cpu: 100m
-     memory: 64Mi
+     memory: 256Mi
    requests:
      cpu: 80m
-     memory: 16Mi
+     memory: 64Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Go pprof showed that most of the memory is allocated for the manifests downloaded from OCH. In the actual rendering there weren't any significant memory allocations. Based on this I decided to just increase the memory limit and play a bit with GOGC.

I increased the memory limit to 64 MB and run the Engine with a few GOGC settings. The Engine was rendering `atlassian.stack.install` manifests.

![ok](https://i.imgur.com/oSiwvun.png)

**Changes proposed in this pull request:**

- Increase memory limit to 64 MB for Voltron Engine
- Set `GOGC=50` env for Voltron Engine deployment

**Testing**

1. Deploy the cluster from this branch
2. Create some actions. You can use this script and run a dozen of times
```bash
#!/bin/bash

MUTATION=$(echo "mutation CreateAction {
  createAction(
    in: {
      name: \\\"test-$RANDOM\\\"
      actionRef: {
        path: \\\"cap.interface.atlassian.stack.install\\\"
        revision: \\\"0.1.0\\\"
      }
      input: { parameters: \\\"{}\\\"}
    }
  ) {
    name
  }
}" | tr \\n " " | tr \\t " ")

echo "{\"query\": \"$MUTATION\"}"

curl https://graphql:<password_here>@gateway.voltron.local/graphql \
  -H 'content-type: application/json' \
  -XPOST \
  -d "{\"query\": \"$MUTATION\"}" \
```

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
