### PR TITLE
Action policy support in engine and renderer

### DIFF
--- a/deploy/kubernetes/charts/capact/charts/engine/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/capact/charts/engine/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: {{.Release.Namespace}}
             - name: APP_HUB_ACTIONS_IMAGE
               value: "{{ .Values.global.containerRegistry.path }}/{{ .Values.argoActions.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+            - name: APP_POLICY_ORDER
+              value: "{{ .Values.policyOrder }}"
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/charts/capact/charts/engine/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/engine/values.yaml
@@ -57,6 +57,8 @@ tolerations: []
 
 affinity: {}
 
+# order from highest priority to the lowest
+policyOrder: "ACTION,GLOBAL,WORKFLOW"
 globalPolicyRules:
 # Insert Interface paths with Implementations. For example:
 #

--- a/deploy/kubernetes/charts/capact/charts/hub-public/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/hub-public/values.yaml
@@ -68,5 +68,5 @@ populator:
     repository: git@github.com:capactio/hub-manifests.git
     # sshKey is a base64 encoded private key used by populator to download manifests. It has read only access
     sshKey: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNEUXhvRUVSTUx0K2E2Ym9yUXdhTTJuak4vL2hqMDZSQTMyRDBuVmlNSnEzd0FBQUpnd2ZrS1hNSDVDCmx3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDRFF4b0VFUk1MdCthNmJvclF3YU0ybmpOLy9oajA2UkEzMkQwblZpTUpxM3cKQUFBRUIybEFhUDVzNG9qRWw0UzlTSU5xbTk0YU1OaXdZWWhpdTJtaHpqS3hUVmE5REdnUVJFd3UzNXJwdWl0REJvemFlTQozLytHUFRwRURmWVBTZFdJd21yZkFBQUFFblJsWVcwdFpHVjJRR05oY0dGamRDNXBid0VDQXc9PQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K
-    branch: main
+    branch: CP-432-modify-och-content
   args: ["while true; do /app register ocf-manifests $MANIFESTS_PATH; sleep 600;done"]

--- a/internal/k8s-engine/controller/suite_test.go
+++ b/internal/k8s-engine/controller/suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = (&ActionReconciler{
 		log: ctrl.Log.WithName("controllers").WithName("Action"),
 		svc: NewActionService(zap.NewRaw(zap.WriteTo(ioutil.Discard)), mgr.GetClient(),
-			&argoRendererFake{}, &actionValidatorFake{}, &policyServiceFake{}, &typeInstanceLockerFake{},
+			&argoRendererFake{}, &actionValidatorFake{}, &policyServiceFake{}, policy.MergeOrder{policy.Action, policy.Global}, &typeInstanceLockerFake{},
 			&typeInstanceGetterFake{}, cfg),
 	}).SetupWithManager(mgr, maxConcurrentReconciles)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/engine/k8s/policy/types.go
+++ b/pkg/engine/k8s/policy/types.go
@@ -11,6 +11,15 @@ const (
 	AnyInterfacePath  string = "cap.*"
 )
 
