### PR TITLE
Disable not necessary builds

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # To be able to compare with the previous commit and detect changed files
       - name: setup env
         run: . ./hack/ci/setup-env.sh
       - id: set-matrix-app

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -153,7 +153,7 @@ jobs:
   build-infra:
     name: Build ${{ matrix.INFRA }}
     runs-on: ubuntu-latest
-    if: ${{ needs.prepare-matrix.outputs.matrix-infra != '' && github.event.pull_request.draft == false }}
+    if: github.event.pull_request.draft == false
     needs: prepare-matrix
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Build time was taken from the last execution on master branch: https://github.com/Project-Voltron/go-voltron/runs/2128194847

- Disabled from master build:
  - unit tests + lint tests + generated files test  7m 5s
  - tools build (currently only `ocftool` which is not pushed anywhere) 4m 25s
  - disable integration tests  14m 53s
  - already disabled the build of the `och` component #194   1m 59s
  
  **Saves: 28m22s per each commit on master branch**

  **From 59,17min to 30,95min**

- Run only if needed: 
  - build infra images only if file change is detected in `hack/images` 2m17s
  - build `och-js` only if file changed is detected in `och-js`   1m 16s
  
  **Saves: 3m33s per each commit on master and PR**