### PR TITLE
Add helper image `merger` to merge yaml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: generate build-all-images test-unit test-lint ## Default: generate all, bui
 
 APPS = gateway k8s-engine hub-js argo-runner helm-runner cloudsql-runner populator terraform-runner argo-actions
 TESTS = e2e
-INFRA = json-go-gen graphql-schema-linter jinja2
+INFRA = json-go-gen graphql-schema-linter jinja2 merger
 
 build-all-tools: ## Builds the standalone binaries for all tools
 	goreleaser build --rm-dist --skip-post-hooks --snapshot --single-target

--- a/hack/ci/setup-env.sh
+++ b/hack/ci/setup-env.sh
@@ -38,5 +38,5 @@ fi
 cat <<EOT >>"$GITHUB_ENV"
 APPS=name=matrix::{"include":[{"APP":"gateway"},{"APP":"k8s-engine"},{"APP":"hub-js"},{"APP":"argo-runner"},{"APP":"helm-runner"},{"APP":"populator"},{"APP":"terraform-runner"},{"APP":"argo-actions"}]}
 TESTS=name=matrix::{"include":[{"TEST":"e2e"}]}
-INFRAS=name=matrix::{"include":[{"INFRA":"json-go-gen"},{"INFRA":"graphql-schema-linter"},{"INFRA":"jinja2"}]}
+INFRAS=name=matrix::{"include":[{"INFRA":"json-go-gen"},{"INFRA":"graphql-schema-linter"},{"INFRA":"jinja2"},{"INFRA":"merger"}]}
 EOT

--- a/hack/images/README.md
+++ b/hack/images/README.md
@@ -14,5 +14,5 @@ The structure of the folder looks as follows:
   ├── jinja2                 # Image containing a containerized jinja CLI tool assisting with rendering templatized OCF content
   ├── json-go-gen            # The image that contains quicktype to generates Go struct from JSON Schemas
   ├── graphql-schema-linter  # The image that contains graphql-schema-linter to lint GraphQL files
-  └── merger                 # The image that contains yaml merger helper scriptyaml merger helper script
+  └── merger                 # The image that contains YAML merger helper
 ```

--- a/hack/images/README.md
+++ b/hack/images/README.md
@@ -13,5 +13,6 @@ The structure of the folder looks as follows:
 ```
   ├── jinja2                 # Image containing a containerized jinja CLI tool assisting with rendering templatized OCF content
   ├── json-go-gen            # The image that contains quicktype to generates Go struct from JSON Schemas