+type OrderItem string
+type MergeOrder []OrderItem
+
+const (
+	Global   OrderItem = "GLOBAL"
+	Action   OrderItem = "ACTION"
+	Workflow OrderItem = "WORKFLOW"
+)
+
 type Policy struct {
 	APIVersion string    `json:"apiVersion"`
 	Rules      RulesList `json:"rules"`

--- a/pkg/hub/client/policy_merger.go
+++ b/pkg/hub/client/policy_merger.go
@@ -1,0 +1,120 @@
+package client
+
+import "capact.io/capact/pkg/engine/k8s/policy"
+
+func (e *PolicyEnforcedClient) mergePolicies() {
+	newPolicy := policy.Policy{}
+
+	for _, p := range e.policyOrder {
+		if p == policy.Global {
+			newPolicy = applyPolicy(newPolicy, e.globalPolicy)
+		} else if p == policy.Action {
+			newPolicy = applyPolicy(newPolicy, e.actionPolicy)
+		} else if p == policy.Workflow {
+			for _, wp := range e.workflowStepPolicy {
+				newPolicy = applyPolicy(newPolicy, wp)
+			}
+		}
+	}
+	e.mergedPolicy = newPolicy
+}
+
+// from new policy we are checking if there are the same rules. If yes we fill missing data,
+// if not we add a rule to the end
+// current policy is a higher priority policy
+func applyPolicy(currentPolicy, newPolicy policy.Policy) policy.Policy {
+	for _, newRuleForInterface := range newPolicy.Rules {
+		policyRuleIndex := getIndexOfPolicyRule(currentPolicy, newRuleForInterface)
+		if policyRuleIndex == -1 {
+			currentPolicy.Rules = append(currentPolicy.Rules, newRuleForInterface)
+			continue
+		}
+		ruleForInterface := currentPolicy.Rules[policyRuleIndex]
+		for _, newRule := range newRuleForInterface.OneOf {
+			ruleIndex := getIndexOfOneOfRule(ruleForInterface.OneOf, newRule)
+			if ruleIndex == -1 {
+				currentPolicy.Rules[policyRuleIndex].OneOf = append(currentPolicy.Rules[policyRuleIndex].OneOf, newRule)
+				continue
+			}
+			if newRule.Inject == nil {
+				break
+			}
+			rule := ruleForInterface.OneOf[ruleIndex]
+			// merge Additional Input
+			if newRule.Inject.AdditionalInput != nil {
+				ruleForInterface.OneOf[ruleIndex].Inject.AdditionalInput = mergeMaps(newRule.Inject.AdditionalInput, rule.Inject.AdditionalInput)
+			}
+			// merge TypeInstances
+			if newRule.Inject.TypeInstances != nil {
+				ruleForInterface.OneOf[ruleIndex].Inject.TypeInstances = mergeTypeInstances(newRule.Inject.TypeInstances, rule.Inject.TypeInstances)
+			}
+		}
+	}
+	return currentPolicy
+}
+
+func getIndexOfPolicyRule(p policy.Policy, rule policy.RulesForInterface) int {
+	for i, ruleForInterface := range p.Rules {
+		if isForSameInterface(ruleForInterface, rule) {
+			return i
+		}
+	}
+	return -1
+}
+
+func getIndexOfOneOfRule(rules []policy.Rule, rule policy.Rule) int {
+	for i, r := range rules {
+		if isSameOneOf(r, rule) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isForSameInterface(p1, p2 policy.RulesForInterface) bool {
+	if p1.Interface.Path != p2.Interface.Path {
+		return false
+	}
+	return p1.Interface.Revision == p2.Interface.Revision
+}
+
+func isSameOneOf(a, b policy.Rule) bool {
+	return a.ImplementationConstraints.Path == b.ImplementationConstraints.Path
+	//TODO match rules with different constraints
+}
+
+func mergeMaps(current, overwrite map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(current))
+	for k, v := range current {
+		out[k] = v
+	}
+	for k, v := range overwrite {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = mergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func mergeTypeInstances(current, overwrite []policy.TypeInstanceToInject) []policy.TypeInstanceToInject {
+	out := append([]policy.TypeInstanceToInject{}, current...)
+	for _, newTI := range overwrite {
+		found := false
+		for i, ti := range current {
+			if newTI.TypeRef.Path == ti.TypeRef.Path && newTI.TypeRef.Revision == ti.TypeRef.Revision {
+				found = true
+				out[i] = newTI
+			}
+		}
+		if !found {
+			out = append(out, newTI)
+		}
+	}
+	return out
+}

--- a/pkg/hub/client/policy_merger_test.go
+++ b/pkg/hub/client/policy_merger_test.go
@@ -1,0 +1,348 @@
+package client_test
+
+import (
+	"testing"
+
+	"capact.io/capact/pkg/engine/k8s/policy"
+	"capact.io/capact/pkg/hub/client"
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyEnforcedClient_mergePolicies(t *testing.T) {
+	interfacePath := "cap.interface.test.install"
+	secondInterfacePath := "cap.interface.alibaba.install"
+	implementationPath := "cap.implementation.test.install"
+	secondImplementationPath := "cap.implementation.test.second.install"
+
+	tests := []struct {
+		name     string
+		global   policy.Policy
+		action   policy.Policy
+		expected policy.Policy
+		order    policy.MergeOrder
+	}{
+		{
+			name: "only global policy",
+			global: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"name": "capact",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			action: policy.Policy{},
+			expected: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"name": "capact",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			order: policy.MergeOrder{policy.Action, policy.Global},
+		},
+		{
+			name: "only action policy",
+			action: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"address": "1.2.3.4",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			global: policy.Policy{},
+			expected: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"address": "1.2.3.4",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			order: policy.MergeOrder{policy.Action, policy.Global},
+		},
+		{
+			name: "action first then global for the same interface",
+			action: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"address": "1.2.3.4",
+											"alias":   "karpatka",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123-111",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			global: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"name":  "capact",
+											"alias": "capactio",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123-222",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &secondImplementationPath,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+								Inject: &policy.InjectData{
+									AdditionalInput: map[string]interface{}{
+										"host": map[string]interface{}{
+											"name":    "capact",
+											"address": "1.2.3.4",
+											"alias":   "karpatka",
+										},
+									},
+									TypeInstances: []policy.TypeInstanceToInject{
+										{
+											ID: "1314-142-123-111",
+											TypeRef: types.ManifestRef{
+												Path: "cap.type.gcp.auth.service-account",
+											},
+										},
+									},
+								},
+							},
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &secondImplementationPath,
+								},
+							},
+						},
+					},
+				},
+			},
+			order: policy.MergeOrder{policy.Action, policy.Global},
+		},
+		{
+			name: "action first then global for different interfaces - only rules",
+			action: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+							},
+						},
+					},
+				},
+			},
+			global: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: secondInterfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &secondImplementationPath,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: policy.Policy{
+				Rules: policy.RulesList{
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: interfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &implementationPath,
+								},
+							},
+						},
+					},
+					policy.RulesForInterface{
+						Interface: types.ManifestRef{
+							Path: secondInterfacePath,
+						},
+						OneOf: []policy.Rule{
+							{
+								ImplementationConstraints: policy.ImplementationConstraints{
+									Path: &secondImplementationPath,
+								},
+							},
+						},
+					},
+				},
+			},
+			order: policy.MergeOrder{policy.Action, policy.Global},
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			cli := client.NewPolicyEnforcedClient(nil)
+			cli.SetPolicyOrder(tt.order)
+			cli.SetGlobalPolicy(tt.global)
+			cli.SetActionPolicy(tt.action)
+
+			// expect
+			assert.Equal(t, tt.expected, cli.Policy())
+		})
+	}
+}

