### PR TITLE
Filter Implementations which need missing required TypeInstance injection

### DIFF
--- a/cmd/populator/cmd/register/ocf_manifests.go
+++ b/cmd/populator/cmd/register/ocf_manifests.go
@@ -16,9 +16,9 @@ import (
 	"capact.io/capact/internal/logger"
 	"capact.io/capact/pkg/sdk/dbpopulator"
 
+	"capact.io/capact/internal/multierror"
 	"github.com/avast/retry-go"
 	"github.com/docker/cli/cli"
-	"github.com/hashicorp/go-multierror"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -72,8 +72,9 @@ input ImplementationRevisionFilter {
   requirementsSatisfiedBy: [TypeInstanceValue!]
 
   """
-  Used along with `requirementsSatisfiedBy` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
-  Ignored if used without `requirementsSatisfiedBy`.
+  Filter by Implementations, which have requirements injection satisfied.
+  If provided, all TypeInstance values are merged into `requirementsSatisfiedBy` filter values, and, in a result,
+  both filters `requirementsSatisfiedBy` and `requiredTypeInstancesInjectionSatisfiedBy` are used.
   """
   requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -81,11 +81,13 @@ input ImplementationRevisionFilter {
   such TypeReference in `Implementation.spec.requires` in any of the sections: oneOf, anyOf or allOf.
   """
   requires: [TypeReferenceWithOptionalRevision]
+
+  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 }
 # lint-enable defined-types-are-used
 
 input TypeInstanceValue {
-  typeRef: TypeReferenceWithOptionalRevision
+  typeRef: TypeReferenceInput!
 
   """
   Currently not supported.
@@ -97,6 +99,11 @@ input TypeInstanceValue {
 input TypeReferenceWithOptionalRevision {
   path: NodePath!
   revision: Version
+}
+
+input TypeReferenceInput {
+  path: NodePath!
+  revision: Version!
 }
 
 input AttributeFilterInput {

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -71,6 +71,12 @@ input ImplementationRevisionFilter {
   """
   requirementsSatisfiedBy: [TypeInstanceValue!]
 
+  """
+  Used along with `requirementsSatisfiedBy` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
+  Ignored if used without `requirementsSatisfiedBy`.
+  """
+  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
+
   attributes: [AttributeFilterInput!]
 
   """
@@ -81,8 +87,6 @@ input ImplementationRevisionFilter {
   such TypeReference in `Implementation.spec.requires` in any of the sections: oneOf, anyOf or allOf.
   """
   requires: [TypeReferenceWithOptionalRevision]
-
-  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 }
 # lint-enable defined-types-are-used
 

--- a/internal/cli/heredoc/heredoc.go
+++ b/internal/cli/heredoc/heredoc.go
@@ -22,5 +22,5 @@ func Doc(raw string) string {
 // Docf returns unindented and formatted string as here-document.
 // Formatting is done as for fmt.Printf().
 func Docf(raw string, args ...interface{}) string {
-	return heredoc.Docf(raw)
+	return heredoc.Docf(raw, args...)
 }

--- a/internal/k8s-engine/graphql/domain/action/resolver.go
+++ b/internal/k8s-engine/graphql/domain/action/resolver.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"capact.io/capact/internal/k8s-engine/graphql/model"
+	"capact.io/capact/internal/multierror"
 	"capact.io/capact/pkg/engine/api/graphql"
 	"capact.io/capact/pkg/engine/k8s/api/v1alpha1"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 

--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -1,0 +1,40 @@
+package multierror
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// New create new *multierror.Error with formatting without `\n\n` at the end
+func New() *multierror.Error {
+	return &multierror.Error{
+		ErrorFormat: listFormatFunc,
+	}
+}
+
+// Append is a wrapper for multierror.Append function.
+func Append(err error, errs ...error) *multierror.Error {
+	return multierror.Append(err, errs...)
+}
+
+// listFormatFunc is a basic formatter that outputs the number of errors
+// that occurred along with a bullet point list of the errors.
+//
+// it's a copy of https://github.com/hashicorp/go-multierror/blob/9974e9ec57696378079ecc3accd3d6f29401b3a0/format.go#L14
+// with removed additional two new lines (`\n\n`) added to error message.
+func listFormatFunc(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\t* %s", es[0])
+	}
+
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d errors occurred:\n\t%s",
+		len(es), strings.Join(points, "\n\t"))
+}

--- a/pkg/engine/k8s/policy/deepcopy.extend.go
+++ b/pkg/engine/k8s/policy/deepcopy.extend.go
@@ -1,0 +1,52 @@
+package policy
+
+import "capact.io/capact/internal/maps"
+
+// DeepCopyInto writes a deep copy of AdditionalParametersToInject into out.
+// controller-gen doesn't support interface{} so writing it manually
+func (in *AdditionalParametersToInject) DeepCopyInto(out *AdditionalParametersToInject) {
+	*out = *in
+	out.Value = maps.Merge(out.Value, in.Value)
+}
+
+// DeepCopy returns a new deep copy of AdditionalParametersToInject.
+// controller-gen doesn't support interface{} so writing it manually
+func (in *AdditionalParametersToInject) DeepCopy() *AdditionalParametersToInject {
+	if in == nil {
+		return nil
+	}
+	out := new(AdditionalParametersToInject)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopy returns a new deep copy of InjectData.
+// controller-gen doesn't support interface{} so writing it manually
+func (in *InjectData) DeepCopy() *InjectData {
+	if in == nil {
+		return nil
+	}
+	out := new(InjectData)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto writes a deep copy of InjectData into out.
+// controller-gen doesn't support interface{} so writing it manually
+func (in *InjectData) DeepCopyInto(out *InjectData) {
+	*out = *in
+	if in.RequiredTypeInstances != nil {
+		in, out := &in.RequiredTypeInstances, &out.RequiredTypeInstances
+		*out = make([]RequiredTypeInstanceToInject, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.AdditionalParameters != nil {
+		in, out := &in.AdditionalParameters, &out.AdditionalParameters
+		*out = make([]AdditionalParametersToInject, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}

--- a/pkg/engine/k8s/policy/fixtures_test.go
+++ b/pkg/engine/k8s/policy/fixtures_test.go
@@ -84,8 +84,8 @@ func fixPolicyWithTypeRef() policy.Policy {
 	}
 }
 
-func fixComplexPolicyWithoutTypeRef() policy.Policy {
-	return policy.Policy{
+func fixComplexPolicyWithoutTypeRef() *policy.Policy {
+	return &policy.Policy{
 		Rules: policy.RulesList{
 			{
 				Interface: types.ManifestRefWithOptRevision{
@@ -147,8 +147,8 @@ func fixComplexPolicyWithoutTypeRef() policy.Policy {
 	}
 }
 
-func fixComplexPolicyWithTypeRef() policy.Policy {
-	return policy.Policy{
+func fixComplexPolicyWithTypeRef() *policy.Policy {
+	return &policy.Policy{
 		Rules: policy.RulesList{
 			{
 				Interface: types.ManifestRefWithOptRevision{

--- a/pkg/engine/k8s/policy/resolve.go
+++ b/pkg/engine/k8s/policy/resolve.go
@@ -1,0 +1,76 @@
+package policy
+
+import (
+	"context"
+
+	hublocalgraphql "capact.io/capact/pkg/hub/api/graphql/local"
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+	"github.com/pkg/errors"
+)
+
+// HubClient defines Hub client which is able to find TypeInstance Type references.
+type HubClient interface {
+	FindTypeInstancesTypeRef(ctx context.Context, ids []string) (map[string]hublocalgraphql.TypeInstanceTypeReference, error)
+}
+
+// ResolveTypeInstanceMetadata resolves needed TypeInstance metadata based on IDs for a given Policy.
+func ResolveTypeInstanceMetadata(ctx context.Context, hubCli HubClient, policy *Policy) error {
+	if policy == nil {
+		return errors.New("policy cannot be nil")
+	}
+
+	if hubCli == nil {
+		return errors.New("hub client cannot be nil")
+	}
+
+	err := resolveTypeRefsForRequiredTypeInstances(ctx, hubCli, policy)
+	if err != nil {
+		return err
+	}
+
+	err = policy.ValidateTypeInstancesMetadata()
+	if err != nil {
+		return errors.Wrap(err, "while TypeInstance metadata validation after resolving TypeRefs")
+	}
+
+	return nil
+}
+
+func resolveTypeRefsForRequiredTypeInstances(ctx context.Context, hubCli HubClient, policy *Policy) error {
+	unresolvedTypeInstances := policy.filterRequiredTypeInstances(filterTypeInstancesWithEmptyTypeRef)
+
+	var idsToQuery []string
+	for _, ti := range unresolvedTypeInstances {
+		idsToQuery = append(idsToQuery, ti.ID)
+	}
+
+	if len(idsToQuery) == 0 {
+		return nil
+	}
+
+	res, err := hubCli.FindTypeInstancesTypeRef(ctx, idsToQuery)
+	if err != nil {
+		return errors.Wrap(err, "while finding TypeRef for TypeInstances")
+	}
+
+	for ruleIdx, rule := range policy.Rules {
+		for ruleItemIdx, ruleItem := range rule.OneOf {
+			if ruleItem.Inject == nil {
+				continue
+			}
+			for reqTIIdx, reqTI := range ruleItem.Inject.RequiredTypeInstances {
+				typeRef, exists := res[reqTI.ID]
+				if !exists {
+					continue
+				}
+
+				policy.Rules[ruleIdx].OneOf[ruleItemIdx].Inject.RequiredTypeInstances[reqTIIdx].TypeRef = &types.ManifestRef{
+					Path:     typeRef.Path,
+					Revision: typeRef.Revision,
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/engine/k8s/policy/resolve_test.go
+++ b/pkg/engine/k8s/policy/resolve_test.go
@@ -1,0 +1,65 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+
+	"capact.io/capact/internal/ptr"
+	"capact.io/capact/pkg/engine/k8s/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveTypeInstanceMetadata(t *testing.T) {
+	// given
+	tests := []struct {
+		Name               string
+		Input              *policy.Policy
+		HubCli             policy.HubClient
+		Expected           *policy.Policy
+		ExpectedErrMessage *string
+	}{
+		{
+			Name:               "Nil HubCli",
+			Input:              &policy.Policy{},
+			HubCli:             nil,
+			ExpectedErrMessage: ptr.String("hub client cannot be nil"),
+		},
+		{
+			Name:     "Unresolved TypeRefs",
+			Input:    fixComplexPolicyWithoutTypeRef(),
+			HubCli:   &fakeHub{ShouldRun: true, ExpectedIDLen: 4},
+			Expected: fixComplexPolicyWithTypeRef(),
+		},
+		{
+			Name:               "Partial result",
+			Input:              fixComplexPolicyWithoutTypeRef(),
+			HubCli:             &fakeHub{ShouldRun: true, ExpectedIDLen: 4, IgnoreIDs: map[string]struct{}{"id2": {}, "id4": {}}},
+			ExpectedErrMessage: ptr.String("while TypeInstance metadata validation after resolving TypeRefs: while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\t* missing Type reference for TypeInstance \"id4\" (description: \"\")\n\n"),
+		},
+		{
+			Name:     "Already resolved",
+			HubCli:   &fakeHub{ShouldRun: false},
+			Input:    fixComplexPolicyWithTypeRef(),
+			Expected: fixComplexPolicyWithTypeRef(),
+		},
+	}
+
+	for _, testCase := range tests {
+		tc := testCase
+		t.Run(tc.Name, func(t *testing.T) {
+			// when
+			in := tc.Input
+			err := policy.ResolveTypeInstanceMetadata(context.Background(), tc.HubCli, in)
+
+			// then
+			if tc.ExpectedErrMessage != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, *tc.ExpectedErrMessage)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.Expected, in)
+			}
+		})
+	}
+}

--- a/pkg/engine/k8s/policy/types_test.go
+++ b/pkg/engine/k8s/policy/types_test.go
@@ -1,14 +1,12 @@
 package policy_test
 
 import (
-	"context"
 	"testing"
 
 	"capact.io/capact/internal/ptr"
 	"capact.io/capact/pkg/engine/k8s/policy"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPolicy_AreTypeInstancesMetadataResolved(t *testing.T) {
@@ -43,138 +41,6 @@ func TestPolicy_AreTypeInstancesMetadataResolved(t *testing.T) {
 
 			// then
 			assert.Equal(t, tc.ExpectedResult, res)
-		})
-	}
-}
-
-func TestPolicy_ValidateTypeInstancesMetadata(t *testing.T) {
-	// given
-	tests := []struct {
-		Name               string
-		Input              policy.Policy
-		ExpectedErrMessage *string
-	}{
-		{
-			Name:  "Empty",
-			Input: policy.Policy{},
-		},
-		{
-			Name:  "Valid",
-			Input: fixPolicyWithTypeRef(),
-		},
-		{
-			Name:               "Invalid",
-			Input:              fixPolicyWithoutTypeRef(),
-			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
-		},
-	}
-
-	for _, testCase := range tests {
-		tc := testCase
-		t.Run(tc.Name, func(t *testing.T) {
-			// when
-			err := tc.Input.ValidateTypeInstancesMetadata()
-
-			// then
-			if tc.ExpectedErrMessage != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, *tc.ExpectedErrMessage)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestPolicy_ResolveTypeInstanceMetadata(t *testing.T) {
-	// given
-	tests := []struct {
-		Name               string
-		Input              policy.Policy
-		HubCli             policy.HubClient
-		Expected           policy.Policy
-		ExpectedErrMessage *string
-	}{
-		{
-			Name:               "Nil HubCli",
-			Input:              policy.Policy{},
-			HubCli:             nil,
-			ExpectedErrMessage: ptr.String("hub client cannot be nil"),
-		},
-		{
-			Name:     "Unresolved TypeRefs",
-			Input:    fixComplexPolicyWithoutTypeRef(),
-			HubCli:   &fakeHub{ShouldRun: true, ExpectedIDLen: 4},
-			Expected: fixComplexPolicyWithTypeRef(),
-		},
-		{
-			Name:               "Partial result",
-			Input:              fixComplexPolicyWithoutTypeRef(),
-			HubCli:             &fakeHub{ShouldRun: true, ExpectedIDLen: 4, IgnoreIDs: map[string]struct{}{"id2": {}, "id4": {}}},
-			ExpectedErrMessage: ptr.String("while TypeInstance metadata validation after resolving TypeRefs: while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\t* missing Type reference for TypeInstance \"id4\" (description: \"\")\n\n"),
-		},
-		{
-			Name:     "Already resolved",
-			HubCli:   &fakeHub{ShouldRun: false},
-			Input:    fixComplexPolicyWithTypeRef(),
-			Expected: fixComplexPolicyWithTypeRef(),
-		},
-	}
-
-	for _, testCase := range tests {
-		tc := testCase
-		t.Run(tc.Name, func(t *testing.T) {
-			// when
-			policy := tc.Input
-			err := policy.ResolveTypeInstanceMetadata(context.Background(), tc.HubCli)
-
-			// then
-			if tc.ExpectedErrMessage != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, *tc.ExpectedErrMessage)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.Expected, policy)
-			}
-		})
-	}
-}
-
-func TestRule_ValidateTypeInstanceMetadata(t *testing.T) {
-	// given
-	tests := []struct {
-		Name               string
-		Input              policy.Rule
-		ExpectedErrMessage *string
-	}{
-		{
-			Name:  "Empty",
-			Input: policy.Rule{},
-		},
-		{
-			Name:  "Valid",
-			Input: fixPolicyWithTypeRef().Rules[0].OneOf[0],
-		},
-		{
-			Name:               "Invalid",
-			Input:              fixPolicyWithoutTypeRef().Rules[0].OneOf[0],
-			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
-		},
-	}
-
-	for _, testCase := range tests {
-		tc := testCase
-		t.Run(tc.Name, func(t *testing.T) {
-			// when
-			err := tc.Input.ValidateTypeInstanceMetadata()
-
-			// then
-			if tc.ExpectedErrMessage != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, *tc.ExpectedErrMessage)
-			} else {
-				require.NoError(t, err)
-			}
 		})
 	}
 }

--- a/pkg/engine/k8s/policy/validate.go
+++ b/pkg/engine/k8s/policy/validate.go
@@ -3,7 +3,8 @@ package policy
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
+	"capact.io/capact/internal/multierror"
+
 	"github.com/pkg/errors"
 )
 
@@ -18,7 +19,7 @@ func validateTypeInstancesMetadata(requiredTypeInstances []RequiredTypeInstanceT
 		return nil
 	}
 
-	multiErr := &multierror.Error{}
+	multiErr := multierror.New()
 	for _, ti := range requiredTypeInstances {
 		tiDesc := ""
 		if ti.Description != nil {

--- a/pkg/engine/k8s/policy/validate.go
+++ b/pkg/engine/k8s/policy/validate.go
@@ -1,0 +1,35 @@
+package policy
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// ValidateTypeInstancesMetadata validates that every TypeInstance has metadata resolved.
+func (in *Policy) ValidateTypeInstancesMetadata() error {
+	unresolvedTypeInstances := in.filterRequiredTypeInstances(filterTypeInstancesWithEmptyTypeRef)
+	return validateTypeInstancesMetadata(unresolvedTypeInstances)
+}
+
+func validateTypeInstancesMetadata(requiredTypeInstances []RequiredTypeInstanceToInject) error {
+	if len(requiredTypeInstances) == 0 {
+		return nil
+	}
+
+	multiErr := &multierror.Error{}
+	for _, ti := range requiredTypeInstances {
+		tiDesc := ""
+		if ti.Description != nil {
+			tiDesc = *ti.Description
+		}
+
+		multiErr = multierror.Append(
+			multiErr,
+			fmt.Errorf("missing Type reference for TypeInstance %q (description: %q)", ti.ID, tiDesc),
+		)
+	}
+
+	return errors.Wrap(multiErr, "while validating TypeInstance metadata for Policy")
+}

--- a/pkg/engine/k8s/policy/validate_test.go
+++ b/pkg/engine/k8s/policy/validate_test.go
@@ -3,6 +3,8 @@ package policy_test
 import (
 	"testing"
 
+	"capact.io/capact/internal/cli/heredoc"
+
 	"capact.io/capact/internal/ptr"
 	"capact.io/capact/pkg/engine/k8s/policy"
 	"github.com/stretchr/testify/assert"
@@ -25,9 +27,15 @@ func TestPolicy_ValidateTypeInstancesMetadata(t *testing.T) {
 			Input: fixPolicyWithTypeRef(),
 		},
 		{
-			Name:               "Invalid",
-			Input:              fixPolicyWithoutTypeRef(),
-			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
+			Name:  "Invalid",
+			Input: fixPolicyWithoutTypeRef(),
+			ExpectedErrMessage: ptr.String(
+				heredoc.Docf(`
+				while validating TypeInstance metadata for Policy: 2 errors occurred:
+					* missing Type reference for TypeInstance "id" (description: "")
+					* missing Type reference for TypeInstance "id2" (description: "ID 2")`,
+				),
+			),
 		},
 	}
 
@@ -64,9 +72,15 @@ func TestRule_ValidateTypeInstanceMetadata(t *testing.T) {
 			Input: fixPolicyWithTypeRef().Rules[0].OneOf[0],
 		},
 		{
-			Name:               "Invalid",
-			Input:              fixPolicyWithoutTypeRef().Rules[0].OneOf[0],
-			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
+			Name:  "Invalid",
+			Input: fixPolicyWithoutTypeRef().Rules[0].OneOf[0],
+			ExpectedErrMessage: ptr.String(
+				heredoc.Doc(`
+				while validating TypeInstance metadata for Policy: 2 errors occurred:
+					* missing Type reference for TypeInstance "id" (description: "")
+					* missing Type reference for TypeInstance "id2" (description: "ID 2")`,
+				),
+			),
 		},
 	}
 

--- a/pkg/engine/k8s/policy/validate_test.go
+++ b/pkg/engine/k8s/policy/validate_test.go
@@ -1,0 +1,88 @@
+package policy_test
+
+import (
+	"testing"
+
+	"capact.io/capact/internal/ptr"
+	"capact.io/capact/pkg/engine/k8s/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicy_ValidateTypeInstancesMetadata(t *testing.T) {
+	// given
+	tests := []struct {
+		Name               string
+		Input              policy.Policy
+		ExpectedErrMessage *string
+	}{
+		{
+			Name:  "Empty",
+			Input: policy.Policy{},
+		},
+		{
+			Name:  "Valid",
+			Input: fixPolicyWithTypeRef(),
+		},
+		{
+			Name:               "Invalid",
+			Input:              fixPolicyWithoutTypeRef(),
+			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
+		},
+	}
+
+	for _, testCase := range tests {
+		tc := testCase
+		t.Run(tc.Name, func(t *testing.T) {
+			// when
+			err := tc.Input.ValidateTypeInstancesMetadata()
+
+			// then
+			if tc.ExpectedErrMessage != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, *tc.ExpectedErrMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRule_ValidateTypeInstanceMetadata(t *testing.T) {
+	// given
+	tests := []struct {
+		Name               string
+		Input              policy.Rule
+		ExpectedErrMessage *string
+	}{
+		{
+			Name:  "Empty",
+			Input: policy.Rule{},
+		},
+		{
+			Name:  "Valid",
+			Input: fixPolicyWithTypeRef().Rules[0].OneOf[0],
+		},
+		{
+			Name:               "Invalid",
+			Input:              fixPolicyWithoutTypeRef().Rules[0].OneOf[0],
+			ExpectedErrMessage: ptr.String("while validating TypeInstance metadata for Policy: 2 errors occurred:\n\t* missing Type reference for TypeInstance \"id\" (description: \"\")\n\t* missing Type reference for TypeInstance \"id2\" (description: \"ID 2\")\n\n"),
+		},
+	}
+
+	for _, testCase := range tests {
+		tc := testCase
+		t.Run(tc.Name, func(t *testing.T) {
+			// when
+			err := tc.Input.ValidateTypeInstanceMetadata()
+
+			// then
+			if tc.ExpectedErrMessage != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, *tc.ExpectedErrMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/hub/api/graphql/public/models_gen.go
+++ b/pkg/hub/api/graphql/public/models_gen.go
@@ -160,7 +160,8 @@ type ImplementationRevisionFilter struct {
 	//
 	// For every item in the array, the returned ImplementationRevisions must specify
 	// such TypeReference in `Implementation.spec.requires` in any of the sections: oneOf, anyOf or allOf.
-	Requires []*TypeReferenceWithOptionalRevision `json:"requires"`
+	Requires                                  []*TypeReferenceWithOptionalRevision `json:"requires"`
+	RequiredTypeInstancesInjectionSatisfiedBy []*TypeInstanceValue                 `json:"requiredTypeInstancesInjectionSatisfiedBy"`
 }
 
 type ImplementationSpec struct {
@@ -316,7 +317,7 @@ type TypeInstanceRelationItem struct {
 }
 
 type TypeInstanceValue struct {
-	TypeRef *TypeReferenceWithOptionalRevision `json:"typeRef"`
+	TypeRef *TypeReferenceInput `json:"typeRef"`
 	// Currently not supported.
 	// Value of the available requirement. If not provided, all valueConstraints conditions are treated as satisfied.
 	Value interface{} `json:"value"`
@@ -338,6 +339,11 @@ type TypeMetadata struct {
 func (TypeMetadata) IsMetadataBaseFields() {}
 
 type TypeReference struct {
+	Path     string `json:"path"`
+	Revision string `json:"revision"`
+}
+
+type TypeReferenceInput struct {
 	Path     string `json:"path"`
 	Revision string `json:"revision"`
 }

--- a/pkg/hub/api/graphql/public/models_gen.go
+++ b/pkg/hub/api/graphql/public/models_gen.go
@@ -153,15 +153,17 @@ type ImplementationRevisionFilter struct {
 	PathPattern *string `json:"pathPattern"`
 	// If provided, Implementations are filtered by the ones that have satisfied requirements with provided TypeInstance values.
 	// For example, to find all Implementations that can be run on a given system, user can provide values of all existing TypeInstances.
-	RequirementsSatisfiedBy []*TypeInstanceValue    `json:"requirementsSatisfiedBy"`
-	Attributes              []*AttributeFilterInput `json:"attributes"`
+	RequirementsSatisfiedBy []*TypeInstanceValue `json:"requirementsSatisfiedBy"`
+	// Used along with `requirementsSatisfiedBy` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
+	// Ignored if used without `requirementsSatisfiedBy`.
+	RequiredTypeInstancesInjectionSatisfiedBy []*TypeInstanceValue    `json:"requiredTypeInstancesInjectionSatisfiedBy"`
+	Attributes                                []*AttributeFilterInput `json:"attributes"`
 	// If provided, the ImplementationRevisions for a given Interface will be filtered
 	// according to provided Type references looked up in the `Implementation.spec.requires` field.
 	//
 	// For every item in the array, the returned ImplementationRevisions must specify
 	// such TypeReference in `Implementation.spec.requires` in any of the sections: oneOf, anyOf or allOf.
-	Requires                                  []*TypeReferenceWithOptionalRevision `json:"requires"`
-	RequiredTypeInstancesInjectionSatisfiedBy []*TypeInstanceValue                 `json:"requiredTypeInstancesInjectionSatisfiedBy"`
+	Requires []*TypeReferenceWithOptionalRevision `json:"requires"`
 }
 
 type ImplementationSpec struct {

--- a/pkg/hub/api/graphql/public/models_gen.go
+++ b/pkg/hub/api/graphql/public/models_gen.go
@@ -154,8 +154,9 @@ type ImplementationRevisionFilter struct {
 	// If provided, Implementations are filtered by the ones that have satisfied requirements with provided TypeInstance values.
 	// For example, to find all Implementations that can be run on a given system, user can provide values of all existing TypeInstances.
 	RequirementsSatisfiedBy []*TypeInstanceValue `json:"requirementsSatisfiedBy"`
-	// Used along with `requirementsSatisfiedBy` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
-	// Ignored if used without `requirementsSatisfiedBy`.
+	// Filter by Implementations, which have requirements injection satisfied.
+	// If provided, all TypeInstance values are merged into `requirementsSatisfiedBy` filter values, and, in a result,
+	// both filters `requirementsSatisfiedBy` and `requiredTypeInstancesInjectionSatisfiedBy` are used.
 	RequiredTypeInstancesInjectionSatisfiedBy []*TypeInstanceValue    `json:"requiredTypeInstancesInjectionSatisfiedBy"`
 	Attributes                                []*AttributeFilterInput `json:"attributes"`
 	// If provided, the ImplementationRevisions for a given Interface will be filtered

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -1669,8 +1669,9 @@ input ImplementationRevisionFilter {
   requirementsSatisfiedBy: [TypeInstanceValue!]
 
   """
-  Used along with ` + "`" + `requirementsSatisfiedBy` + "`" + ` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
-  Ignored if used without ` + "`" + `requirementsSatisfiedBy` + "`" + `.
+  Filter by Implementations, which have requirements injection satisfied.
+  If provided, all TypeInstance values are merged into ` + "`" + `requirementsSatisfiedBy` + "`" + ` filter values, and, in a result,
+  both filters ` + "`" + `requirementsSatisfiedBy` + "`" + ` and ` + "`" + `requiredTypeInstancesInjectionSatisfiedBy` + "`" + ` are used.
   """
   requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -1668,6 +1668,12 @@ input ImplementationRevisionFilter {
   """
   requirementsSatisfiedBy: [TypeInstanceValue!]
 
+  """
+  Used along with ` + "`" + `requirementsSatisfiedBy` + "`" + ` filter. It brings additional level of filtering by Implementations, which have requirements injection satisfied.
+  Ignored if used without ` + "`" + `requirementsSatisfiedBy` + "`" + `.
+  """
+  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
+
   attributes: [AttributeFilterInput!]
 
   """
@@ -1678,8 +1684,6 @@ input ImplementationRevisionFilter {
   such TypeReference in ` + "`" + `Implementation.spec.requires` + "`" + ` in any of the sections: oneOf, anyOf or allOf.
   """
   requires: [TypeReferenceWithOptionalRevision]
-
-  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 }
 # lint-enable defined-types-are-used
 
@@ -12687,6 +12691,14 @@ func (ec *executionContext) unmarshalInputImplementationRevisionFilter(ctx conte
 			if err != nil {
 				return it, err
 			}
+		case "requiredTypeInstancesInjectionSatisfiedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requiredTypeInstancesInjectionSatisfiedBy"))
+			it.RequiredTypeInstancesInjectionSatisfiedBy, err = ec.unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "attributes":
 			var err error
 
@@ -12700,14 +12712,6 @@ func (ec *executionContext) unmarshalInputImplementationRevisionFilter(ctx conte
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requires"))
 			it.Requires, err = ec.unmarshalOTypeReferenceWithOptionalRevision2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReferenceWithOptionalRevision(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "requiredTypeInstancesInjectionSatisfiedBy":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requiredTypeInstancesInjectionSatisfiedBy"))
-			it.RequiredTypeInstancesInjectionSatisfiedBy, err = ec.unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -1678,11 +1678,13 @@ input ImplementationRevisionFilter {
   such TypeReference in ` + "`" + `Implementation.spec.requires` + "`" + ` in any of the sections: oneOf, anyOf or allOf.
   """
   requires: [TypeReferenceWithOptionalRevision]
+
+  requiredTypeInstancesInjectionSatisfiedBy: [TypeInstanceValue]
 }
 # lint-enable defined-types-are-used
 
 input TypeInstanceValue {
-  typeRef: TypeReferenceWithOptionalRevision
+  typeRef: TypeReferenceInput!
 
   """
   Currently not supported.
@@ -1694,6 +1696,11 @@ input TypeInstanceValue {
 input TypeReferenceWithOptionalRevision {
   path: NodePath!
   revision: Version
+}
+
+input TypeReferenceInput {
+  path: NodePath!
+  revision: Version!
 }
 
 input AttributeFilterInput {
@@ -12696,6 +12703,14 @@ func (ec *executionContext) unmarshalInputImplementationRevisionFilter(ctx conte
 			if err != nil {
 				return it, err
 			}
+		case "requiredTypeInstancesInjectionSatisfiedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requiredTypeInstancesInjectionSatisfiedBy"))
+			it.RequiredTypeInstancesInjectionSatisfiedBy, err = ec.unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -12772,7 +12787,7 @@ func (ec *executionContext) unmarshalInputTypeInstanceValue(ctx context.Context,
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("typeRef"))
-			it.TypeRef, err = ec.unmarshalOTypeReferenceWithOptionalRevision2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReferenceWithOptionalRevision(ctx, v)
+			it.TypeRef, err = ec.unmarshalNTypeReferenceInput2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReferenceInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -12781,6 +12796,34 @@ func (ec *executionContext) unmarshalInputTypeInstanceValue(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
 			it.Value, err = ec.unmarshalOAny2interface(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTypeReferenceInput(ctx context.Context, obj interface{}) (TypeReferenceInput, error) {
+	var it TypeReferenceInput
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "path":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+			it.Path, err = ec.unmarshalNNodePath2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "revision":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revision"))
+			it.Revision, err = ec.unmarshalNVersion2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -16116,6 +16159,11 @@ func (ec *executionContext) marshalNTypeReference2ᚖcapactᚗioᚋcapactᚋpkg�
 	return ec._TypeReference(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNTypeReferenceInput2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReferenceInput(ctx context.Context, v interface{}) (*TypeReferenceInput, error) {
+	res, err := ec.unmarshalInputTypeReferenceInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNTypeRevision2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeRevisionᚄ(ctx context.Context, sel ast.SelectionSet, v []*TypeRevision) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -16968,6 +17016,30 @@ func (ec *executionContext) unmarshalOTypeFilter2ᚖcapactᚗioᚋcapactᚋpkg�
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx context.Context, v interface{}) ([]*TypeInstanceValue, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*TypeInstanceValue, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOTypeInstanceValue2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValueᚄ(ctx context.Context, v interface{}) ([]*TypeInstanceValue, error) {
 	if v == nil {
 		return nil, nil
@@ -16990,6 +17062,14 @@ func (ec *executionContext) unmarshalOTypeInstanceValue2ᚕᚖcapactᚗioᚋcapa
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) unmarshalOTypeInstanceValue2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeInstanceValue(ctx context.Context, v interface{}) (*TypeInstanceValue, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTypeInstanceValue(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOTypeReference2ᚖcapactᚗioᚋcapactᚋpkgᚋhubᚋapiᚋgraphqlᚋpublicᚐTypeReference(ctx context.Context, sel ast.SelectionSet, v *TypeReference) graphql.Marshaler {

--- a/pkg/hub/client/policy_enforced_client.go
+++ b/pkg/hub/client/policy_enforced_client.go
@@ -216,7 +216,7 @@ func (e *PolicyEnforcedClient) resolvePolicyTIMetadataIfShould(ctx context.Conte
 		return nil
 	}
 
-	err := e.mergedPolicy.ResolveTypeInstanceMetadata(ctx, e.hubCli)
+	err := policy.ResolveTypeInstanceMetadata(ctx, e.hubCli, &e.mergedPolicy)
 	if err != nil {
 		return errors.Wrap(err, "while resolving TypeInstance metadata for Policy")
 	}

--- a/pkg/hub/client/policy_enforced_client.go
+++ b/pkg/hub/client/policy_enforced_client.go
@@ -64,13 +64,13 @@ func (e *PolicyEnforcedClient) ListImplementationRevisionForInterface(ctx contex
 		return nil, policy.Rule{}, nil
 	}
 
-	typeInstanceValues, err := e.listCurrentTypeInstanceValues(ctx)
+	allTypeInstances, err := e.listAllTypeInstanceValues(ctx)
 	if err != nil {
 		return nil, policy.Rule{}, err
 	}
-	typeInstanceValues = append(typeInstanceValues, e.constantTypeInstanceValues()...)
+	allTypeInstances = append(allTypeInstances, e.constantTypeInstanceValues()...)
 
-	implementations, rule, err := e.findImplementationsForRules(ctx, interfaceRef, rules, typeInstanceValues)
+	implementations, rule, err := e.findImplementationsForRules(ctx, interfaceRef, rules, allTypeInstances)
 	if err != nil {
 		return nil, policy.Rule{}, err
 	}
@@ -228,11 +228,10 @@ func (e *PolicyEnforcedClient) findImplementationsForRules(
 	ctx context.Context,
 	interfaceRef hubpublicgraphql.InterfaceReference,
 	rules policy.RulesForInterface,
-	currentTypeInstances []*hubpublicgraphql.TypeInstanceValue,
+	allTypeInstances []*hubpublicgraphql.TypeInstanceValue,
 ) ([]hubpublicgraphql.ImplementationRevision, policy.Rule, error) {
 	for _, rule := range rules.OneOf {
-		filter := e.implementationConstraintsToHubFilter(rule.ImplementationConstraints)
-		filter.RequirementsSatisfiedBy = currentTypeInstances
+		filter := e.hubFilterForPolicyRule(rule, allTypeInstances)
 
 		implementations, err := e.hubCli.ListImplementationRevisionsForInterface(
 			ctx,
@@ -277,8 +276,10 @@ func (e *PolicyEnforcedClient) findAliasForTypeInstance(typeInstance policy.Requ
 	return "", false
 }
 
-func (e *PolicyEnforcedClient) implementationConstraintsToHubFilter(constraints policy.ImplementationConstraints) hubpublicgraphql.ImplementationRevisionFilter {
+func (e *PolicyEnforcedClient) hubFilterForPolicyRule(rule policy.Rule, allTypeInstances []*hubpublicgraphql.TypeInstanceValue) hubpublicgraphql.ImplementationRevisionFilter {
 	filter := hubpublicgraphql.ImplementationRevisionFilter{}
+
+	constraints := rule.ImplementationConstraints
 
 	// Path
 	if constraints.Path != nil {
@@ -305,6 +306,24 @@ func (e *PolicyEnforcedClient) implementationConstraintsToHubFilter(constraints 
 				Revision: attrConstraint.Revision,
 			})
 		}
+	}
+
+	// Requirements
+	filter.RequirementsSatisfiedBy = allTypeInstances
+
+	// Requirements Injection
+	if rule.Inject != nil {
+		var injectedRequiredTypeInstances []*hubpublicgraphql.TypeInstanceValue
+		for _, ti := range rule.Inject.RequiredTypeInstances {
+			injectedRequiredTypeInstances = append(injectedRequiredTypeInstances, &hubpublicgraphql.TypeInstanceValue{
+				TypeRef: &hubpublicgraphql.TypeReferenceInput{
+					Path:     ti.TypeRef.Path,
+					Revision: ti.TypeRef.Revision,
+				},
+				Value: nil, // not supported right now
+			})
+		}
+		filter.RequiredTypeInstancesInjectionSatisfiedBy = injectedRequiredTypeInstances
 	}
 
 	return filter
@@ -334,7 +353,7 @@ func (e *PolicyEnforcedClient) isTypeRefValidAndEqual(typeInstance policy.Requir
 	return true
 }
 
-func (e *PolicyEnforcedClient) listCurrentTypeInstanceValues(ctx context.Context) ([]*hubpublicgraphql.TypeInstanceValue, error) {
+func (e *PolicyEnforcedClient) listAllTypeInstanceValues(ctx context.Context) ([]*hubpublicgraphql.TypeInstanceValue, error) {
 	currentTypeInstancesTypeRef, err := e.hubCli.ListTypeInstancesTypeRef(ctx)
 	if err != nil {
 		return nil, err
@@ -351,9 +370,9 @@ func (e *PolicyEnforcedClient) typeInstancesToTypeInstanceValues(in []hublocalgr
 	for i := range in {
 		typeRef := in[i]
 		out = append(out, &hubpublicgraphql.TypeInstanceValue{
-			TypeRef: &hubpublicgraphql.TypeReferenceWithOptionalRevision{
+			TypeRef: &hubpublicgraphql.TypeReferenceInput{
 				Path:     typeRef.Path,
-				Revision: &typeRef.Revision,
+				Revision: typeRef.Revision,
 			},
 		})
 	}
@@ -365,8 +384,9 @@ func (e *PolicyEnforcedClient) typeInstancesToTypeInstanceValues(in []hublocalgr
 func (e *PolicyEnforcedClient) constantTypeInstanceValues() []*hubpublicgraphql.TypeInstanceValue {
 	return []*hubpublicgraphql.TypeInstanceValue{
 		{
-			TypeRef: &hubpublicgraphql.TypeReferenceWithOptionalRevision{
-				Path: "cap.core.type.platform.kubernetes",
+			TypeRef: &hubpublicgraphql.TypeReferenceInput{
+				Path:     "cap.core.type.platform.kubernetes",
+				Revision: "0.1.0",
 			},
 		},
 	}

--- a/pkg/hub/client/policy_enforced_client_test.go
+++ b/pkg/hub/client/policy_enforced_client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"capact.io/capact/internal/cli/heredoc"
+
 	"capact.io/capact/pkg/hub/client/fake"
 	"github.com/stretchr/testify/require"
 
@@ -154,7 +156,11 @@ func TestPolicyEnforcedClient_ListTypeInstancesToInjectBasedOnPolicy(t *testing.
 					},
 				},
 			},
-			expectedErrMessage: ptr.String("while validating Policy rule: while validating TypeInstance metadata for Policy: 1 error occurred:\n\t* missing Type reference for TypeInstance \"my-uuid\" (description: \"My UUID\")\n\n"),
+			expectedErrMessage: ptr.String(
+				heredoc.Doc(`
+				while validating Policy rule: while validating TypeInstance metadata for Policy: 1 error occurred:
+					* missing Type reference for TypeInstance "my-uuid" (description: "My UUID")`),
+			),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/hub/client/public/filter.go
+++ b/pkg/hub/client/public/filter.go
@@ -20,6 +20,8 @@ func FilterImplementationRevisions(revs []gqlpublicapi.ImplementationRevision, o
 	revs = filterImplementationRevisionsByRequirementsSatisfiedBy(revs, opts.requirementsSatisfiedBy)
 	revs = filterImplementationRevisionsByRequires(revs, opts.requires)
 
+	// TODO: Filter by requiredTypeInstances injection
+
 	return revs
 }
 
@@ -40,7 +42,7 @@ func filterImplementationRevisionsByPathPattern(revs []gqlpublicapi.Implementati
 	return out
 }
 
-func filterImplementationRevisionsByRequirementsSatisfiedBy(revs []gqlpublicapi.ImplementationRevision, requirementsSatisfiedBy map[string]*string) []gqlpublicapi.ImplementationRevision {
+func filterImplementationRevisionsByRequirementsSatisfiedBy(revs []gqlpublicapi.ImplementationRevision, requirementsSatisfiedBy map[string]string) []gqlpublicapi.ImplementationRevision {
 	if len(requirementsSatisfiedBy) == 0 {
 		return revs
 	}
@@ -124,7 +126,7 @@ func filterImplementationRevisionsByRequires(revs []gqlpublicapi.ImplementationR
 	return out
 }
 
-func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]*string) bool {
+func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
@@ -146,7 +148,7 @@ func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequire
 	return satisfiedCnt == 1
 }
 
-func atLeastOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]*string) bool {
+func atLeastOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
@@ -163,7 +165,7 @@ func atLeastOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequ
 	return false
 }
 
-func allRequirementsAreSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]*string) bool {
+func allRequirementsAreSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
@@ -213,7 +215,7 @@ func containsAtLeastOne(attr []*gqlpublicapi.AttributeRevision, expAttr map[stri
 			continue
 		}
 
-		if contains(expAttr, atr.Metadata.Path, atr.Revision) {
+		if containsForOptionalRevision(expAttr, atr.Metadata.Path, atr.Revision) {
 			return true
 		}
 	}
@@ -229,7 +231,7 @@ func containsAll(attr []*gqlpublicapi.AttributeRevision, expAttr map[string]*str
 			continue
 		}
 
-		if contains(expAttr, atr.Metadata.Path, atr.Revision) {
+		if containsForOptionalRevision(expAttr, atr.Metadata.Path, atr.Revision) {
 			matchedEntities++
 		}
 	}
@@ -237,13 +239,22 @@ func containsAll(attr []*gqlpublicapi.AttributeRevision, expAttr map[string]*str
 	return len(expAttr) == matchedEntities
 }
 
-func contains(attr map[string]*string, path, rev string) bool {
+func containsForOptionalRevision(attr map[string]*string, path, rev string) bool {
 	revision, found := attr[path]
 	if !found {
 		return false
 	}
 
 	if revision != nil && *revision != rev {
+		return false
+	}
+
+	return true
+}
+
+func contains(attr map[string]string, path, rev string) bool {
+	revision, found := attr[path]
+	if !found || revision != rev {
 		return false
 	}
 

--- a/pkg/hub/client/public/filter.go
+++ b/pkg/hub/client/public/filter.go
@@ -17,9 +17,8 @@ func FilterImplementationRevisions(revs []gqlpublicapi.ImplementationRevision, o
 
 	revs = filterImplementationRevisionsByPathPattern(revs, opts.implPathPattern)
 	revs = filterImplementationRevisionsByAttr(revs, opts.attrFilter)
-	revs = filterImplementationRevisionsByRequirementsSatisfiedBy(revs, opts.requirementsSatisfiedBy)
+	revs = filterImplementationRevisionsByRequirementsSatisfiedBy(revs, opts.requirementsSatisfiedBy, opts.requiredTIInjectionSatisfiedBy)
 	revs = filterImplementationRevisionsByRequires(revs, opts.requires)
-	revs = filterImplementationRevisionsByRequiredTypeInstancesInjection(revs, opts.requiredTIInjectionSatisfiedBy)
 
 	return revs
 }
@@ -41,7 +40,7 @@ func filterImplementationRevisionsByPathPattern(revs []gqlpublicapi.Implementati
 	return out
 }
 
-func filterImplementationRevisionsByRequirementsSatisfiedBy(revs []gqlpublicapi.ImplementationRevision, requirementsSatisfiedBy map[string]string) []gqlpublicapi.ImplementationRevision {
+func filterImplementationRevisionsByRequirementsSatisfiedBy(revs []gqlpublicapi.ImplementationRevision, requirementsSatisfiedBy map[string]string, requiredTIInjectionSatisfiedBy map[string]string) []gqlpublicapi.ImplementationRevision {
 	if len(requirementsSatisfiedBy) == 0 {
 		return revs
 	}
@@ -60,17 +59,17 @@ requirements:
 		}
 
 		for _, req := range impl.Spec.Requires {
-			satisfied := allRequirementsAreSatisfied(req.AllOf, requirementsSatisfiedBy)
+			satisfied := allRequirementsAreSatisfied(req.AllOf, requirementsSatisfiedBy, requiredTIInjectionSatisfiedBy)
 			if !satisfied {
 				continue requirements
 			}
 
-			atLeastOneSatisfied := atLeastOneRequirementIsSatisfied(req.AnyOf, requirementsSatisfiedBy)
+			atLeastOneSatisfied := atLeastOneRequirementIsSatisfied(req.AnyOf, requirementsSatisfiedBy, requiredTIInjectionSatisfiedBy)
 			if !atLeastOneSatisfied {
 				continue requirements
 			}
 
-			onlyOneSatisfied := onlyOneRequirementIsSatisfied(req.OneOf, requirementsSatisfiedBy)
+			onlyOneSatisfied := onlyOneRequirementIsSatisfied(req.OneOf, requirementsSatisfiedBy, requiredTIInjectionSatisfiedBy)
 			if !onlyOneSatisfied {
 				continue requirements
 			}
@@ -125,57 +124,26 @@ func filterImplementationRevisionsByRequires(revs []gqlpublicapi.ImplementationR
 	return out
 }
 
-func filterImplementationRevisionsByRequiredTypeInstancesInjection(revs []gqlpublicapi.ImplementationRevision, requiredTIInjectionSatisfiedBy map[string]string) []gqlpublicapi.ImplementationRevision {
-	var out []gqlpublicapi.ImplementationRevision
-
-reqInjection:
-	for _, impl := range revs {
-		if impl.Spec == nil {
-			continue
-		}
-
-		if len(impl.Spec.Requires) == 0 {
-			out = append(out, impl)
-			continue
-		}
-
-		for _, req := range impl.Spec.Requires {
-
-			satisfied := allRequiredTypeInstancesInjectionsAreSatisfied(req.AllOf, requiredTIInjectionSatisfiedBy)
-			if !satisfied {
-				continue reqInjection
-			}
-
-			atLeastOneSatisfied := atLeastOneRequiredTypeInstancesInjectionIsSatisfied(req.AnyOf, requiredTIInjectionSatisfiedBy)
-			if !atLeastOneSatisfied {
-				continue reqInjection
-			}
-
-			onlyOneSatisfied := onlyOneRequiredTypeInstancesInjectionIsSatisfied(req.OneOf, requiredTIInjectionSatisfiedBy)
-			if !onlyOneSatisfied {
-				continue reqInjection
-			}
-		}
-
-		out = append(out, impl)
-	}
-	return out
-}
-
-func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
+func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq, requiredTIInjectionSatisfiedBy map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
 
 	satisfiedCnt := 0
-	for _, all := range implReq {
-		if all.TypeRef == nil {
+	for _, item := range implReq {
+		if item.TypeRef == nil {
 			continue
 		}
-		satisfied := contains(availableReq, all.TypeRef.Path, all.TypeRef.Revision)
-		if satisfied {
+		satisfied := contains(availableReq, item.TypeRef.Path, item.TypeRef.Revision)
+		if !satisfied {
+			continue
+		}
+
+		// required TypeInstance injection
+		if item.Alias == nil || contains(requiredTIInjectionSatisfiedBy, item.TypeRef.Path, item.TypeRef.Revision) {
 			satisfiedCnt++
 		}
+
 		if satisfiedCnt > 1 {
 			return false
 		}
@@ -184,73 +152,55 @@ func onlyOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequire
 	return satisfiedCnt == 1
 }
 
-func atLeastOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
+func atLeastOneRequirementIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq, requiredTIInjectionSatisfiedBy map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
 
-	for _, all := range implReq {
-		if all.TypeRef == nil {
+	for _, item := range implReq {
+		if item.TypeRef == nil {
 			continue
 		}
-		satisfied := contains(availableReq, all.TypeRef.Path, all.TypeRef.Revision)
-		if satisfied {
+		satisfied := contains(availableReq, item.TypeRef.Path, item.TypeRef.Revision)
+		if !satisfied {
+			continue
+		}
+
+		// required TypeInstance injection
+		if item.Alias == nil || contains(requiredTIInjectionSatisfiedBy, item.TypeRef.Path, item.TypeRef.Revision) {
 			return true
 		}
 	}
+
 	return false
 }
 
-func allRequirementsAreSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq map[string]string) bool {
-	if len(implReq) == 0 {
-		return true
-	}
-
-	for _, all := range implReq {
-		if all.TypeRef == nil {
-			continue
-		}
-		satisfied := contains(availableReq, all.TypeRef.Path, all.TypeRef.Revision)
-		if !satisfied { // all needs to be satisfied so we can already give up
-			return false
-		}
-	}
-	return true
-}
-
-func allRequiredTypeInstancesInjectionsAreSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, requiredTIInjectionSatisfiedBy map[string]string) bool {
+func allRequirementsAreSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, availableReq, requiredTIInjectionSatisfiedBy map[string]string) bool {
 	if len(implReq) == 0 {
 		return true
 	}
 
 	for _, item := range implReq {
+		if item.TypeRef == nil {
+			continue
+		}
+		satisfied := contains(availableReq, item.TypeRef.Path, item.TypeRef.Revision)
+		if !satisfied { // all needs to be satisfied, so we can already give up
+			return false
+		}
+
+		// required TypeInstance injection
 		if item.Alias == nil {
+			// no injection needed
 			continue
 		}
 
 		if !contains(requiredTIInjectionSatisfiedBy, item.TypeRef.Path, item.TypeRef.Revision) {
+			// injection needed and TypeInstance for injection not found
 			return false
 		}
 	}
-
 	return true
-}
-
-func atLeastOneRequiredTypeInstancesInjectionIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, requiredTIInjectionSatisfiedBy map[string]string) bool {
-	for _, item := range implReq {
-		if item.Alias == nil {
-			// satisfied
-			return true
-		}
-
-		if !contains(requiredTIInjectionSatisfiedBy, item.TypeRef.Path, item.TypeRef.Revision) {
-			continue req
-		}
-	}
-}
-
-func onlyOneRequiredTypeInstancesInjectionIsSatisfied(implReq []*gqlpublicapi.ImplementationRequirementItem, requiredTIInjectionSatisfiedBy map[string]string) bool {
-
 }
 
 func filterImplementationRevisionsByAttr(revs []gqlpublicapi.ImplementationRevision, attrFilter map[gqlpublicapi.FilterRule]map[string]*string) []gqlpublicapi.ImplementationRevision {

--- a/pkg/hub/client/public/filter_test.go
+++ b/pkg/hub/client/public/filter_test.go
@@ -194,6 +194,37 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 						},
 					},
 				}),
+				fixImplementationRevisionWithRequire("any-of", "0.1.0", gqlpublicapi.ImplementationRequirement{
+					Prefix: "cap.core.type.platform",
+					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.not-existing",
+								Revision: "0.1.0",
+							},
+						},
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.sample",
+								Revision: "0.1.0",
+							},
+						},
+					},
+					OneOf: []*gqlpublicapi.ImplementationRequirementItem{
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.not-existing",
+								Revision: "0.1.0",
+							},
+						},
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.sample",
+								Revision: "0.1.0",
+							},
+						},
+					},
+				}),
 			},
 			revisionToFilterOut: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement-alias", "0.1.0", gqlpublicapi.ImplementationRequirement{
@@ -203,6 +234,23 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 							TypeRef: &gqlpublicapi.TypeReference{
 								Path:     "cap.core.type.platform.cf",
 								Revision: "0.1.1",
+							},
+						},
+					},
+				}),
+				fixImplementationRevisionWithRequire("any-of", "0.1.0", gqlpublicapi.ImplementationRequirement{
+					Prefix: "cap.core.type.platform",
+					OneOf: []*gqlpublicapi.ImplementationRequirementItem{
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.gcp.sa",
+								Revision: "0.1.1",
+							},
+						},
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.sample",
+								Revision: "0.1.0",
 							},
 						},
 					},

--- a/pkg/hub/client/public/filter_test.go
+++ b/pkg/hub/client/public/filter_test.go
@@ -122,9 +122,9 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 			},
 			requirementsSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
 				{
-					TypeRef: &gqlpublicapi.TypeReferenceWithOptionalRevision{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
 						Path:     "cap.type.gcp.sa",
-						Revision: ptr.String("0.1.1"),
+						Revision: "0.1.1",
 					},
 				},
 			},
@@ -159,9 +159,9 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 			},
 			requirementsSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
 				{
-					TypeRef: &gqlpublicapi.TypeReferenceWithOptionalRevision{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
 						Path:     "cap.type.gcp.sa",
-						Revision: ptr.String("0.1.1"),
+						Revision: "0.1.1",
 					},
 				},
 			},

--- a/pkg/hub/client/public/filter_test.go
+++ b/pkg/hub/client/public/filter_test.go
@@ -135,7 +135,6 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 			expRevision: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevision("without-any-requirements", "0.0.1"),
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AllOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -168,11 +167,10 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "Return Implementations satisfied by injected RequiredTypeInstances",
+			name: "Return Implementations satisfied by injected RequiredTypeInstances and requires satisfied by",
 			expRevision: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevision("without-any-requirements", "0.0.1"),
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AllOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							Alias: ptr.String("gcp-sa"),
@@ -184,7 +182,6 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AllOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -195,7 +192,6 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("any-of", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -239,7 +235,6 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("any-of", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					OneOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -280,6 +275,83 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 				{
 					TypeRef: &gqlpublicapi.TypeReferenceInput{
 						Path:     "cap.core.type.platform.cf",
+						Revision: "0.1.1",
+					},
+				},
+			},
+		},
+		{
+			name: "Return Implementations satisfied by injected RequiredTypeInstances without using `requirementsSatisfiedBy`",
+			expRevision: []gqlpublicapi.ImplementationRevision{
+				fixImplementationRevision("without-any-requirements", "0.0.1"),
+				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
+					AllOf: []*gqlpublicapi.ImplementationRequirementItem{
+						{
+							Alias: ptr.String("gcp-sa"),
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.gcp.sa",
+								Revision: "0.1.1",
+							},
+						},
+						{
+							Alias: ptr.String("aws-credentials"),
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.aws.credentials",
+								Revision: "0.1.0",
+							},
+						},
+					},
+				}),
+			},
+			requiredTIInjectionSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.type.gcp.sa",
+						Revision: "0.1.1",
+					},
+				},
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.type.aws.credentials",
+						Revision: "0.1.0",
+					},
+				},
+			},
+		},
+		{
+			name: "Return Implementations satisfied by injected RequiredTypeInstances without including them in `requirementsSatisfiedBy`",
+			expRevision: []gqlpublicapi.ImplementationRevision{
+				fixImplementationRevision("without-any-requirements", "0.0.1"),
+				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
+					AllOf: []*gqlpublicapi.ImplementationRequirementItem{
+						{
+							Alias: ptr.String("gcp-sa"),
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.type.gcp.sa",
+								Revision: "0.1.1",
+							},
+						},
+						{
+							TypeRef: &gqlpublicapi.TypeReference{
+								Path:     "cap.core.type.platform.kubernetes",
+								Revision: "0.1.1",
+							},
+						},
+					},
+				}),
+			},
+			requiredTIInjectionSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.type.gcp.sa",
+						Revision: "0.1.1",
+					},
+				},
+			},
+			requirementsSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.core.type.platform.kubernetes",
 						Revision: "0.1.1",
 					},
 				},
