### PR TITLE
Allow running PR builds from untrusted contributors

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -168,6 +168,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Download artifact

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.APP }}-${{ github.event.pull_request.number }}
+          name: ${{ matrix.APP }}-${{github.sha}}
           path: /tmp/${{ matrix.APP }}.tar
           retention-days: 5
 
@@ -171,10 +171,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.APP }}-${{ github.event.pull_request.number }}
+          name: ${{ matrix.APP }}-${{github.sha}}
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/${{ matrix.APP }}.tar
@@ -208,7 +210,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: test-${{ matrix.TEST }}-${{ github.event.pull_request.number }}
+          name: test-${{ matrix.TEST }}-${{github.sha}}
           path: /tmp/${{ matrix.TEST }}-test.tar
           retention-days: 1
 
@@ -225,10 +227,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.TEST }}-${{ github.event.pull_request.number }}
+          name: test-${{ matrix.TEST }}-${{github.sha}}
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/${{ matrix.TEST }}-test.tar
@@ -257,12 +261,12 @@ jobs:
           . ./hack/ci/setup-env.sh
       - run: |
           make build-infra-image-${{ matrix.INFRA }}
-          make save-test-image-${{ matrix.APP }}
+          make save-infra-image-${{ matrix.INFRA }}
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: infra-${{ matrix.APP }}-${{ github.event.pull_request.number }}
-          path: /tmp/infra-${{ matrix.APP }}.tar
+          name: infra-${{ matrix.INFRA }}-${{github.sha}}
+          path: /tmp/infra-${{ matrix.INFRA }}.tar
           retention-days: 1
 
   push-infra:
@@ -278,10 +282,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.INFRA }}-${{ github.event.pull_request.number }}
+          name: infra-${{ matrix.INFRA }}-${{github.sha}}
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/infra-${{ matrix.INFRA }}.tar

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,7 @@
 name: PR build
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -188,6 +188,10 @@ jobs:
         run: |
           . ./hack/ci/setup-env.sh
       - run: make push-app-image-${{ matrix.APP }}
+      - name: Delete Docker image artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ matrix.APP }}-${{github.sha}}
 
   build-tests:
     name: Build ${{ matrix.TEST }}
@@ -249,6 +253,10 @@ jobs:
         run: |
           . ./hack/ci/setup-env.sh
       - run: make push-test-image-${{ matrix.TEST }}
+      - name: Delete Docker image artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: test-${{ matrix.TEST }}-${{github.sha}}
 
   build-infra:
     name: Build ${{ matrix.INFRA }}
@@ -309,6 +317,10 @@ jobs:
         run: |
           . ./hack/ci/setup-env.sh
       - run: make push-infra-image-${{ matrix.INFRA }}
+      - name: Delete Docker image artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: infra-${{ matrix.INFRA }}-${{github.sha}}
 
   build-cli:
     name: Build Capact CLI

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -156,7 +156,7 @@ jobs:
         with:
           name: ${{ matrix.APP }}-${{github.sha}}
           path: /tmp/${{ matrix.APP }}.tar
-          retention-days: 5
+          retention-days: 1
 
   push-apps:
     name: Push ${{ matrix.APP }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.APP }}-${{ github.event.pull_request.number }}
-          path: /tmp/${{ matrix.APP }}.tar
+          path: /tmp
       - name: Load image
         run: docker load --input /tmp/${{ matrix.APP }}.tar
       - name: Log into registry
@@ -191,7 +191,6 @@ jobs:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout code
@@ -203,7 +202,36 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . ./hack/ci/setup-env.sh
-      - run: make build-test-image-${{ matrix.TEST }}
+      - run: |
+          make build-test-image-${{ matrix.TEST }}
+          make save-test-image-${{ matrix.TEST }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-${{ matrix.TEST }}-${{ github.event.pull_request.number }}
+          path: /tmp/${{ matrix.TEST }}-test.tar
+          retention-days: 1
+
+  push-test:
+    name: Push ${{ matrix.TEST }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: [prepare-matrix, build-test]
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.TEST }}-${{ github.event.pull_request.number }}
+          path: /tmp
+      - name: Load image
+        run: docker load --input /tmp/${{ matrix.TEST }}-test.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - run: make push-test-image-${{ matrix.TEST }}
@@ -217,8 +245,6 @@ jobs:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
     permissions:
       contents: read
-      packages: write
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -229,7 +255,36 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . ./hack/ci/setup-env.sh
-      - run: make build-infra-image-${{ matrix.INFRA }}
+      - run: |
+          make build-infra-image-${{ matrix.INFRA }}
+          make save-test-image-${{ matrix.APP }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: infra-${{ matrix.APP }}-${{ github.event.pull_request.number }}
+          path: /tmp/infra-${{ matrix.APP }}.tar
+          retention-days: 1
+
+  push-infra:
+    name: Push ${{ matrix.INFRA }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: [prepare-matrix, build-infra]
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-infra)}}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.INFRA }}-${{ github.event.pull_request.number }}
+          path: /tmp
+      - name: Load image
+        run: docker load --input /tmp/infra-${{ matrix.INFRA }}.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - run: make push-infra-image-${{ matrix.INFRA }}
@@ -270,7 +325,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [ build-app, build-tests, build-cli ]
+    needs: [ push-app, push-tests, build-cli ]
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -128,7 +128,7 @@ jobs:
       - id: set-matrix-tool
         run: echo "::set-output ${TOOLS}"
 
-  build-app:
+  build-apps:
     name: Build ${{ matrix.APP }}
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
@@ -158,11 +158,11 @@ jobs:
           path: /tmp/${{ matrix.APP }}.tar
           retention-days: 5
 
