### PR TITLE
Adjust populator and Hub GraphQL schema to support typeRef in Interface input-parameters

### DIFF
--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -235,7 +235,8 @@ type InterfaceInput @additionalLabels(labels: ["published"]){
 
 type InputParameter @additionalLabels(labels: ["published"]){
   name: String!
-  typeRef: TypeReference! @relation(name: "OF_TYPE", direction: "OUT")
+  jsonSchema: Any 
+  typeRef: TypeReference @relation(name: "OF_TYPE", direction: "OUT")
 }
 
 type InterfaceOutput @additionalLabels(labels: ["published"]){

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -235,7 +235,7 @@ type InterfaceInput @additionalLabels(labels: ["published"]){
 
 type InputParameter @additionalLabels(labels: ["published"]){
   name: String!
-  jsonSchema: Any
+  typeRef: TypeReference! @relation(name: "OF_TYPE", direction: "OUT")
 }
 
 type InterfaceOutput @additionalLabels(labels: ["published"]){

--- a/pkg/hub/api/graphql/public/models_gen.go
+++ b/pkg/hub/api/graphql/public/models_gen.go
@@ -174,8 +174,8 @@ type ImplementationSpec struct {
 }
 
 type InputParameter struct {
-	Name       string      `json:"name"`
-	JSONSchema interface{} `json:"jsonSchema"`
+	Name    string         `json:"name"`
+	TypeRef *TypeReference `json:"typeRef"`
 }
 
 type InputTypeInstance struct {

--- a/pkg/hub/api/graphql/public/models_gen.go
+++ b/pkg/hub/api/graphql/public/models_gen.go
@@ -174,8 +174,9 @@ type ImplementationSpec struct {
 }
 
 type InputParameter struct {
-	Name    string         `json:"name"`
-	TypeRef *TypeReference `json:"typeRef"`
+	Name       string         `json:"name"`
+	JSONSchema interface{}    `json:"jsonSchema"`
+	TypeRef    *TypeReference `json:"typeRef"`
 }
 
 type InputTypeInstance struct {

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -169,8 +169,9 @@ type ComplexityRoot struct {
 	}
 
 	InputParameter struct {
-		Name    func(childComplexity int) int
-		TypeRef func(childComplexity int) int
+		JSONSchema func(childComplexity int) int
+		Name       func(childComplexity int) int
+		TypeRef    func(childComplexity int) int
 	}
 
 	InputTypeInstance struct {
@@ -863,6 +864,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ImplementationSpec.Requires(childComplexity), true
+
+	case "InputParameter.jsonSchema":
+		if e.complexity.InputParameter.JSONSchema == nil {
+			break
+		}
+
+		return e.complexity.InputParameter.JSONSchema(childComplexity), true
 
 	case "InputParameter.name":
 		if e.complexity.InputParameter.Name == nil {
@@ -1816,7 +1824,8 @@ type InterfaceInput @additionalLabels(labels: ["published"]){
 
 type InputParameter @additionalLabels(labels: ["published"]){
   name: String!
-  typeRef: TypeReference! @relation(name: "OF_TYPE", direction: "OUT")
+  jsonSchema: Any 
+  typeRef: TypeReference @relation(name: "OF_TYPE", direction: "OUT")
 }
 
 type InterfaceOutput @additionalLabels(labels: ["published"]){
@@ -6339,6 +6348,38 @@ func (ec *executionContext) _InputParameter_name(ctx context.Context, field grap
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _InputParameter_jsonSchema(ctx context.Context, field graphql.CollectedField, obj *InputParameter) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "InputParameter",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.JSONSchema, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(interface{})
+	fc.Result = res
+	return ec.marshalOAny2interface(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _InputParameter_typeRef(ctx context.Context, field graphql.CollectedField, obj *InputParameter) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6402,14 +6443,11 @@ func (ec *executionContext) _InputParameter_typeRef(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*TypeReference)
 	fc.Result = res
-	return ec.marshalNTypeReference2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReference(ctx, field.Selections, res)
+	return ec.marshalOTypeReference2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReference(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _InputTypeInstance_name(ctx context.Context, field graphql.CollectedField, obj *InputTypeInstance) (ret graphql.Marshaler) {
@@ -13450,11 +13488,10 @@ func (ec *executionContext) _InputParameter(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "jsonSchema":
+			out.Values[i] = ec._InputParameter_jsonSchema(ctx, field, obj)
 		case "typeRef":
 			out.Values[i] = ec._InputParameter_typeRef(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -16862,6 +16899,13 @@ func (ec *executionContext) unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapa
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) marshalOTypeReference2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReference(ctx context.Context, sel ast.SelectionSet, v *TypeReference) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TypeReference(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOTypeReferenceWithOptionalRevision2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReferenceWithOptionalRevision(ctx context.Context, v interface{}) ([]*TypeReferenceWithOptionalRevision, error) {

--- a/pkg/hub/client/public/fields.go
+++ b/pkg/hub/client/public/fields.go
@@ -137,7 +137,10 @@ var InterfaceRevisionFields = fmt.Sprintf(`
         input {
           parameters {
             name
-            jsonSchema
+						typeRef {
+							path
+							revision
+						}
           }
           typeInstances {
             name

--- a/pkg/hub/client/public/fields.go
+++ b/pkg/hub/client/public/fields.go
@@ -4,143 +4,144 @@ import "fmt"
 
 // GenericMetadataFields for querying the GenericMetadata fields.
 var GenericMetadataFields = `
-			prefix
-			path
-			name
-			displayName
-			description
-			maintainers {
-				name
-				email
-			}
-			iconURL
-			documentationURL
-			supportURL
-			iconURL
-			`
+      prefix
+      path
+      name
+      displayName
+      description
+      maintainers {
+        name
+        email
+      }
+      iconURL
+      documentationURL
+      supportURL
+      iconURL
+      `
 
 // AttributeFields for quering the Attributes fields and GenericMetadata.
 var AttributeFields = fmt.Sprintf(`
-			metadata {
-				%s
-			}
-			revision
-			spec {
-				additionalRefs
-			}
-			`, GenericMetadataFields)
+      metadata {
+        %s
+      }
+      revision
+      spec {
+        additionalRefs
+      }
+      `, GenericMetadataFields)
 
 // ImplementationFields for quering the Implementation fields with all revisions.
 var ImplementationFields = fmt.Sprintf(`
-			path
-			name
-			prefix
-			revisions {
-				%s
-			}
+      path
+      name
+      prefix
+      revisions {
+        %s
+      }
 `, ImplementationRevisionFields)
 
 // ImplementationRevisionFields for quering ImplementationRevision fields.
 var ImplementationRevisionFields = fmt.Sprintf(`
-			metadata {
-					%s
-					attributes {
-						%s
-					}
-			}
-			revision
-			spec {
-				appVersion
-				implements {
-					path
-					revision
-				}
-				requires {
-					prefix
-					oneOf {
-						typeRef {
-							path
-							revision
-						}
-						valueConstraints
-						alias
-					}
-					anyOf {
-						typeRef {
-							path
-							revision
-						}
-						valueConstraints
-						alias
-					}
-					allOf {
-						typeRef {
-							path
-							revision
-						}
-						valueConstraints
-						alias
-					}
-				}
-				imports {
-					interfaceGroupPath
-					alias
-					appVersion
-					methods {
-						name
-						revision
-					}
-				}
-				additionalInput {
-					typeInstances {
-						name
-						typeRef {
-							path
-							revision
-						}
-						verbs
-					}
-					parameters {
-						typeRef {
-							path
-							revision
-						}
-					}
-				}
-				additionalOutput {
-					typeInstances {
-						name
-						typeRef {
-							path
-							revision
-						}
-					}
-				}
-				outputTypeInstanceRelations {
-					typeInstanceName
-					uses
-				}
-				action {
-					runnerInterface
-					args
-				}
-			}
-			`, GenericMetadataFields, AttributeFields)
+      metadata {
+        %s
+        attributes {
+          %s
+        }
+      }
+      revision
+      spec {
+        appVersion
+        implements {
+          path
+          revision
+        }
+        requires {
+          prefix
+          oneOf {
+            typeRef {
+              path
+              revision
+            }
+            valueConstraints
+            alias
+          }
+          anyOf {
+            typeRef {
+              path
+              revision
+            }
+            valueConstraints
+            alias
+          }
+          allOf {
+            typeRef {
+              path
+              revision
+            }
+            valueConstraints
+            alias
+          }
+        }
+        imports {
+          interfaceGroupPath
+          alias
+          appVersion
+          methods {
+            name
+            revision
+          }
+        }
+        additionalInput {
+          typeInstances {
+            name
+            typeRef {
+              path
+              revision
+            }
+            verbs
+          }
+          parameters {
+            typeRef {
+              path
+              revision
+            }
+          }
+        }
+        additionalOutput {
+          typeInstances {
+            name
+            typeRef {
+              path
+              revision
+            }
+          }
+        }
+        outputTypeInstanceRelations {
+          typeInstanceName
+          uses
+        }
+        action {
+          runnerInterface
+          args
+        }
+      }
+      `, GenericMetadataFields, AttributeFields)
 
 // InterfaceRevisionFields for quering InterfaceRevision fields with GenericMetadata and all revisions.
 var InterfaceRevisionFields = fmt.Sprintf(`
       revision
       metadata {
-				%s
+        %s
       }
       spec {
         input {
           parameters {
             name
-						typeRef {
-							path
-							revision
-						}
+            jsonSchema
+            typeRef {
+              path
+              revision
+            }
           }
           typeInstances {
             name
@@ -161,17 +162,17 @@ var InterfaceRevisionFields = fmt.Sprintf(`
           }
         }
       }
-			implementationRevisions {
-					%s
-			}
+      implementationRevisions {
+          %s
+      }
 `, GenericMetadataFields, ImplementationRevisionFields)
 
 // InterfacesFields for quering Interface with the latest revision only.
 var InterfacesFields = fmt.Sprintf(`
-		path
-		name
-		prefix
-		latestRevision {
-		  %s
-		}
+    path
+    name
+    prefix
+    latestRevision {
+      %s
+    }
 `, InterfaceRevisionFields)

--- a/pkg/sdk/dbpopulator/populator.go
+++ b/pkg/sdk/dbpopulator/populator.go
@@ -137,9 +137,14 @@ CALL {
   WITH input, parameters
   UNWIND keys(parameters) as name
     CREATE (parameter: InputParameter:unpublished {
-      name: name,
-      jsonSchema: parameters[name].jsonSchema.value})
+      name: name
+    })
     CREATE (input)-[:HAS]->(parameter)
+
+    MERGE (typeReference: TypeReference:unpublished{
+      path: parameters[name].typeRef.path,
+      revision: parameters[name].typeRef.revision})
+    CREATE (parameter)-[:OF_TYPE]->(typeReference)
   RETURN count([]) as _tmp0
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Adjust populator and Hub GraphQL schema to support typeRef in Interface input-parameters

You might need to use this manifest branch https://github.com/capactio/hub-manifests/pull/18 to test this.

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
