### PR TITLE
Add old Service to hub-local chart to support seamless migration

### DIFF
--- a/deploy/kubernetes/charts/capact/charts/hub-local/templates/old-service.yaml
+++ b/deploy/kubernetes/charts/capact/charts/hub-local/templates/old-service.yaml
@@ -1,0 +1,24 @@
+# TODO: Remove this Service after 0.4.0 release.
+#
+# NOTE: We changed the internal DNS from `capact-och-local.capact-system` to `capact-hub-local.capact-system`.
+# But the Action is rendered before upgrade and Engine sets up the TypeInstance upload step with old URL.
+# As a result, Action fails as the updated TypeInstances cannot be uploaded to Local Hub, error:
+# `Post "http://capact-och-local.capact-system/graphql": dial tcp: lookup capact-och-local.capact-system on 10.4.0.10:53: no such host`
+# To avoid such situation we leave the old Service but now it points to the new Local Hub deployment.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  # old Service name
+  name: capact-och-local
+  labels:
+    deprecated: "true"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "hub.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add old Service to hub-local chart to support seamless migration. This issue was discovered after long-running cluster update.

TODO:
- [x] Once accepted, add info in https://github.com/capactio/capact/issues/326 to remove the Svc after release.
## Related issue(s)

- https://github.com/capactio/capact/issues/322
