### PR TITLE
Update aws-for-fluent-bit chart to 0.1.7

### DIFF
--- a/hack/eks/aws-for-fluent-bit/install.sh
+++ b/hack/eks/aws-for-fluent-bit/install.sh
@@ -17,8 +17,7 @@ helm repo update
 helm upgrade aws-for-fluent-bit "eks-charts/aws-for-fluent-bit" \
     --install \
     --namespace="kube-system" \
-    --version v0.1.6 \
+    --version v0.1.7 \
     --values "${CURRENT_DIR}/values.yml" \
     --set "cloudWatch.logGroupName=/aws/eks/${CAPACT_NAME}/logs" \
     --set "cloudWatch.region=${CAPACT_REGION}" \
-    --wait

--- a/hack/eks/install.sh
+++ b/hack/eks/install.sh
@@ -70,7 +70,7 @@ capact::aws::install::fluent_bit() {
 capact::aws::install::efs_csi_driver() {
   shout "Deploying AWS EFS CSI driver..."
   "${CURRENT_DIR}"/aws-efs-csi-driver/install.sh
-  shout "aws-for-fluent-bit deployed successfully!"
+  shout "AWS EFS CSI driver deployed successfully!"
 }
 
 capact::aws::install::capact() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Update `aws-for-fluent-bit` chart to 0.1.7. The current version has a bug and the fluent-bit pod request 500Mi memory and 500m CPU
- Remove `--wait` from the Helm update for `aws-for-fluent-bit`. If there are more nodes it can time out till the DaemonSet pods get updated.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
