### PR TITLE
Add option to cancel build process during installation

### DIFF
--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -34,7 +34,7 @@ func Install(ctx context.Context, w io.Writer, k8sCfg *rest.Config, opts capact.
 		registryPath := opts.Parameters.Override.CapactValues.Global.ContainerRegistry.Path
 		registryTag := opts.Parameters.Override.CapactValues.Global.ContainerRegistry.Tag
 		// TODO can we parallelize it?
-		created, err := capact.BuildImages(w, registryPath, registryTag, opts.BuildImages)
+		created, err := capact.BuildImages(ctx, w, registryPath, registryTag, opts.BuildImages)
 		if err != nil {
 			return errors.Wrap(err, "while building images")
 		}


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add option to cancel build process during installation

Currently, when you run `capact install --version @local` and press `ctrl + c` you cannot cancel the build process.

This PRs add support for cancelling build process:
```
$ capact install --version=@local
Installing Capact on cluster...
[+] Building 0.8s (2/3)
[+] Building 0.9s (3/3) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                             0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                                                                                 0.0s
 => CANCELED resolve image config for docker.io/docker/dockerfile:1-experimental                                                                                                                                                 0.4s
failed to solve with frontend dockerfile.v0: failed to solve with frontend gateway.v0: failed to do request: context canceled
```

We can take it further and adjust the load images process too. But probably it will be better to fix it in upstream and later backport it to us: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/nodeutils/util.go