-  push-app:
+  push-apps:
     name: Push ${{ matrix.APP }}
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [prepare-matrix, build-app]
+    needs: [prepare-matrix, build-apps]
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
     permissions:
@@ -212,11 +212,11 @@ jobs:
           path: /tmp/${{ matrix.TEST }}-test.tar
           retention-days: 1
 
-  push-test:
+  push-tests:
     name: Push ${{ matrix.TEST }}
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [prepare-matrix, build-test]
+    needs: [prepare-matrix, build-tests]
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-test)}}
     permissions:
@@ -325,7 +325,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [ push-app, push-tests, build-cli ]
+    needs: [ push-apps, push-tests, build-cli ]
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -159,10 +159,10 @@ jobs:
           retention-days: 5
 
   push-app:
-    name: Build ${{ matrix.APP }}
+    name: Push ${{ matrix.APP }}
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: prepare-matrix
+    needs: [prepare-matrix, build-app]
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
     permissions:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,7 @@
 name: PR build
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"
@@ -137,7 +137,6 @@ jobs:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout code
@@ -149,7 +148,35 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . ./hack/ci/setup-env.sh
-      - run: make build-app-image-${{ matrix.APP }}
+      - run: |
+          make build-app-image-${{ matrix.APP }}
+          make save-app-image-${{ matrix.APP }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.APP }}-${{ github.event.pull_request.number }}
+          path: /tmp/${{ matrix.APP }}.tar
+          retention-days: 5
+
+  push-app:
+    name: Build ${{ matrix.APP }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix-app)}}
+    permissions:
+      contents: read
+      packages: write
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.APP }}-${{ github.event.pull_request.number }}
+          path: /tmp/${{ matrix.APP }}.tar
+      - name: Load image
+        run: docker load --input /tmp/${{ matrix.APP }}.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - run: make push-app-image-${{ matrix.APP }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,7 @@
 name: PR build
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -182,6 +182,11 @@ jobs:
         run: docker load --input /tmp/${{ matrix.APP }}.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
       - run: make push-app-image-${{ matrix.APP }}
 
   build-tests:
@@ -238,6 +243,11 @@ jobs:
         run: docker load --input /tmp/${{ matrix.TEST }}-test.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
       - run: make push-test-image-${{ matrix.TEST }}
 
   build-infra:
@@ -293,6 +303,11 @@ jobs:
         run: docker load --input /tmp/infra-${{ matrix.INFRA }}.tar
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Setup environment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          . ./hack/ci/setup-env.sh
       - run: make push-infra-image-${{ matrix.INFRA }}
 
   build-cli:

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ build-test-image-%:
 		--build-arg BUILD_CMD="go test -v -c" \
 		--build-arg SOURCE_PATH="./test/$(APP)/*_test.go" \
 		-t $(DOCKER_REPOSITORY)/$(APP)-test:$(DOCKER_TAG) .
-.PHONY: build-test-image
 
 push-test-image-%:
 	$(eval APP := $*)

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,14 @@ build-app-image-terraform-runner: ## Build application image for terraform runne
 build-app-image-%:
 	$(eval APP := $*)
 	docker build --build-arg COMPONENT=$(APP) --target generic -t $(DOCKER_REPOSITORY)/$(APP):$(DOCKER_TAG) .
-.PHONY: build-app-image-%
 
 push-app-image-%:
 	$(eval APP := $*)
 	docker push $(DOCKER_REPOSITORY)/$(APP):$(DOCKER_TAG)
-.PHONY: push-apps-images-%
+
+save-app-image-%:
+	$(eval APP := $*)
+	docker save $(DOCKER_REPOSITORY)/$(APP):$(DOCKER_TAG) > /tmp/$(APP).tar
 
 # Test images
 build-test-image-e2e:
@@ -91,7 +93,10 @@ build-test-image-%:
 push-test-image-%:
 	$(eval APP := $*)
 	docker push $(DOCKER_REPOSITORY)/$(APP)-test:$(DOCKER_TAG)
-.PHONY: push-test-image
+
+save-test-image-%:
+	$(eval APP := $*)
+	docker save $(DOCKER_REPOSITORY)/$(APP)-test:$(DOCKER_TAG) > /tmp/$(APP)-test.tar
 
 # Infra images
 INFRA_IMAGES_DIR = ./hack/images
@@ -105,6 +110,10 @@ push-infra-image-%:
 	$(eval APP := $*)
 	docker push $(DOCKER_REPOSITORY)/infra/$(APP):$(DOCKER_TAG)
 .PHONY: push-infra-image
+
+save-infra-image-%:
+	$(eval APP := $*)
+	docker save $(DOCKER_REPOSITORY)/infra/$(APP):$(DOCKER_TAG) > /tmp/infra-$(APP).tar
 
 ###########
 # Testing #

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,10 @@ INFRA_IMAGES_DIR = ./hack/images
 build-infra-image-%:
 	$(eval APP := $*)
 	docker build -t $(DOCKER_REPOSITORY)/infra/$(APP):$(DOCKER_TAG) -f $(INFRA_IMAGES_DIR)/$(APP)/Dockerfile $(INFRA_IMAGES_DIR)/$(APP)
-.PHONY: build-infra-image
 
 push-infra-image-%:
 	$(eval APP := $*)
 	docker push $(DOCKER_REPOSITORY)/infra/$(APP):$(DOCKER_TAG)
-.PHONY: push-infra-image
 
 save-infra-image-%:
 	$(eval APP := $*)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- split build and pushing images for apps, tests and infra to two separate jobs:
  - build job has only read permissions
  - push job has write permissions, but uses the scripts from main
- add Make target to export images a tarballs
- remove some `.PHONY` targets as they don't work with pattern rules

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
