### PR TITLE
Replace deprecated `go get` with `go install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/$COMPONENT /app.test
 
 RUN apk add --no-cache 'git=>2.30' && \
-    go get github.com/onsi/ginkgo/ginkgo
+    go install github.com/onsi/ginkgo/ginkgo@latest
 
 LABEL source=git@github.com:capactio/capact.git
 LABEL app=$COMPONENT

--- a/hack/gen-graphql-resources.sh
+++ b/hack/gen-graphql-resources.sh
@@ -39,7 +39,7 @@ host::install::gqlgen() {
   pushd "$TMP_DIR" >/dev/null
 
   go mod init tmp
-  go get github.com/99designs/gqlgen@$STABLE_GQLGEN_VERSION
+  go install github.com/99designs/gqlgen@$STABLE_GQLGEN_VERSION
 
   popd >/dev/null
 

--- a/hack/gen-k8s-resources.sh
+++ b/hack/gen-k8s-resources.sh
@@ -42,7 +42,7 @@ host::install::controller-gen() {
     pushd "$TMP_DIR" >/dev/null
 
     go mod init tmp
-    go get sigs.k8s.io/controller-tools/cmd/controller-gen@$STABLE_CONTROLLER_GEN_VERSION
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@$STABLE_CONTROLLER_GEN_VERSION
 
     popd >/dev/null
 


### PR DESCRIPTION
Source: https://golang.org/doc/go-get-install-deprecation

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Replace deprecated `go get` with `go install`

Source: https://golang.org/doc/go-get-install-deprecation

