### PR TITLE
renderer: fix hanging tests

### DIFF
--- a/pkg/och/client/fake/fake.go
+++ b/pkg/och/client/fake/fake.go
@@ -1,7 +1,6 @@
 package fake
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io/ioutil"
@@ -194,14 +193,10 @@ func (s *FileSystemClient) loadManifest(filepath string) error {
 }
 
 func deepCopy(src interface{}, dst interface{}) error {
-	var mod bytes.Buffer
-	enc := json.NewEncoder(&mod)
-	dec := json.NewDecoder(&mod)
-
-	err := enc.Encode(src)
+	data, err := json.Marshal(src)
 	if err != nil {
 		return err
 	}
 
-	return dec.Decode(dst)
+	return json.Unmarshal(data, &dst)
 }


### PR DESCRIPTION
Change gob to json in deepCopy

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Based on my investigation the `gob` package in `deepCopy` caused the problem with hanging test due to a deadlock. I changed it to `json` and the problem disappeared.

Changes proposed in this pull request:

- Change `gob` to `json` in `deepCopy` in fake OCH client in renderer tests

**Testing**

Keep this running for a while:
`while true; do go clean -testcache && go test ./pkg/sdk/renderer/argo/... ; done`

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
