### PR TITLE
Share Capact CLI between GH Action steps

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -190,8 +190,7 @@ jobs:
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Set up GoReleaser
-        # We use a new `no_unique_dist_dir` feature, which is not yet released.
-        run: go install github.com/goreleaser/goreleaser@b53dbb89d02aa3673782f3d063d7d5039446baac
+        run: go install github.com/goreleaser/goreleaser@v0.173.2
       - name: Set up GCS
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,7 @@
 name: PR build
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"
@@ -33,177 +33,177 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.0
         with:
           access_token: ${{ github.token }}
-#
-#  entry-tests:
-#    name: Lint and test code
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.draft == false
-#    permissions:
-#      contents: read
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: Setup environment
-#        env:
-#          PR_NUMBER: ${{ github.event.pull_request.number }}
-#        run: |
-#          . ./hack/ci/setup-env.sh
-#      - name: Setup Go
-#        uses: actions/setup-go@v2
-#        with:
-#          go-version: ${{env.GO_VERSION}}
-#      - name: Run linting
-#        run: |
-#          make test-lint
-#      - name: Run unit tests
-#        run: make test-unit
-#      - name: Check generated files
-#        run: |
-#          make test-generated
-#
-#  documentation-sanity:
-#    name: Check documentation
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.draft == false
-#    permissions:
-#      contents: read
-#      pull-requests: write
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: Run LanguageTool
-#        uses: reviewdog/action-languagetool@v1
-#        with:
-#          github_token: ${{ secrets.github_token }}
-#          reporter: github-pr-review
-#          level: info
-#          custom_api_endpoint: ''
-#          ### Flags for LanguageTool ###
-#          # Ref: https://languagetool.org/http-api/swagger-ui/#!/default/post_check
-#          language: 'en-US'
-#          enabled_rules: ''
-#          disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION'
-#          enabled_categories: ''
-#          disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
-#          enabled_only: 'false'
-#      - name: Run misspell check
-#        uses: reviewdog/action-misspell@v1
-#        with:
-#          github_token: ${{ secrets.github_token }}
-#          reporter: github-pr-review
-#          level: info
-#          locale: "US"
-#
-#  prepare-matrix:
-#    name: Prepare components build matrix
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.draft == false
-#    outputs:
-#      matrix-app: ${{ steps.set-matrix-app.outputs.matrix }}
-#      matrix-test: ${{ steps.set-matrix-test.outputs.matrix }}
-#      matrix-infra: ${{ steps.set-matrix-infra.outputs.matrix }}
-#      matrix-tool: ${{ steps.set-matrix-tool.outputs.matrix }}
-#    permissions:
-#      contents: read
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: setup env
-#        run: . ./hack/ci/setup-env.sh
-#      - id: set-matrix-app
-#        run: echo "::set-output ${APPS}"
-#      - id: set-matrix-test
-#        run: echo "::set-output ${TESTS}"
-#      - id: set-matrix-infra
-#        run: echo "::set-output ${INFRAS}"
-#      - id: set-matrix-tool
-#        run: echo "::set-output ${TOOLS}"
-#
-#  build-app:
-#    name: Build ${{ matrix.APP }}
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.draft == false
-#    needs: prepare-matrix
-#    strategy:
-#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
-#    permissions:
-#      contents: read
-#      packages: write
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: Setup environment
-#        env:
-#          PR_NUMBER: ${{ github.event.pull_request.number }}
-#        run: |
-#          . ./hack/ci/setup-env.sh
-#      - run: make build-app-image-${{ matrix.APP }}
-#      - name: Log into registry
-#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-#      - run: make push-app-image-${{ matrix.APP }}
-#
-#  build-tests:
-#    name: Build ${{ matrix.TEST }}
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.draft == false
-#    needs: prepare-matrix
-#    strategy:
-#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
-#    permissions:
-#      contents: read
-#      packages: write
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: Setup environment
-#        env:
-#          PR_NUMBER: ${{ github.event.pull_request.number }}
-#        run: |
-#          . ./hack/ci/setup-env.sh
-#      - run: make build-test-image-${{ matrix.TEST }}
-#      - name: Log into registry
-#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-#      - run: make push-test-image-${{ matrix.TEST }}
-#
-#  build-infra:
-#    name: Build ${{ matrix.INFRA }}
-#    runs-on: ubuntu-latest
-#    if: ${{ needs.prepare-matrix.outputs.matrix-infra != '' && github.event.pull_request.draft == false }}
-#    needs: prepare-matrix
-#    strategy:
-#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
-#    permissions:
-#      contents: read
-#      packages: write
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: Setup environment
-#        env:
-#          PR_NUMBER: ${{ github.event.pull_request.number }}
-#        run: |
-#          . ./hack/ci/setup-env.sh
-#      - run: make build-infra-image-${{ matrix.INFRA }}
-#      - name: Log into registry
-#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-#      - run: make push-infra-image-${{ matrix.INFRA }}
+
+  entry-tests:
+    name: Lint and test code
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{env.GO_VERSION}}
+      - name: Run linting
+        run: |
+          make test-lint
+      - name: Run unit tests
+        run: make test-unit
+      - name: Check generated files
+        run: |
+          make test-generated
+
+  documentation-sanity:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run LanguageTool
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          custom_api_endpoint: ''
+          ### Flags for LanguageTool ###
+          # Ref: https://languagetool.org/http-api/swagger-ui/#!/default/post_check
+          language: 'en-US'
+          enabled_rules: ''
+          disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION'
+          enabled_categories: ''
+          disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
+          enabled_only: 'false'
+      - name: Run misspell check
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          locale: "US"
+
+  prepare-matrix:
+    name: Prepare components build matrix
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    outputs:
+      matrix-app: ${{ steps.set-matrix-app.outputs.matrix }}
+      matrix-test: ${{ steps.set-matrix-test.outputs.matrix }}
+      matrix-infra: ${{ steps.set-matrix-infra.outputs.matrix }}
+      matrix-tool: ${{ steps.set-matrix-tool.outputs.matrix }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: setup env
+        run: . ./hack/ci/setup-env.sh
+      - id: set-matrix-app
+        run: echo "::set-output ${APPS}"
+      - id: set-matrix-test
+        run: echo "::set-output ${TESTS}"
+      - id: set-matrix-infra
+        run: echo "::set-output ${INFRAS}"
+      - id: set-matrix-tool
+        run: echo "::set-output ${TOOLS}"
+
+  build-app:
+    name: Build ${{ matrix.APP }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
+      - run: make build-app-image-${{ matrix.APP }}
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - run: make push-app-image-${{ matrix.APP }}
+
+  build-tests:
+    name: Build ${{ matrix.TEST }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
+      - run: make build-test-image-${{ matrix.TEST }}
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - run: make push-test-image-${{ matrix.TEST }}
+
+  build-infra:
+    name: Build ${{ matrix.INFRA }}
+    runs-on: ubuntu-latest
+    if: ${{ needs.prepare-matrix.outputs.matrix-infra != '' && github.event.pull_request.draft == false }}
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
+      - run: make build-infra-image-${{ matrix.INFRA }}
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - run: make push-infra-image-${{ matrix.INFRA }}
 
   build-cli:
     name: Build Capact CLI
@@ -241,8 +241,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-#    needs: [ entry-tests, build-app, build-tests, build-cli ]
-    needs: [ build-cli ]
+    needs: [ entry-tests, build-app, build-tests, build-cli ]
     permissions:
       contents: read
 
@@ -268,29 +267,30 @@ jobs:
         run: |
           chmod +x $CAPACT_BINARY
           $CAPACT_BINARY version
-#      - name: Setup Go
-#        uses: actions/setup-go@v2
-#        with:
-#          go-version: ${{env.GO_VERSION}}
-#      - name: Run K8s Controller integration tests
-#        run: |
-#          make test-k8s-controller
-#      - name: Run cross-functional integration tests
-#        env:
-#          BUILD_IMAGES: "false"
-#          ARTIFACTS: "output/"
-#          DISABLE_MONITORING_INSTALLATION: "true"
-#          HUB_MANIFESTS_SOURCE_REPO_REF: "3be817d39c69aefec4b8860c69ba2f37afba7cc8"
-#        run: |
-#          make test-integration
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        if: ${{ always() }}
-#        with:
-#          name: cluster_dump_${{github.sha}}
-#          path: "output"
-#          retention-days: 5 # Default 90 days
-      # delete-artifact
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{env.GO_VERSION}}
+      - name: Run K8s Controller integration tests
+        run: |
+          make test-k8s-controller
+      - name: Run cross-functional integration tests
+        env:
+          BUILD_IMAGES: "false"
+          ARTIFACTS: "output/"
+          DISABLE_MONITORING_INSTALLATION: "true"
+          HUB_MANIFESTS_SOURCE_REPO_REF: "3be817d39c69aefec4b8860c69ba2f37afba7cc8"
+        run: |
+          make test-integration
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: cluster_dump_${{github.sha}}
+          path: "output"
+          retention-days: 5 # Default 90 days
+
+      # Delete Capact CLI
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: cli_${{github.sha}}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -241,7 +241,8 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [ entry-tests, build-app, build-tests ]
+#    needs: [ entry-tests, build-app, build-tests, build-cli ]
+    needs: [ build-cli ]
     permissions:
       contents: read
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -263,9 +263,11 @@ jobs:
       - name: Display structure
         run: ls -R
       - name: Display downloaded file
+        env:
+            CAPACT_BINARY: "${{ github.workspace}}/capact-linux-amd64"
         run: |
-          chmod +x ./capact
-          ./capact version
+          chmod +x $CAPACT_BINARY
+          $CAPACT_BINARY version
 #      - name: Setup Go
 #        uses: actions/setup-go@v2
 #        with:
@@ -288,3 +290,7 @@ jobs:
 #          name: cluster_dump_${{github.sha}}
 #          path: "output"
 #          retention-days: 5 # Default 90 days
+      # delete-artifact
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: cli_${{github.sha}}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -231,7 +231,8 @@ jobs:
         # We use a new `no_unique_dist_dir` feature, which is not yet released
         run: go install github.com/goreleaser/goreleaser@b53dbb89d02aa3673782f3d063d7d5039446baac
       - run: make build-tool-cli
-      - uses: actions/upload-artifact@v2
+      - name: Share Capact CLI for integration tests bootstrapping
+        uses: actions/upload-artifact@v2
         with:
           name: cli_${{github.sha}}
           path: ${{ github.workspace }}/bin/capact-linux-amd64
@@ -255,13 +256,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . ./hack/ci/setup-env.sh
-      - uses: actions/download-artifact@v2
+      - name: Download Capact CLI
+        uses: actions/download-artifact@v2
         with:
           name: cli_${{github.sha}}
           path: ${{ github.workspace }}
-      - name: Display structure
-        run: ls -R
-      - name: Display downloaded file
+      - name: Setup Capact CLI
         env:
             CAPACT_BINARY: "${{ github.workspace}}/capact-linux-amd64"
         run: |
@@ -289,8 +289,7 @@ jobs:
           name: cluster_dump_${{github.sha}}
           path: "output"
           retention-days: 5 # Default 90 days
-
-      # Delete Capact CLI
-      - uses: geekyeggo/delete-artifact@v1
+      - name: Delete Capact CLI artifact
+        uses: geekyeggo/delete-artifact@v1
         with:
           name: cli_${{github.sha}}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -33,177 +33,177 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.0
         with:
           access_token: ${{ github.token }}
-
-  entry-tests:
-    name: Lint and test code
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup environment
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          . ./hack/ci/setup-env.sh
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{env.GO_VERSION}}
-      - name: Run linting
-        run: |
-          make test-lint
-      - name: Run unit tests
-        run: make test-unit
-      - name: Check generated files
-        run: |
-          make test-generated
-
-  documentation-sanity:
-    name: Check documentation
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Run LanguageTool
-        uses: reviewdog/action-languagetool@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          level: info
-          custom_api_endpoint: ''
-          ### Flags for LanguageTool ###
-          # Ref: https://languagetool.org/http-api/swagger-ui/#!/default/post_check
-          language: 'en-US'
-          enabled_rules: ''
-          disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION'
-          enabled_categories: ''
-          disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
-          enabled_only: 'false'
-      - name: Run misspell check
-        uses: reviewdog/action-misspell@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          level: info
-          locale: "US"
-
-  prepare-matrix:
-    name: Prepare components build matrix
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    outputs:
-      matrix-app: ${{ steps.set-matrix-app.outputs.matrix }}
-      matrix-test: ${{ steps.set-matrix-test.outputs.matrix }}
-      matrix-infra: ${{ steps.set-matrix-infra.outputs.matrix }}
-      matrix-tool: ${{ steps.set-matrix-tool.outputs.matrix }}
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: setup env
-        run: . ./hack/ci/setup-env.sh
-      - id: set-matrix-app
-        run: echo "::set-output ${APPS}"
-      - id: set-matrix-test
-        run: echo "::set-output ${TESTS}"
-      - id: set-matrix-infra
-        run: echo "::set-output ${INFRAS}"
-      - id: set-matrix-tool
-        run: echo "::set-output ${TOOLS}"
-
-  build-app:
-    name: Build ${{ matrix.APP }}
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    needs: prepare-matrix
-    strategy:
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup environment
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          . ./hack/ci/setup-env.sh
-      - run: make build-app-image-${{ matrix.APP }}
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - run: make push-app-image-${{ matrix.APP }}
-
-  build-tests:
-    name: Build ${{ matrix.TEST }}
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    needs: prepare-matrix
-    strategy:
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup environment
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          . ./hack/ci/setup-env.sh
-      - run: make build-test-image-${{ matrix.TEST }}
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - run: make push-test-image-${{ matrix.TEST }}
-
-  build-infra:
-    name: Build ${{ matrix.INFRA }}
-    runs-on: ubuntu-latest
-    if: ${{ needs.prepare-matrix.outputs.matrix-infra != '' && github.event.pull_request.draft == false }}
-    needs: prepare-matrix
-    strategy:
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup environment
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          . ./hack/ci/setup-env.sh
-      - run: make build-infra-image-${{ matrix.INFRA }}
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - run: make push-infra-image-${{ matrix.INFRA }}
+#
+#  entry-tests:
+#    name: Lint and test code
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.draft == false
+#    permissions:
+#      contents: read
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: Setup environment
+#        env:
+#          PR_NUMBER: ${{ github.event.pull_request.number }}
+#        run: |
+#          . ./hack/ci/setup-env.sh
+#      - name: Setup Go
+#        uses: actions/setup-go@v2
+#        with:
+#          go-version: ${{env.GO_VERSION}}
+#      - name: Run linting
+#        run: |
+#          make test-lint
+#      - name: Run unit tests
+#        run: make test-unit
+#      - name: Check generated files
+#        run: |
+#          make test-generated
+#
+#  documentation-sanity:
+#    name: Check documentation
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.draft == false
+#    permissions:
+#      contents: read
+#      pull-requests: write
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: Run LanguageTool
+#        uses: reviewdog/action-languagetool@v1
+#        with:
+#          github_token: ${{ secrets.github_token }}
+#          reporter: github-pr-review
+#          level: info
+#          custom_api_endpoint: ''
+#          ### Flags for LanguageTool ###
+#          # Ref: https://languagetool.org/http-api/swagger-ui/#!/default/post_check
+#          language: 'en-US'
+#          enabled_rules: ''
+#          disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION'
+#          enabled_categories: ''
+#          disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
+#          enabled_only: 'false'
+#      - name: Run misspell check
+#        uses: reviewdog/action-misspell@v1
+#        with:
+#          github_token: ${{ secrets.github_token }}
+#          reporter: github-pr-review
+#          level: info
+#          locale: "US"
+#
+#  prepare-matrix:
+#    name: Prepare components build matrix
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.draft == false
+#    outputs:
+#      matrix-app: ${{ steps.set-matrix-app.outputs.matrix }}
+#      matrix-test: ${{ steps.set-matrix-test.outputs.matrix }}
+#      matrix-infra: ${{ steps.set-matrix-infra.outputs.matrix }}
+#      matrix-tool: ${{ steps.set-matrix-tool.outputs.matrix }}
+#    permissions:
+#      contents: read
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: setup env
+#        run: . ./hack/ci/setup-env.sh
+#      - id: set-matrix-app
+#        run: echo "::set-output ${APPS}"
+#      - id: set-matrix-test
+#        run: echo "::set-output ${TESTS}"
+#      - id: set-matrix-infra
+#        run: echo "::set-output ${INFRAS}"
+#      - id: set-matrix-tool
+#        run: echo "::set-output ${TOOLS}"
+#
+#  build-app:
+#    name: Build ${{ matrix.APP }}
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.draft == false
+#    needs: prepare-matrix
+#    strategy:
+#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
+#    permissions:
+#      contents: read
+#      packages: write
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: Setup environment
+#        env:
+#          PR_NUMBER: ${{ github.event.pull_request.number }}
+#        run: |
+#          . ./hack/ci/setup-env.sh
+#      - run: make build-app-image-${{ matrix.APP }}
+#      - name: Log into registry
+#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+#      - run: make push-app-image-${{ matrix.APP }}
+#
+#  build-tests:
+#    name: Build ${{ matrix.TEST }}
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.draft == false
+#    needs: prepare-matrix
+#    strategy:
+#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
+#    permissions:
+#      contents: read
+#      packages: write
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: Setup environment
+#        env:
+#          PR_NUMBER: ${{ github.event.pull_request.number }}
+#        run: |
+#          . ./hack/ci/setup-env.sh
+#      - run: make build-test-image-${{ matrix.TEST }}
+#      - name: Log into registry
+#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+#      - run: make push-test-image-${{ matrix.TEST }}
+#
+#  build-infra:
+#    name: Build ${{ matrix.INFRA }}
+#    runs-on: ubuntu-latest
+#    if: ${{ needs.prepare-matrix.outputs.matrix-infra != '' && github.event.pull_request.draft == false }}
+#    needs: prepare-matrix
+#    strategy:
+#      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
+#    permissions:
+#      contents: read
+#      packages: write
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: Setup environment
+#        env:
+#          PR_NUMBER: ${{ github.event.pull_request.number }}
+#        run: |
+#          . ./hack/ci/setup-env.sh
+#      - run: make build-infra-image-${{ matrix.INFRA }}
+#      - name: Log into registry
+#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+#      - run: make push-infra-image-${{ matrix.INFRA }}
 
   build-cli:
     name: Build Capact CLI
@@ -231,6 +231,11 @@ jobs:
         # We use a new `no_unique_dist_dir` feature, which is not yet released
         run: go install github.com/goreleaser/goreleaser@b53dbb89d02aa3673782f3d063d7d5039446baac
       - run: make build-tool-cli
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cli_${{github.sha}}
+          path: ${{ github.workspace }}/bin/capact-linux-amd64
+          retention-days: 1 # Default 90 days
 
   integration-tests:
     name: Integration tests
@@ -250,25 +255,35 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . ./hack/ci/setup-env.sh
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - uses: actions/download-artifact@v2
         with:
-          go-version: ${{env.GO_VERSION}}
-      - name: Run K8s Controller integration tests
+          name: cli_${{github.sha}}
+          path: ${{ github.workspace }}
+      - name: Display structure
+        run: ls -R
+      - name: Display downloaded file
         run: |
-          make test-k8s-controller
-      - name: Run cross-functional integration tests
-        env:
-          BUILD_IMAGES: "false"
-          ARTIFACTS: "output/"
-          DISABLE_MONITORING_INSTALLATION: "true"
-          HUB_MANIFESTS_SOURCE_REPO_REF: "3be817d39c69aefec4b8860c69ba2f37afba7cc8"
-        run: |
-          make test-integration
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: cluster_dump_${{github.sha}}
-          path: "output"
-          retention-days: 5 # Default 90 days
+          chmod +x ./capact
+          ./capact version
+#      - name: Setup Go
+#        uses: actions/setup-go@v2
+#        with:
+#          go-version: ${{env.GO_VERSION}}
+#      - name: Run K8s Controller integration tests
+#        run: |
+#          make test-k8s-controller
+#      - name: Run cross-functional integration tests
+#        env:
+#          BUILD_IMAGES: "false"
+#          ARTIFACTS: "output/"
+#          DISABLE_MONITORING_INSTALLATION: "true"
+#          HUB_MANIFESTS_SOURCE_REPO_REF: "3be817d39c69aefec4b8860c69ba2f37afba7cc8"
+#        run: |
+#          make test-integration
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        if: ${{ always() }}
+#        with:
+#          name: cluster_dump_${{github.sha}}
+#          path: "output"
+#          retention-days: 5 # Default 90 days

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -228,8 +228,7 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Set up GoReleaser
-        # We use a new `no_unique_dist_dir` feature, which is not yet released
-        run: go install github.com/goreleaser/goreleaser@b53dbb89d02aa3673782f3d063d7d5039446baac
+        run: go install github.com/goreleaser/goreleaser@v0.173.2
       - run: make build-tool-cli
       - name: Share Capact CLI for integration tests bootstrapping
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,7 @@
 name: PR build
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Share Capact CLI between GH Action steps


We use the `pull_request_target` event, so the `workflow` files are taken from the `main` branch, so my changes are not taken into account.

I tested that on my fork, see: https://github.com/mszostok/capact/runs/3076727952

## Related issue(s)

 - https://github.com/capactio/capact/issues/328 