@@ -354,7 +426,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 			name: "Return Implementations that requires GCP SA",
 			expRevision: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.1", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -365,7 +436,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("with-multiple-requirements", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -395,7 +465,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement-diff-version", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					OneOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -417,7 +486,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 			name: "Return Implementations that has GCP SA and AWS subscription without revision in `requires` section",
 			expRevision: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevisionWithRequire("with-multiple-requirements", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -437,7 +505,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 			},
 			revisionToFilterOut: []gqlpublicapi.ImplementationRevision{
 				fixImplementationRevisionWithRequire("with-aws-subscription-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -448,7 +515,6 @@ func TestImplementationRequiresFilters(t *testing.T) {
 					},
 				}),
 				fixImplementationRevisionWithRequire("with-gcp-sa-requirement", "0.1.0", gqlpublicapi.ImplementationRequirement{
-					Prefix: "cap.core.type.platform",
 					AnyOf: []*gqlpublicapi.ImplementationRequirementItem{
 						{
 							TypeRef: &gqlpublicapi.TypeReference{
@@ -531,8 +597,7 @@ func fixImplementationRevisionWithAttr(implPath, implRev, attrPath, attrRev stri
 func fixImplementationRevision(path, rev string) gqlpublicapi.ImplementationRevision {
 	return gqlpublicapi.ImplementationRevision{
 		Metadata: &gqlpublicapi.ImplementationMetadata{
-			Path:   path,
-			Prefix: ptr.String(path),
+			Path: path,
 		},
 		Spec:     &gqlpublicapi.ImplementationSpec{},
 		Revision: rev,

--- a/pkg/hub/client/public/filter_test.go
+++ b/pkg/hub/client/public/filter_test.go
@@ -108,10 +108,11 @@ func TestImplementationAttributeFilters(t *testing.T) {
 
 func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 	tests := []struct {
-		name                    string
-		expRevision             []gqlpublicapi.ImplementationRevision
-		revisionToFilterOut     []gqlpublicapi.ImplementationRevision
-		requirementsSatisfiedBy []*gqlpublicapi.TypeInstanceValue
+		name                           string
+		expRevision                    []gqlpublicapi.ImplementationRevision
+		revisionToFilterOut            []gqlpublicapi.ImplementationRevision
+		requirementsSatisfiedBy        []*gqlpublicapi.TypeInstanceValue
+		requiredTIInjectionSatisfiedBy []*gqlpublicapi.TypeInstanceValue
 	}{
 		{
 			name: "Return all Implementations as they are without requirements",
@@ -166,39 +167,6 @@ func TestImplementationRequirementsSatisfiedByFilters(t *testing.T) {
 				},
 			},
 		},
-	}
-	for _, test := range tests {
-		tt := test
-		t.Run(tt.name, func(t *testing.T) {
-			// given
-			filter := gqlpublicapi.ImplementationRevisionFilter{
-				RequirementsSatisfiedBy: tt.requirementsSatisfiedBy,
-			}
-
-			getOpts := &ListImplementationRevisionsForInterfaceOptions{}
-			getOpts.Apply(WithFilter(filter))
-
-			allRevs := append(tt.expRevision, tt.revisionToFilterOut...)
-
-			// when
-			gotRevs := FilterImplementationRevisions(allRevs, getOpts)
-
-			// then
-			assert.Len(t, gotRevs, len(tt.expRevision))
-			for idx := range tt.expRevision {
-				assert.Contains(t, gotRevs, tt.expRevision[idx])
-			}
-		})
-	}
-}
-
-func TestImplementationRequiredTypeInstancesInjectionSatisfiedByFilters(t *testing.T) {
-	tests := []struct {
-		name                           string
-		expRevision                    []gqlpublicapi.ImplementationRevision
-		revisionToFilterOut            []gqlpublicapi.ImplementationRevision
-		requiredTIInjectionSatisfiedBy []*gqlpublicapi.TypeInstanceValue
-	}{
 		{
 			name: "Return Implementations satisfied by injected RequiredTypeInstances",
 			expRevision: []gqlpublicapi.ImplementationRevision{
@@ -247,10 +215,24 @@ func TestImplementationRequiredTypeInstancesInjectionSatisfiedByFilters(t *testi
 						Revision: "0.1.1",
 					},
 				},
+			},
+			requirementsSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.type.gcp.sa",
+						Revision: "0.1.1",
+					},
+				},
 				{
 					TypeRef: &gqlpublicapi.TypeReferenceInput{
 						Path:     "cap.type.sample",
 						Revision: "0.1.0",
+					},
+				},
+				{
+					TypeRef: &gqlpublicapi.TypeReferenceInput{
+						Path:     "cap.core.type.platform.cf",
+						Revision: "0.1.1",
 					},
 				},
 			},
@@ -261,6 +243,7 @@ func TestImplementationRequiredTypeInstancesInjectionSatisfiedByFilters(t *testi
 		t.Run(tt.name, func(t *testing.T) {
 			// given
 			filter := gqlpublicapi.ImplementationRevisionFilter{
+				RequirementsSatisfiedBy:                   tt.requirementsSatisfiedBy,
 				RequiredTypeInstancesInjectionSatisfiedBy: tt.requiredTIInjectionSatisfiedBy,
 			}
 

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -9,11 +9,12 @@ type ListImplementationRevisionsForInterfaceOption func(*ListImplementationRevis
 
 // ListImplementationRevisionsForInterfaceOptions stores Implementation Revision filtering parameters.
 type ListImplementationRevisionsForInterfaceOptions struct {
-	attrFilter                   map[gqlpublicapi.FilterRule]map[string]*string
-	implPathPattern              *string
-	requirementsSatisfiedBy      map[string]string
-	requires                     map[string]*string
-	sortByPathAscAndRevisionDesc bool
+	attrFilter                     map[gqlpublicapi.FilterRule]map[string]*string
+	implPathPattern                *string
+	requirementsSatisfiedBy        map[string]string
+	requiredTIInjectionSatisfiedBy map[string]string
+	requires                       map[string]*string
+	sortByPathAscAndRevisionDesc   bool
 }
 
 // Apply is used to configure the ListImplementationRevisionsForInterfaceOptions.

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -11,8 +11,8 @@ type ListImplementationRevisionsForInterfaceOption func(*ListImplementationRevis
 type ListImplementationRevisionsForInterfaceOptions struct {
 	attrFilter                     map[gqlpublicapi.FilterRule]map[string]*string
 	implPathPattern                *string
-	requirementsSatisfiedBy        map[string]string
-	requiredTIInjectionSatisfiedBy map[string]string
+	requirementsSatisfiedBy        map[gqlpublicapi.TypeReference]struct{}
+	requiredTIInjectionSatisfiedBy map[gqlpublicapi.TypeReference]struct{}
 	requires                       map[string]*string
 	sortByPathAscAndRevisionDesc   bool
 }
@@ -47,23 +47,32 @@ func WithFilter(filter gqlpublicapi.ImplementationRevisionFilter) ListImplementa
 
 		// 3. Process TypeInstances, which should satisfy requirements
 		if len(filter.RequirementsSatisfiedBy) > 0 {
-			opt.requirementsSatisfiedBy = make(map[string]string)
+			opt.requirementsSatisfiedBy = make(map[gqlpublicapi.TypeReference]struct{})
 			for _, req := range filter.RequirementsSatisfiedBy {
 				if req.TypeRef == nil {
 					continue
 				}
-				opt.requirementsSatisfiedBy[req.TypeRef.Path] = req.TypeRef.Revision
+				typeRef := gqlpublicapi.TypeReference{
+					Path:     req.TypeRef.Path,
+					Revision: req.TypeRef.Revision,
+				}
+				opt.requirementsSatisfiedBy[typeRef] = struct{}{}
 			}
 		}
 
 		// 4. Process TypeInstances which should satisfy required TypeInstances injection
 		if len(filter.RequiredTypeInstancesInjectionSatisfiedBy) > 0 {
-			opt.requiredTIInjectionSatisfiedBy = make(map[string]string)
+			opt.requiredTIInjectionSatisfiedBy = make(map[gqlpublicapi.TypeReference]struct{})
 			for _, req := range filter.RequiredTypeInstancesInjectionSatisfiedBy {
 				if req.TypeRef == nil {
 					continue
 				}
-				opt.requiredTIInjectionSatisfiedBy[req.TypeRef.Path] = req.TypeRef.Revision
+
+				typeRef := gqlpublicapi.TypeReference{
+					Path:     req.TypeRef.Path,
+					Revision: req.TypeRef.Revision,
+				}
+				opt.requiredTIInjectionSatisfiedBy[typeRef] = struct{}{}
 			}
 		}
 

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -63,6 +63,10 @@ func WithFilter(filter gqlpublicapi.ImplementationRevisionFilter) ListImplementa
 		// 4. Process TypeInstances which should satisfy required TypeInstances injection
 		if len(filter.RequiredTypeInstancesInjectionSatisfiedBy) > 0 {
 			opt.requiredTIInjectionSatisfiedBy = make(map[gqlpublicapi.TypeReference]struct{})
+			if opt.requirementsSatisfiedBy == nil {
+				opt.requirementsSatisfiedBy = make(map[gqlpublicapi.TypeReference]struct{})
+			}
+
 			for _, req := range filter.RequiredTypeInstancesInjectionSatisfiedBy {
 				if req.TypeRef == nil {
 					continue

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -56,7 +56,18 @@ func WithFilter(filter gqlpublicapi.ImplementationRevisionFilter) ListImplementa
 			}
 		}
 
-		// 4. Process TypeInstances, which should be defined in `requires` section
+		// 4. Process TypeInstances which should satisfy required TypeInstances injection
+		if len(filter.RequiredTypeInstancesInjectionSatisfiedBy) > 0 {
+			opt.requiredTIInjectionSatisfiedBy = make(map[string]string)
+			for _, req := range filter.RequiredTypeInstancesInjectionSatisfiedBy {
+				if req.TypeRef == nil {
+					continue
+				}
+				opt.requiredTIInjectionSatisfiedBy[req.TypeRef.Path] = req.TypeRef.Revision
+			}
+		}
+
+		// 5. Process TypeInstances, which should be defined in `requires` section
 		if len(filter.Requires) > 0 {
 			opt.requires = map[string]*string{}
 			for _, req := range filter.Requires {

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -11,7 +11,7 @@ type ListImplementationRevisionsForInterfaceOption func(*ListImplementationRevis
 type ListImplementationRevisionsForInterfaceOptions struct {
 	attrFilter                   map[gqlpublicapi.FilterRule]map[string]*string
 	implPathPattern              *string
-	requirementsSatisfiedBy      map[string]*string
+	requirementsSatisfiedBy      map[string]string
 	requires                     map[string]*string
 	sortByPathAscAndRevisionDesc bool
 }
@@ -46,7 +46,7 @@ func WithFilter(filter gqlpublicapi.ImplementationRevisionFilter) ListImplementa
 
 		// 3. Process TypeInstances, which should satisfy requirements
 		if len(filter.RequirementsSatisfiedBy) > 0 {
-			opt.requirementsSatisfiedBy = map[string]*string{}
+			opt.requirementsSatisfiedBy = make(map[string]string)
 			for _, req := range filter.RequirementsSatisfiedBy {
 				if req.TypeRef == nil {
 					continue

--- a/pkg/hub/client/public/impl_options.go
+++ b/pkg/hub/client/public/impl_options.go
@@ -73,6 +73,9 @@ func WithFilter(filter gqlpublicapi.ImplementationRevisionFilter) ListImplementa
 					Revision: req.TypeRef.Revision,
 				}
 				opt.requiredTIInjectionSatisfiedBy[typeRef] = struct{}{}
+
+				// append to RequirementsSatisfiedBy as well
+				opt.requirementsSatisfiedBy[typeRef] = struct{}{}
 			}
 		}
 

--- a/pkg/sdk/renderer/argo/fixtures_test.go
+++ b/pkg/sdk/renderer/argo/fixtures_test.go
@@ -70,29 +70,6 @@ func fixAWSGlobalPolicy(additionalParameters ...policy.AdditionalParametersToInj
 					Revision: ptr.String("0.1.0"),
 				},
 				OneOf: []policy.Rule{
-
-					{
-						ImplementationConstraints: policy.ImplementationConstraints{
-							Requires: &[]types.ManifestRefWithOptRevision{
-								{
-									Path:     "cap.type.aws.auth.credentials",
-									Revision: ptr.String("0.1.0"),
-								},
-							},
-							Attributes: &[]types.ManifestRefWithOptRevision{
-								{
-									Path: "cap.attribute.cloud.provider.aws",
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				Interface: types.ManifestRefWithOptRevision{
-					Path: "cap.interface.aws.rds.postgresql.provision",
-				},
-				OneOf: []policy.Rule{
 					{
 						ImplementationConstraints: policy.ImplementationConstraints{
 							Requires: &[]types.ManifestRefWithOptRevision{
@@ -112,16 +89,11 @@ func fixAWSGlobalPolicy(additionalParameters ...policy.AdditionalParametersToInj
 								{
 									RequiredTypeInstanceReference: policy.RequiredTypeInstanceReference{
 										ID:          "517cf827-233c-4bf1-8fc9-48534424dd58",
-										Description: ptr.String("GCP SA"),
+										Description: ptr.String("AWS Credentials"),
 									},
 								},
 							},
 							AdditionalParameters: additionalParameters,
-						},
-					},
-					{
-						ImplementationConstraints: policy.ImplementationConstraints{
-							Path: ptr.String("cap.implementation.bitnami.postgresql.install"),
 						},
 					},
 				},
@@ -163,11 +135,27 @@ func fixGlobalPolicyForFallback() policy.Policy {
 								{
 									RequiredTypeInstanceReference: policy.RequiredTypeInstanceReference{
 										ID:          "517cf827-233c-4bf1-8fc9-48534424dd58",
-										Description: ptr.String("GCP SA"),
+										Description: ptr.String("AWS Credentials"),
 									},
 								},
 							},
 						},
+					},
+					{
+						ImplementationConstraints: policy.ImplementationConstraints{
+							Requires: &[]types.ManifestRefWithOptRevision{
+								{
+									Path:     "cap.type.aws.auth.credentials",
+									Revision: ptr.String("0.1.0"),
+								},
+							},
+							Attributes: &[]types.ManifestRefWithOptRevision{
+								{
+									Path: "cap.attribute.cloud.provider.aws",
+								},
+							},
+						},
+						// No injects, even if the requirements are satisfied this Implementation should be ignored
 					},
 					{
 						ImplementationConstraints: policy.ImplementationConstraints{

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -427,8 +427,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-3-0-step
-          template: inject-input-type-instances-3-0
+          name: inject-input-type-instances-4-0-step
+          template: inject-input-type-instances-4-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -865,7 +865,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-3-0
+      name: inject-input-type-instances-4-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -426,6 +426,9 @@ args:
         - from: '{{steps.render-rds.outputs.artifacts.render}}'
           name: rds-instance
       steps:
+      - - arguments: {}
+          name: inject-input-type-instances-3-0-step
+          template: inject-input-type-instances-3-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -851,6 +854,23 @@ args:
         - globalName: mattermost-install-install-db-rds-instance
           name: rds-instance
           path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{517cf827-233c-4bf1-8fc9-48534424dd58,/aws-credentials.yaml}'
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-3-0
+      outputs:
+        artifacts:
+        - globalName: aws-credentials
+          name: aws-credentials
+          path: /aws-credentials.yaml
     - inputs:
         artifacts:
         - name: postgresql

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -117,6 +117,9 @@ args:
         - from: '{{steps.render-rds.outputs.artifacts.render}}'
           name: rds-instance
       steps:
+      - - arguments: {}
+          name: inject-input-type-instances-5-0-step
+          template: inject-input-type-instances-5-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -542,6 +545,23 @@ args:
         - globalName: app1-install-install-db-rds-instance
           name: rds-instance
           path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{517cf827-233c-4bf1-8fc9-48534424dd58,/aws-credentials.yaml}'
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-5-0
+      outputs:
+        artifacts:
+        - globalName: aws-credentials
+          name: aws-credentials
+          path: /aws-credentials.yaml
     - inputs:
         artifacts:
         - name: postgresql

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -118,8 +118,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-5-0-step
-          template: inject-input-type-instances-5-0
+          name: inject-input-type-instances-6-0-step
+          template: inject-input-type-instances-6-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -556,7 +556,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-5-0
+      name: inject-input-type-instances-6-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -117,6 +117,9 @@ args:
         - from: '{{steps.render-rds.outputs.artifacts.render}}'
           name: rds-instance
       steps:
+      - - arguments: {}
+          name: inject-input-type-instances-6-0-step
+          template: inject-input-type-instances-6-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -542,6 +545,23 @@ args:
         - globalName: main-install-db-rds-instance
           name: rds-instance
           path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{517cf827-233c-4bf1-8fc9-48534424dd58,/aws-credentials.yaml}'
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-6-0
+      outputs:
+        artifacts:
+        - globalName: aws-credentials
+          name: aws-credentials
+          path: /aws-credentials.yaml
     - inputs:
         artifacts:
         - name: postgresql

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -118,8 +118,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-6-0-step
-          template: inject-input-type-instances-6-0
+          name: inject-input-type-instances-7-0-step
+          template: inject-input-type-instances-7-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -556,7 +556,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-6-0
+      name: inject-input-type-instances-7-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/validation/action/io_validator.go
+++ b/pkg/sdk/validation/action/io_validator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"capact.io/capact/internal/multierror"
+
 	"capact.io/capact/internal/ctxutil"
 	"capact.io/capact/internal/ptr"
 	gqllocalapi "capact.io/capact/pkg/hub/api/graphql/local"
@@ -12,7 +14,6 @@ import (
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"capact.io/capact/pkg/sdk/validation"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/valyala/fastjson"
 	"github.com/xeipuuv/gojsonschema"
@@ -327,7 +328,7 @@ func (c *InputOutputValidator) resolveTypeRefsToJSONSchemas(ctx context.Context,
 	}
 
 	var (
-		merr    = &multierror.Error{ErrorFormat: listFormatFunc}
+		merr    = multierror.New()
 		schemas = validation.SchemaCollection{}
 	)
 	for name, ref := range inTypeRefs {
@@ -378,24 +379,4 @@ func (c *InputOutputValidator) implHasNoInputInstances(impl gqlpublicapi.Impleme
 	}
 
 	return false
-}
-
-// listFormatFunc is a basic formatter that outputs the number of errors
-// that occurred along with a bullet point list of the errors.
-//
-// it's a copy of https://github.com/hashicorp/go-multierror/blob/9974e9ec57696378079ecc3accd3d6f29401b3a0/format.go#L14
-// with removed additional two new lines (`\n\n`) added to error message.
-func listFormatFunc(es []error) string {
-	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\t* %s", es[0])
-	}
-
-	points := make([]string, len(es))
-	for i, err := range es {
-		points[i] = fmt.Sprintf("* %s", err)
-	}
-
-	return fmt.Sprintf(
-		"%d errors occurred:\n\t%s",
-		len(es), strings.Join(points, "\n\t"))
 }

--- a/pkg/sdk/validation/issue_builder.go
+++ b/pkg/sdk/validation/issue_builder.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"capact.io/capact/internal/multierror"
-	gomultierror "github.com/hashicorp/go-multierror"
+	multierr "github.com/hashicorp/go-multierror"
 )
 
 // IssueBuilder provides functionality to report issue by name and return aggregated result.
@@ -57,7 +57,7 @@ func (bldr *IssueBuilder) Result() Result {
 
 // headeredErrListFormatFunc is a basic formatter that outputs the errors as
 // a bullet point list with a given header.
-func headeredErrListFormatFunc(fieldName string) gomultierror.ErrorFormatFunc {
+func headeredErrListFormatFunc(fieldName string) multierr.ErrorFormatFunc {
 	return func(es []error) string {
 		points := make([]string, len(es))
 		for i, err := range es {

--- a/pkg/sdk/validation/issue_builder.go
+++ b/pkg/sdk/validation/issue_builder.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
+	"capact.io/capact/internal/multierror"
+	gomultierror "github.com/hashicorp/go-multierror"
 )
 
 // IssueBuilder provides functionality to report issue by name and return aggregated result.
@@ -56,7 +57,7 @@ func (bldr *IssueBuilder) Result() Result {
 
 // headeredErrListFormatFunc is a basic formatter that outputs the errors as
 // a bullet point list with a given header.
-func headeredErrListFormatFunc(fieldName string) multierror.ErrorFormatFunc {
+func headeredErrListFormatFunc(fieldName string) gomultierror.ErrorFormatFunc {
 	return func(es []error) string {
 		points := make([]string, len(es))
 		for i, err := range es {

--- a/pkg/sdk/validation/types.go
+++ b/pkg/sdk/validation/types.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
-	"github.com/hashicorp/go-multierror"
+	gomultierror "github.com/hashicorp/go-multierror"
 )
 
 // Result holds validation result indexed by name. For example, by TypeInstance name.
-type Result map[string]*multierror.Error
+type Result map[string]*gomultierror.Error
 
 type (
 	// Schema holds JSONSchema value and information if instance of this schema is required.

--- a/pkg/sdk/validation/types.go
+++ b/pkg/sdk/validation/types.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
-	gomultierror "github.com/hashicorp/go-multierror"
+	multierr "github.com/hashicorp/go-multierror"
 )
 
 // Result holds validation result indexed by name. For example, by TypeInstance name.
-type Result map[string]*gomultierror.Error
+type Result map[string]*multierr.Error
 
 type (
 	// Schema holds JSONSchema value and information if instance of this schema is required.

--- a/test/e2e/hub_test.go
+++ b/test/e2e/hub_test.go
@@ -148,9 +148,9 @@ var _ = Describe("GraphQL API", func() {
 				filter := gqlpublicapi.ImplementationRevisionFilter{
 					RequirementsSatisfiedBy: []*gqlpublicapi.TypeInstanceValue{
 						{
-							TypeRef: &gqlpublicapi.TypeReferenceWithOptionalRevision{
+							TypeRef: &gqlpublicapi.TypeReferenceInput{
 								Path:     "cap.core.type.platform.kubernetes",
-								Revision: ptr.String("0.1.0"),
+								Revision: "0.1.0",
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Filter Implementations which need missing required Type Instance injection
- Refactor Resolving Type References for Policy

## Notes

~This pull request bases on #452. Once #452 is merged, this PR will be rebased.~
Done

## Testing

No manual testing needed, as modified integration tests and unit tests (including renderer one) cover this case.

## Related issue(s)

https://github.com/capactio/capact/issues/438