### PR TITLE
Prepare production-ready configuration for Atlassian Crowd

### DIFF
--- a/och-content/implementation/atlassian/crowd/install.yaml
+++ b/och-content/implementation/atlassian/crowd/install.yaml
@@ -229,7 +229,7 @@ spec:
                                   cpu: <@ input.resources.limits.cpu | default("1") @>
 
                               ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-                              replicaCount: <@ input.replicaCount | default(3) @>
+                              replicaCount: <@ input.replicaCount | default(1) @>
 
                               ## ref: https://kubernetes.io/docs/user-guide/node-selection/
                               nodeSelector: <@ input.nodeSelector | default({}) @>

--- a/och-content/type/productivity/crowd/install-input.yaml
+++ b/och-content/type/productivity/crowd/install-input.yaml
@@ -50,7 +50,7 @@ spec:
                 "cpu": "1"
               }
             },
-            "replicaCount": 2,
+            "replicaCount": 1,
             "readinessProbe": {
               "enabled": false
             },
@@ -298,7 +298,7 @@ spec:
           "type": "integer",
           "title": "The number of replicas",
           "description": "Reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/",
-          "default": 3
+          "default": 1
         },
         "nodeSelector": {
           "$id": "#/properties/nodeSelector",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Prepare production-ready configuration for Atlassian Crowd

## Notes
- Unfortunately this chart doesn't support official [Clustering mode](https://confluence.atlassian.com/crowd/crowd-data-center-935372453.html). That is, even if you scale up the app and use NFS to allow scheduling them on different nodes, the Pods doesn't discover themselves in the Clustering UI. I don't know what are the implications. However, after configuration step everything seems to work fine.
Anyway, we should wait for https://github.com/atlassian-labs/data-center-helm-charts/pull/106 
- First time the image has to run as a root, if we don't want to provide our own configuration: see https://hub.docker.com/r/atlassian/crowd "Shared directory and user IDs" section
- Atlassian Crowd was successfully tested on AWS EKS with and without EFS.

## Testing

Run cluster:
```bash
DISABLE_MONITORING_INSTALLATION=true ENABLE_POPULATOR=false make dev-cluster
```

**Optionally** - if you want to use PVC with nfs storageClass:
- You can use `MULTINODE_CLUSTER=true` env during cluster installation (it's not required if you don't want to schedule Crowd pods on different nodes).
- Install NFS provisioner:

    ```bash
    helm repo add stable https://charts.helm.sh/stable
    helm install nfs-provisioner stable/nfs-server-provisioner -n nfs --create-namespace
    ```

Populate DB:
```bash
kubectl -n neo4j port-forward svc/neo4j-neo4j 7687:7687
APP_JSONPUBLISHADDR=http://{ip} APP_LOGGER_DEV_MODE=true APP_MANIFESTS_PATH=./och-content go run cmd/populator/main.go .
```

Build CLI
```
go build -ldflags " -w -X capact.io/capact/internal/ocftool.CLIName=capact" -o /usr/local/bin/capact ./cmd/ocftool/main.go
```

Login:
```
capact login https://gateway.capact.local -u graphql -p t0p_s3cr3t
```

Find and run `cap.interface.productivity.crowd.install`
```
capact hub interfaces browse
```

Name it `crowd` and keep the `default` namespace - or whichever you want.
Provide the following input parameters:

**Option A:** When NFS provisioner is installed:

```yaml
host: crowd.capact.local
replicaCount: 1
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: node.capact.io/type
          operator: NotIn
          values:
          - storage
serviceAccount:  
  annotations:
    test-run: "true"
resources:
  requests:
    memory: 200M
    cpu: 200m
envVars:
  FOO: "bar"
  BAR: "baz"
livenessProbe:
  enabled: false
persistence:
  accessMode: ReadWriteMany
  storageClass: nfs
```

or

**Option B**: Fallback to default parameters

```yaml
host: crowd.capact.local
```

Do not provide TypeInstances.

Get, run and watch Action
```
capact action get crowd
capact action run crowd
capact action watch crowd
```


4. After it's complete, check https://crowd.capact.local/

Due to a known lack of ability to pass DB details during Crowd installation, you need to provide database connection parameters.

You can check them using:
```graphql
query TypeInstance {
  typeInstance(id:"{crowd-config-id}") {
    id
    typeRef {
      path
      revision
    }
    uses {
      typeRef {
        path
      }
      latestResourceVersion {
        spec {
          value
        }
      }
    }
  }
}
```
Look for TypeInstance with `postgresql.config` typeRef.

You can get a trial licence and configure Crowd.

When you finished, do cleanup: 

```bash
kubectl delete action concourse
helm delete $(helm list -q)
```
