### PR TITLE
Add support for hub-manifest ref update, update ref to latest ver

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -278,7 +278,6 @@ jobs:
           BUILD_IMAGES: "false"
           ARTIFACTS: "output/"
           DISABLE_MONITORING_INSTALLATION: "true"
-          HUB_MANIFESTS_SOURCE_REPO_REF: "3be817d39c69aefec4b8860c69ba2f37afba7cc8"
         run: |
           make test-integration
       - name: Upload artifacts

--- a/deploy/kubernetes/charts/capact/charts/hub-public/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/capact/charts/hub-public/templates/_helpers.tpl
@@ -67,5 +67,7 @@ Create the manifest source path
 {{- define "populator.manifestPath" -}}
 {{- .Values.populator.manifestsLocation.repository -}}
 ?ref={{ .Values.populator.manifestsLocation.branch -}}
+{{- if .Values.populator.manifestsLocation.sshKey -}}
 &sshkey={{ .Values.populator.manifestsLocation.sshKey -}}
+{{- end }}
 {{- end }}

--- a/deploy/kubernetes/charts/capact/charts/hub-public/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/hub-public/values.yaml
@@ -65,8 +65,9 @@ populator:
   port: 8081
   updateOnGitCommit: true
   manifestsLocation:
-    repository: git@github.com:capactio/hub-manifests.git
-    # sshKey is a base64 encoded private key used by populator to download manifests. It has read only access
-    sshKey: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNEUXhvRUVSTUx0K2E2Ym9yUXdhTTJuak4vL2hqMDZSQTMyRDBuVmlNSnEzd0FBQUpnd2ZrS1hNSDVDCmx3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDRFF4b0VFUk1MdCthNmJvclF3YU0ybmpOLy9oajA2UkEzMkQwblZpTUpxM3cKQUFBRUIybEFhUDVzNG9qRWw0UzlTSU5xbTk0YU1OaXdZWWhpdTJtaHpqS3hUVmE5REdnUVJFd3UzNXJwdWl0REJvemFlTQozLytHUFRwRURmWVBTZFdJd21yZkFBQUFFblJsWVcwdFpHVjJRR05oY0dGamRDNXBid0VDQXc9PQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K
+    # It's public repository
+    repository: github.com/capactio/hub-manifests
     branch: main
+    # sshKey is a base64 encoded private key used by populator to download manifests. It has read only access
+    #sshKey:
   args: ["while true; do /app register ocf-manifests $MANIFESTS_PATH; sleep 600;done"]

--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -46,3 +46,5 @@ readonly CAPACT_USE_TEST_SETUP="false"
 #
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
+readonly HUB_MANIFESTS_SOURCE_REPO_URL="git@github.com:capactio/hub-manifests.git"
+readonly HUB_MANIFESTS_SOURCE_REPO_REF="5464edbf0b3f5ef2d1a02c6266dfc50fb5ac0a4a"

--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -46,5 +46,5 @@ readonly CAPACT_USE_TEST_SETUP="false"
 #
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
-readonly HUB_MANIFESTS_SOURCE_REPO_URL="git@github.com:capactio/hub-manifests.git"
-readonly HUB_MANIFESTS_SOURCE_REPO_REF="5464edbf0b3f5ef2d1a02c6266dfc50fb5ac0a4a"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/capactio/hub-manifests"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="5464edbf0b3f5ef2d1a02c6266dfc50fb5ac0a4a"

--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -47,4 +47,6 @@ readonly CAPACT_USE_TEST_SETUP="false"
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
 readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/capactio/hub-manifests"
+# The git ref to checkout. It can point to a commit SHA, a branch name, or a tag.
+# If you want to use your forked version, remember to update CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL  respectively.
 readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="5464edbf0b3f5ef2d1a02c6266dfc50fb5ac0a4a"

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -182,6 +182,7 @@ capact::delete_cluster() {
 #  - USE_TEST_SETUP - if set to true, then a test policy is configured
 #  - INCREASE_RESOURCE_LIMITS - if set to true, then the components will use higher resource requests and limits
 #  - HUB_MANIFESTS_SOURCE_REPO_REF - set this to override the Git branch from which the source manifests are populated
+#  - HUB_MANIFESTS_SOURCE_REPO_URL - set this to override the Git URL from which the source manifests are populated
 #  - ENABLE_HOSTS_UPDATE - if set to true, /etc/hosts is updated
 #  - ENABLE_ADDING_TRUSTED_CERT - if set to true, add Capact self-signed TLS certificate as trusted
 capact::install() {
@@ -193,6 +194,8 @@ capact::install() {
     export PRINT_INSECURE_NOTES=${PRINT_INSECURE_NOTES:-"false"}
     export ENABLE_HOSTS_UPDATE=${ENABLE_HOSTS_UPDATE:-"true"}
     export ENABLE_ADDING_TRUSTED_CERT=${ENABLE_ADDING_TRUSTED_CERT:-"true"}
+    export HUB_MANIFESTS_SOURCE_REPO_REF=${HUB_MANIFESTS_SOURCE_REPO_REF:-${CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF}}
+    export HUB_MANIFESTS_SOURCE_REPO_URL=${HUB_MANIFESTS_SOURCE_REPO_URL:-${CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL}}
     export COMPONENTS="neo4j,ingress-nginx,argo,cert-manager,capact"
     export CAPACT_OVERRIDES=${CAPACT_OVERRIDES:=""}
 

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -218,6 +218,10 @@ capact::install() {
       CAPACT_OVERRIDES+=",hub-public.populator.manifestsLocation.branch=${HUB_MANIFESTS_SOURCE_REPO_REF}"
     fi
 
+    if [ -n "${HUB_MANIFESTS_SOURCE_REPO_URL:-}" ]; then
+      CAPACT_OVERRIDES+=",hub-public.populator.manifestsLocation.repository=${HUB_MANIFESTS_SOURCE_REPO_URL}"
+    fi
+
     if [[ "${BUILD_IMAGES:-"true"}" == "false" ]]; then
       BUILD_IMAGES_FLAG=--build-image=""
     fi


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Unfortunately, we cannot update HUB_MANIFESTS_SOURCE_REPO_REF as CI manifests are taken from main. Additionally, we use forks, so we are not able to test content from PRs only by changing commit SHA. This PR fixes this problem by allowing to override both `repo url` and `ref`.

## Description

Changes proposed in this pull request:

- Add support for hub-manifest ref update, 
- Update hub-manifests ref to the latest version,
- Support optional sshKey. Currently, we do not need to have sshkey as hub-manifests repo is open-sourced.

# Testing

To test that optional the `sshKey` param works properly, run such commands:

```bash
# Test with `sshKey`
helm template --set hub-public.populator.manifestsLocation.sshKey='test' ./deploy/kubernetes/charts/capact | grep -m 1 -A 1 MANIFESTS_PATH

# Test without `sshKey`
helm template ./deploy/kubernetes/charts/capact | grep -m 1 -A 1 MANIFESTS_PATH
```

## Related issue(s)

- https://github.com/capactio/capact/issues/399