### PR TITLE
Do not escape qutoes, goOutput is a string now

### DIFF
--- a/och-content/implementation/elastic/elasticsearch/install.yaml
+++ b/och-content/implementation/elastic/elasticsearch/install.yaml
@@ -116,7 +116,7 @@ spec:
                                 host: "{{ (index .Values.ingress.hosts 0).host }}"
                                 port: 80
                               <% else %>
-                                host: "{{ template \"elasticsearch.masterService\" . }}.{{ .Release.Namespace }}"
+                                host: "{{ template "elasticsearch.masterService" . }}.{{ .Release.Namespace }}"
                                 port: "{{ .Values.httpPort }}"
                               <% endif %>
                                 basicAuthSecretName: <@ metadata.name @>


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fix installing local Elasticsearch

**Testing**

Create `bb.yaml` file 

```yaml
ingress:
  host: bb.capact.local
```

Create action and when ready, run it:

```bash
capact act create cap.interface.productivity.bitbucket.install --name bb --parameters-from-file bb.yaml
```