### PR TITLE
Increate proxy read timeout for Confluence

### DIFF
--- a/och-content/implementation/atlassian/confluence/install.yaml
+++ b/och-content/implementation/atlassian/confluence/install.yaml
@@ -170,6 +170,9 @@ spec:
                                   acmechallengetype: http01
                                   cert-manager.io/cluster-issuer: letsencrypt
                                   kubernetes.io/ingress.class: nginx
+                                  # Needed for Confluence setup, default 60s is too low and causes failure
+                                  # Perfectly is should be removed after Confluence setup
+                                  nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
                                   kubernetes.io/tls-acme: "true"
                                 tls:
                                   - secretName: confluence-server-tls-<@ random_word(length=5) @>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase proxy read timeout for Confluence

Confluence with remote DB is veeeeeryyy sloooow. On my laptop DB setup took almost 9 minutes. Later every action is quite slow and take more than a minute to finish.

**Testing**

1. Populate new manifests
2. Update your policy to use GCP based PostgreSQL
3. Deploy Confluence `cap.interface.productivity.confluence.install`
4. After deployment setup Confluence
    * Get a trial License
    * Press "next" on every page (one step will take almost 10 minutes)
    * Configure a user
    * Create empty page
    * Add some content
