### PR TITLE
Remove the ClusterRoleBinding, fix get query for ClusterRoleBinding

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -242,7 +242,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [ entry-tests, build-app, build-tests, build-cli ]
+    needs: [ build-app, build-tests, build-cli ]
     permissions:
       contents: read
     env:

--- a/deploy/kubernetes/charts/capact/charts/engine/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/capact/charts/engine/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+          # image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+          # Use PR image
+          image: "ghcr.io/capactio/pr/k8s-engine:PR-424"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: APP_GRAPH_QL_ADDR

--- a/deploy/kubernetes/charts/capact/templates/tests/test-e2e.yaml
+++ b/deploy/kubernetes/charts/capact/templates/tests/test-e2e.yaml
@@ -10,7 +10,9 @@ spec:
   serviceAccountName: "{{ include "capact.fullname" . }}-test-e2e"
   containers:
     - name: tests-runner
-      image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.integrationTest.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+      # image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.integrationTest.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+      # Use PR image
+      image: "ghcr.io/capactio/pr/e2e-test:PR-424"
       env:
         - name: STATUS_ENDPOINTS
           value: "http://capact-engine-graphql.{{.Release.Namespace}}.svc.cluster.local/healthz,http://capact-gateway.{{.Release.Namespace}}.svc.cluster.local/healthz,http://capact-hub-local.{{.Release.Namespace}}.svc.cluster.local/healthz,http://capact-hub-public.{{.Release.Namespace}}.svc.cluster.local/healthz"

--- a/internal/k8s-engine/controller/action_controller.go
+++ b/internal/k8s-engine/controller/action_controller.go
@@ -1,10 +1,11 @@
 package controller
 
 import (
-	"capact.io/capact/internal/ptr"
-	"capact.io/capact/pkg/engine/k8s/api/v1alpha1"
 	"context"
 	"fmt"
+
+	"capact.io/capact/internal/ptr"
+	"capact.io/capact/pkg/engine/k8s/api/v1alpha1"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"

--- a/internal/k8s-engine/controller/action_service.go
+++ b/internal/k8s-engine/controller/action_service.go
@@ -5,30 +5,30 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
-	policypkg "capact.io/capact/internal/k8s-engine/policy"
-
-	"go.uber.org/zap"
-
-	"capact.io/capact/pkg/engine/k8s/policy"
-
 	graphqldomain "capact.io/capact/internal/k8s-engine/graphql/domain/action"
+	policypkg "capact.io/capact/internal/k8s-engine/policy"
 	statusreporter "capact.io/capact/internal/k8s-engine/status-reporter"
 	"capact.io/capact/internal/ptr"
 	"capact.io/capact/pkg/engine/k8s/api/v1alpha1"
+	"capact.io/capact/pkg/engine/k8s/policy"
 	hublocalapi "capact.io/capact/pkg/hub/api/graphql/local"
 	hubpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	"capact.io/capact/pkg/runner"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"capact.io/capact/pkg/sdk/renderer/argo"
+
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -150,7 +150,7 @@ func (a *ActionService) EnsureWorkflowSAExists(ctx context.Context, action *v1al
 	case err == nil:
 	case apierrors.IsAlreadyExists(err):
 		old := &rbacv1.ClusterRoleBinding{}
-		key := client.ObjectKey{Name: binding.Name, Namespace: binding.Namespace}
+		key := client.ObjectKey{Name: binding.Name}
 		if err := a.k8sCli.Get(ctx, key, old); err != nil {
 			return nil, err
 		}
@@ -168,6 +168,72 @@ func (a *ActionService) EnsureWorkflowSAExists(ctx context.Context, action *v1al
 	}
 
 	return sa, nil
+}
+
+func (a *ActionService) CleanupActionOwnedResources(ctx context.Context, action *v1alpha1.Action) (ignored bool, err error) {
+	ignored = true
+	if !controllerutil.ContainsFinalizer(action, v1alpha1.ActionFinalizer) {
+		return ignored, nil // our finalizer was already removed
+	}
+
+	if action.IsExecuted() {
+		// Current decision:
+		a.log.Info("Ignoring delete request. Wait until Action execution will be finished.", zap.String("phase", string(action.Status.Phase)))
+
+		// Deletion in this state is complicated as such Action can be in the middle of e.g. data migration, system shutdown,
+		// creating resources on hyperscaler side, etc.
+		// In the future we can revisit this approach based on user feedback and e.g. cancel running actions, maybe even rollback
+		// already executed steps, etc.
+		return ignored, nil
+	}
+
+	// ===== Execute clean-up logic
+	ignored = false
+
+	// 1. Ensure that TypeInstances are unlocked.
+	err = a.UnlockTypeInstances(ctx, action)
+	if a.ignoreNotActionableTypeInstanceErrors(err) != nil {
+		return ignored, errors.Wrap(err, "while unlocking TypeInstances")
+	}
+
+	// 2. Ensure ClusterRoleBinding deleted
+	// We use ownerReference for created resources. But the cluster-scoped resources cannot have namespace-scoped owners.
+	// As a result, we need to remove it manually.
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: a.objectMetaFromAction(action),
+	}
+	if err := a.k8sCli.Delete(ctx, binding); client.IgnoreNotFound(err) != nil {
+		return ignored, errors.Wrapf(err, "while deleting ClusterRoleBinding owned by %s/%s Action", action.GetName(), action.GetNamespace())
+	}
+
+	// 3. Remove finalizer
+	controllerutil.RemoveFinalizer(action, v1alpha1.ActionFinalizer)
+	if err := a.k8sCli.Update(ctx, action); err != nil {
+		return ignored, errors.Wrap(err, "while removing Action finalizer")
+	}
+
+	return ignored, nil
+}
+
+// ignoreNotActionableTypeInstanceErrors ignores GraphQL error which says that TI are locked by different owner or do not exist.
+// In our case it means that TI were already unlocked by a given Action and someone else locked them or deleted.
+//
+// TODO: Get rid of ridiculous string assertion after adding proper error types to GraphQL responses.
+//       http://knowyourmeme.com/memes/this-is-fine
+func (a *ActionService) ignoreNotActionableTypeInstanceErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if strings.Contains(err.Error(), "locked by different owner") {
+		return nil
+	}
+
+	if strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+
+	return err
 }
 
 // EnsureRunnerInputDataCreated ensures that Kubernetes Secret with input data for a runner is created and up to date.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Before reviewing, read this comment: https://github.com/capactio/capact/issues/420#issuecomment-891718145

Changes proposed in this pull request: 

- Remove the `ClusterRoleBinding`, fix get query for `ClusterRoleBinding`
- Ignore evicted Pods
- Run integration tests without waiting for entry-tests. Currently, we wait ~8min for entry-tests before running e2e tests. IMO it's useless as the e2e test can be started in parallel, in that way we will reduce time to merge in happy path scenarios.

## Related issue(s)

- Fix https://github.com/capactio/capact/issues/420

