### PR TITLE
Set values for admin user, not for non admin

### DIFF
--- a/och-content/implementation/bitnami/postgresql/install.yaml
+++ b/och-content/implementation/bitnami/postgresql/install.yaml
@@ -83,16 +83,18 @@ spec:
                             values:
                               image:
                                 pullPolicy: Always
-                              postgresqlDatabase: <@ defaultDBName @>
-                              postgresqlUsername: <@ superuser.username @>
-                              postgresqlPassword: <@ superuser.password | default(random_word(length=16)) @>
+                              global:
+                                postgresql:
+                                  postgresqlDatabase: <@ defaultDBName @>
+                                  postgresqlPassword: <@ superuser.password | default(random_word(length=16)) @>
                             output:
                               goTemplate:
                                 host: '{{ template "common.names.fullname" . }}'
                                 port: '{{ template "postgresql.port" . }}'
                                 defaultDBName: '{{ template "postgresql.database" . }}'
                                 superuser:
-                                  username: '{{ template "postgresql.username" . }}'
+                                  # It cannot be changed
+                                  username: 'postgres'
                                   password: '{{ template "postgresql.password" . }}'
                       - name: configuration
                         raw:
@@ -106,6 +108,7 @@ spec:
                     - name: psql-helm-release
                       from: helm-release
                   arguments:
+
                     artifacts:
                       - name: input-parameters
                         from: "{{steps.create-helm-args.outputs.artifacts.render}}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixes setting values for admin user

**Testing**

Deploy PostgreSQL database. 

```graphql
mutation deployDB {
    createAction(
        in: {
            name: "postgress"
            actionRef: {
                #path: "cap.interface.database.postgresql.install"
                path: "cap.interface.database.postgresql.install"
                revision: "0.1.0"
            }
            dryRun: false
            advancedRendering: false
            input: {
              parameters: "{\"superuser\":{\"username\":\"postgres\",\"password\":\"secret\"},\"defaultDBName\": \"test\"}"             
            }
        }
    ) {
        name
    		input {
          parameters
        }
    }
}
```

When deployed list helm releases:

```shell
helm list
```

Get notes to see how to connect to DB.

```shell
helm get notes postgresql-<number>
```

Make sure that you are using password passed in the action. Username is ignored as this docker image always create super user called `postgres`