### PR TITLE
Pass env as a string in RocketChat manifests

### DIFF
--- a/och-content/implementation/rocketchat/install.yaml
+++ b/och-content/implementation/rocketchat/install.yaml
@@ -104,9 +104,9 @@ spec:
                               name: "rocketchat"
                               repo: "https://charts.helm.sh/stable"
                             values:
-                              extraEnv:
-                              - name: EXIT_UNHANDLEDPROMISEREJECTION
-                                value: "true"
+                              extraEnv: |
+                                - name: EXIT_UNHANDLEDPROMISEREJECTION
+                                  value: "true"
                               image:
                                 tag: 3.13.1
                               mongodb:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

In RocketChat Helm charts envs are rendered using `tpl` function.

- Pass envs as string

**Testing**

1. Deploy RocketChat

```graphql
mutation CreateRocketChatAction {
    createAction(
        in: {
            name: "install-rocketchat",
            actionRef: {
                path: "cap.interface.productivity.rocketchat.install",
                revision: "0.1.0",
            },
            dryRun: false,
            advancedRendering: false,
            input: {
                            input: {
                parameters: "{\"host\": \"rocketchat.voltron.local\", \"replicas\":\"3\", \"affinity\":{\"nodeAffinity\": {\"requiredDuringSchedulingIgnoredDuringExecution\": {\"nodeSelectorTerms\": [{\"matchExpressions\": [{\"key\": \"node.voltron.dev/type\",\"operator\": \"NotIn\",\"values\": [\"storage\"]}]}]}}}}",
            }
        }
    ) {
        name
        input {
            parameters
        }
    }
}


query Get {
  action(name:"install-rocketchat"){
    name
    createdAt
		input{
      parameters
    }
    
    status{
      phase
      runner{
        status
      }
    }
  }
}

mutation Run {
    runAction(name: "install-rocketchat") {
        name
    }
}

mutation Delete {
    deleteAction(name: "install-rocketchat") {
        name
    }
}
```

2. Make sure that RocketChat Pod has set env
```yaml
    - name: EXIT_UNHANDLEDPROMISEREJECTION
      value: "true"
```