-  └── graphql-schema-linter  # The image that contains graphql-schema-linter to lint GraphQL files
+  ├── graphql-schema-linter  # The image that contains graphql-schema-linter to lint GraphQL files
+  └── merger                 # The image that contains yaml merger helper scriptyaml merger helper script
 ```

--- a/hack/images/merger/Dockerfile
+++ b/hack/images/merger/Dockerfile
@@ -1,0 +1,10 @@
+FROM mikefarah/yq:4.11.2
+
+WORKDIR /yamls
+USER root
+
+RUN apk add --no-cache "bash=>5.1.0"
+
+COPY merger.sh /
+
+ENTRYPOINT ["/merger.sh"]

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -21,5 +21,5 @@ You can configure the merger script passing the following environment variables:
 
 | Variable                  | Default      | Description                                      |
 | ------------------------- | ------------ | ------------------------------------------------ |
-| SRC                       | /yamls       | Path to the directory with yaml files.           |
-| OUT                       | /merged.yaml | Output file with prefixed and merged yaml files. |
+| SRC                       | /yamls       | Path to the directory with YAML files.           |
+| OUT                       | /merged.yaml | Output file with prefixed and merged YAML files. |

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -4,7 +4,7 @@
 
 This folder contains the Docker image which merges multiple input YAML files into a single one.
 
-The Docker image consists a helper script, `merger.sh`. The script is an entrypoint of the image, and it is used to prefix and merge all yaml files found in `$SRC` directory.
+The Docker image contains the `merger.sh` helper script. The script is an entrypoint of the image, and it is used to prefix and merge all YAML files found in `$SRC` directory.
 Each file is prefixed with a file name without extension.
 
 ## Installation

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This folder contains Docker image with a helper for merging input parameters in manifests.
+This folder contains the Docker image which merges multiple input YAML files into a single one.
 
 The Docker image consists a helper script, `merger.sh`. The script is an entrypoint of the image, and it is used to prefix and merge all yaml files found in `$SRC` directory.
 Each file is prefixed with a file name without extension.

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -17,7 +17,7 @@ docker build -t merger .
 
 ## Configuration
 
-You can configure the merger script passing the following environment variables:
+You can configure the merger script by passing the following environment variables:
 
 | Variable                  | Default      | Description                                      |
 | ------------------------- | ------------ | ------------------------------------------------ |

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -1,4 +1,4 @@
-# inputs-merger
+# merger
 
 ## Overview
 

--- a/hack/images/merger/README.md
+++ b/hack/images/merger/README.md
@@ -1,0 +1,25 @@
+# inputs-merger
+
+## Overview
+
+This folder contains Docker image with a helper for merging input parameters in manifests.
+
+The Docker image consists a helper script, `merger.sh`. The script is an entrypoint of the image, and it is used to prefix and merge all yaml files found in `$SRC` directory.
+Each file is prefixed with a file name without extension.
+
+## Installation
+
+To build the Docker image, run this command:
+
+```bash
+docker build -t merger .
+```
+
+## Configuration
+
+You can configure the merger script passing the following environment variables:
+
+| Variable                  | Default      | Description                                      |
+| ------------------------- | ------------ | ------------------------------------------------ |
+| SRC                       | /yamls       | Path to the directory with yaml files.           |
+| OUT                       | /merged.yaml | Output file with prefixed and merged yaml files. |

--- a/hack/images/merger/merger.sh
+++ b/hack/images/merger/merger.sh
@@ -4,7 +4,7 @@ SRC=${SRC:-"/yamls"}
 OUT=${OUT:-"/merged.yaml"}
 
 # prefix each file with its filename
-for filename in "${SRC}"/*.yaml; do
+for filename in "${SRC}"/*; do
   filename=$(basename -- "$filename")
   prefix="${filename%.*}"
   yq e -i "{\"${prefix}\": . }" "${SRC}"/"${filename}"

--- a/hack/images/merger/merger.sh
+++ b/hack/images/merger/merger.sh
@@ -4,11 +4,12 @@ SRC=${SRC:-"/yamls"}
 OUT=${OUT:-"/merged.yaml"}
 
 # prefix each file with its filename
-for filename in ${SRC}/*.yaml; do
+for filename in "${SRC}"/*.yaml; do
   filename=$(basename -- "$filename")
   prefix="${filename%.*}"
-  yq e -i "{\"${prefix}\": . }" ${SRC}/${filename}
+  yq e -i "{\"${prefix}\": . }" "${SRC}"/"${filename}"
 done
 
 # merge all yaml files into one
-yq ea '. as $item ireduce ({}; . * $item )' ${SRC}/*.yaml >${OUT}
+# shellcheck disable=SC2016
+yq ea '. as $item ireduce ({}; . * $item )' "${SRC}"/*.yaml >"${OUT}"

--- a/hack/images/merger/merger.sh
+++ b/hack/images/merger/merger.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SRC=${SRC:-"/yamls"}
+OUT=${OUT:-"/merged.yaml"}
+
+# prefix each file with its filename
+for filename in ${SRC}/*.yaml; do
+  filename=$(basename -- "$filename")
+  prefix="${filename%.*}"
+  yq e -i "{\"${prefix}\": . }" ${SRC}/${filename}
+done
+
+# merge all yaml files into one
+yq ea '. as $item ireduce ({}; . * $item )' ${SRC}/*.yaml >${OUT}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add helper image `merger` to merge yaml files

## Testing

Build image
```shell
docker build -t merger .
```

Create few yaml files:

`input.yaml`:
```yaml
a: 1
```

`additional:yaml`:
```yaml
b: 2
```

`extra.yaml`:
```yaml
c: 3
```

Run merger
```bash
docker run --mount src=`pwd`,target=/yamls,type=bind -e OUT=/yamls/all.yaml merger
```

Check the output file:
`all.yaml`
```yaml
input:
  a: 1
additional:
  b: 2
extra:
  c: 3
```
## Related issue(s)

#419 
