### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -18,6 +18,7 @@ on:
       - "main"
       - "release-0.2"
       - "release-0.3"
+      - "release-0.4"
 
 jobs:
   entry-tests:

--- a/deploy/kubernetes/charts/argo/Chart.yaml
+++ b/deploy/kubernetes/charts/argo/Chart.yaml
@@ -4,7 +4,7 @@ description: Argo chart for Kubernetes
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: argo

--- a/deploy/kubernetes/charts/capact/Chart.yaml
+++ b/deploy/kubernetes/charts/capact/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/kubernetes/charts/cert-manager/Chart.yaml
+++ b/deploy/kubernetes/charts/cert-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for CertManager for Capact installation
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: cert-manager

--- a/deploy/kubernetes/charts/ingress-nginx/Chart.yaml
+++ b/deploy/kubernetes/charts/ingress-nginx/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Nginx Ingress Controller for Capact installation
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: ingress-nginx

--- a/deploy/kubernetes/charts/kubed/Chart.yaml
+++ b/deploy/kubernetes/charts/kubed/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for kubed for Capact installation
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: kubed

--- a/deploy/kubernetes/charts/monitoring/Chart.yaml
+++ b/deploy/kubernetes/charts/monitoring/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Capact monitoring stack
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: kube-prometheus-stack

--- a/deploy/kubernetes/charts/neo4j/Chart.yaml
+++ b/deploy/kubernetes/charts/neo4j/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for neo4j for Capact installation
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   - name: neo4j


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Prepare 0.4.0 release

Links in the release notes will be updated before posting GH release.

## Release notes

🚨**Capact** v0.4.0 is now available! It's our first open source release! 

The very first official Capact website is live too! Check it out at [capact.io](https://capact.io).

#### ✨ Key highlights

- From now on, to interact with Capact all you need is Capact CLI! You don’t have to play directly with the GraphQL console anymore. To start using it, see our [CLI getting started](https://capact.io/docs/cli/getting-started) guide.
- We extended our Policy engine to cover all your use cases: 
    1. [Global policy](https://capact.io/docs/feature/policies/global-policy)
    2. [Action policy](https://capact.io/docs/feature/policies/action-policy)
    3. [Workflow step policy](https://capact.io/docs/feature/policies/workflow-step-policy) 
    
    The policies from the three sources above are merged and evaluated during Action rendering. See the [Policy overview](https://capact.io/docs/feature/policies/overview) to learn more.
- The OCH was renamed to Capact Hub to make it more meaningful.
- TypeInstances that are used by a given Action are now locked by the Engine to avoid any race condition during the Action execution.
- We added Mattermost manifests to our Hub. Check out our [installation tutorial](https://capact.io/docs/example/mattermost-installation).
- To make running Capact easier, we created documentation dedicated to [operations](https://capact.io/docs/operation). It describes how to identify and resolve common Capact problems that you might encounter and how to check the dashboards of Capact components.
- We moved the Capact documentation to the [`website`](https://github.com/capactio/website) repository under [`docs`](https://github.com/capactio/website/tree/main/docs) directory. 

#### Capact CLI Binaries

Linux: `curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/v0.4.0/capact-linux-amd64`
macOS: `curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/v0.4.0/capact-darwin-amd64`
Windows: `curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/v0.4.0/capact-windows-amd64.exe`

#### Populator Binaries

Linux: `curl -Lo ./populator https://storage.googleapis.com/capactio-binaries/v0.4.0/populator-linux-amd64`
macOS: `curl -Lo ./populator https://storage.googleapis.com/capactio-binaries/v0.4.0/populator-darwin-amd64`
Windows: `curl -Lo ./populator https://storage.googleapis.com/capactio-binaries/v0.4.0/populator-windows-amd64.exe`


## Related issue(s)

https://github.com/capactio/capact/issues/326