### PR TITLE
Fix panic in Engine

### DIFF
--- a/internal/k8s-engine/controller/action_service.go
+++ b/internal/k8s-engine/controller/action_service.go
@@ -250,7 +250,11 @@ func (a *ActionService) EnsureRunnerExecuted(ctx context.Context, saName string,
 }
 
 func (a *ActionService) LockTypeInstances(ctx context.Context, action *v1alpha1.Action) error {
-	if action == nil || action.Status.Rendering == nil || action.Status.Rendering.TypeInstancesToLock == nil {
+	if action == nil || action.Status.Rendering == nil {
+		return errors.New("Action or Action rendering status is nil")
+	}
+
+	if action.Status.Rendering.TypeInstancesToLock == nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix panic in Engine during locking/unlocking TypeInstances with Action without rendering status

Sample log:
```
2021-05-18T11:56:07.932Z	INFO	controllers.Action	zapr@v0.1.0/zapr.go:69	Handling finished action	{"action": "capact-system/capact-upgrade-xn9k5"}
E0518 11:56:07.932214       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 428 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x17789a0, 0x2615790)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/runtime/runtime.go:48 +0x86
panic(0x17789a0, 0x2615790)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
capact.io/capact/internal/k8s-engine/controller.(*ActionService).UnlockTypeInstances(0xc000195490, 0x1ba3270, 0xc00004c030, 0xc00013a780, 0x0, 0xc0005e89a0)
	/capact.io/capact/internal/k8s-engine/controller/action_service.go:266 +0x30
capact.io/capact/internal/k8s-engine/controller.(*ActionReconciler).handleFinishedAction(0xc0008bd140, 0x1ba3270, 0xc00004c030, 0xc00013a780, 0x0, 0x0, 0x14, 0x1b75618)
	/capact.io/capact/internal/k8s-engine/controller/action_controller.go:290 +0x56
capact.io/capact/internal/k8s-engine/controller.(*ActionReconciler).Reconcile(0xc0008bd140, 0xc000432d50, 0xd, 0xc000985800, 0x14, 0x1a122212d, 0xc0000f6510, 0xc00055f9f8, 0xc00055f9e0)
	/capact.io/capact/internal/k8s-engine/controller/action_controller.go:139 +0x7de
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000331ce0, 0x17d7aa0, 0xc0003c0580, 0x59f00)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:255 +0x166
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000331ce0, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:231 +0xb0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(...)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:210
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00058d260)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00058d260, 0x3b9aca00, 0x0, 0x1, 0xc0007270e0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:153 +0x105
k8s.io/apimachinery/pkg/util/wait.Until(0xc00058d260, 0x3b9aca00, 0xc0007270e0)
	/go/pkg/mod/k8s.io/apimachinery@v0.17.9/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.11/pkg/internal/controller/controller.go:192 +0x3f5
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1580790]
```