--- a/pkg/sdk/renderer/argo/options.go
+++ b/pkg/sdk/renderer/argo/options.go
@@ -19,9 +19,21 @@ func WithSecretUserInput(ref *UserInputSecretRef) RendererOption {
 	}
 }
 
-func WithPolicy(policy policy.Policy) RendererOption {
+func WithGlobalPolicy(policy policy.Policy) RendererOption {
 	return func(r *dedicatedRenderer) {
-		r.policyEnforcedCli.SetPolicy(policy)
+		r.policyEnforcedCli.SetGlobalPolicy(policy)
+	}
+}
+
+func WithActionPolicy(policy policy.Policy) RendererOption {
+	return func(r *dedicatedRenderer) {
+		r.policyEnforcedCli.SetActionPolicy(policy)
+	}
+}
+
+func WithPolicyOrder(order policy.MergeOrder) RendererOption {
+	return func(r *dedicatedRenderer) {
+		r.policyEnforcedCli.SetPolicyOrder(order)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add algorithm to merge multiple policies
- If provided in the Policy, render additional-parameters as a raw artifact 

## Testing

Create an Action Policy file:

```bash
cat << EOF >/tmp/policy.yaml
rules:
  - interface:
      path: cap.interface.productivity.rocketchat.install
    oneOf:
      - implementationConstraints:
          path: "cap.implementation.rocketchat.install"
        inject:
          additionalInput:
            additional-parameters:
              ingress:
                enabled: false
  - interface:
      path: cap.interface.database.mongodb.install
    oneOf:
      - implementationConstraints:
          path: "cap.implementation.bitnami.mongodb.install"
        inject:
          additionalInput:
            additional-parameters:
              image:
                registry: docker.io
                pullPolicy: Always
EOF
```

Create RocketChat input parameters

```bash
cat << EOF >/tmp/rocketchat-params.yaml
host: rocketchat.capact.local
EOF
```

Create and action
```bash
capact act create cap.interface.productivity.rocketchat.install --name rocketchat --parameters-from-file /tmp/rocketchat-params.yaml --action-policy-from-file /tmp/policy.yaml
```

Wait for it to be rendered and run it. Wait till it's ready.

After deployment, check the helm values for RocketChat and MongoDB to see if values from the Action Policy were applied.

## Related issue(s)

Resolves #330