### PR TITLE
Add Helm manifest gen

### DIFF
--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
@@ -1,0 +1,62 @@
+package implementation
+
+import (
+	"strings"
+
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var helmCfg manifestgen.HelmConfig
+
+// NewHelm returns a cobra.Command to bootstrap Helm based manifests.
+func NewHelm() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "helm [MANIFEST_PATH] [HELM_CHART_PATH]",
+		Short: "Generate Helm chart based manifests",
+		Long:  "Generate Helm based manifests based on a Helm chart",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return errors.New("accepts two arguments: [MANIFEST_PATH] [HELM_CHART_PATH]")
+			}
+
+			path := args[0]
+			if !strings.HasPrefix(path, "cap.implementation.") || len(strings.Split(path, ".")) < 4 {
+				return errors.New(`manifest path must be in format "cap.implementation.[PREFIX].[NAME]"`)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			helmCfg.ManifestPath = args[0]
+			helmCfg.ChartName = args[1]
+
+			files, err := manifestgen.GenerateHelmManifests(&helmCfg)
+			if err != nil {
+				return errors.Wrap(err, "while generating Helm manifests")
+			}
+
+			outputDir, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return errors.Wrap(err, "while reading output flag")
+			}
+
+			overrideManifests, err := cmd.Flags().GetBool("override")
+			if err != nil {
+				return errors.Wrap(err, "while overriding existing manifest")
+			}
+
+			if err := manifestgen.WriteManifestFiles(outputDir, files, overrideManifests); err != nil {
+				return errors.Wrap(err, "while writing manifest files")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&helmCfg.RepoURL, "repo", "r", "", "URL of the Helm repository")
+	cmd.Flags().StringVarP(&helmCfg.Version, "version", "v", "", "Version of the Helm chart")
+
+	return cmd
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
@@ -13,12 +13,12 @@ var helmCfg manifestgen.HelmConfig
 // NewHelm returns a cobra.Command to bootstrap Helm based manifests.
 func NewHelm() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "helm [MANIFEST_PATH] [HELM_CHART_PATH]",
+		Use:   "helm [MANIFEST_PATH] [HELM_CHART_NAME]",
 		Short: "Generate Helm chart based manifests",
 		Long:  "Generate Helm based manifests based on a Helm chart",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
-				return errors.New("accepts two arguments: [MANIFEST_PATH] [HELM_CHART_PATH]")
+				return errors.New("accepts two arguments: [MANIFEST_PATH] [HELM_CHART_NAME]")
 			}
 
 			path := args[0]
@@ -42,7 +42,7 @@ func NewHelm() *cobra.Command {
 				return errors.Wrap(err, "while reading output flag")
 			}
 
-			overrideManifests, err := cmd.Flags().GetBool("override")
+			overrideManifests, err := cmd.Flags().GetBool("overwrite")
 			if err != nil {
 				return errors.Wrap(err, "while overriding existing manifest")
 			}
@@ -55,7 +55,9 @@ func NewHelm() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&helmCfg.RepoURL, "repo", "r", "", "URL of the Helm repository")
+	cmd.Flags().StringVarP(&helmCfg.InterfacePathWithRevision, "interface", "i", "", "Path with revision of the Interface, which is implemented by this Implementation")
+	cmd.Flags().StringVarP(&helmCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Implementation manifest")
+	cmd.Flags().StringVar(&helmCfg.RepoURL, "repo", "", "URL of the Helm repository")
 	cmd.Flags().StringVarP(&helmCfg.Version, "version", "v", "", "Version of the Helm chart")
 
 	return cmd

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
@@ -15,7 +15,7 @@ func NewHelm() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "helm [MANIFEST_PATH] [HELM_CHART_NAME]",
 		Short: "Generate Helm chart based manifests",
-		Long:  "Generate Helm based manifests based on a Helm chart",
+		Long:  "Generate Implementation manifests based on a Helm chart",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
 				return errors.New("accepts two arguments: [MANIFEST_PATH] [HELM_CHART_NAME]")
@@ -57,8 +57,8 @@ func NewHelm() *cobra.Command {
 
 	cmd.Flags().StringVarP(&helmCfg.InterfacePathWithRevision, "interface", "i", "", "Path with revision of the Interface, which is implemented by this Implementation")
 	cmd.Flags().StringVarP(&helmCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Implementation manifest")
-	cmd.Flags().StringVar(&helmCfg.RepoURL, "repo", "", "URL of the Helm repository")
-	cmd.Flags().StringVarP(&helmCfg.Version, "version", "v", "", "Version of the Helm chart")
+	cmd.Flags().StringVar(&helmCfg.ChartRepoURL, "repo", "", "URL of the Helm repository")
+	cmd.Flags().StringVarP(&helmCfg.ChartVersion, "version", "v", "", "Version of the Helm chart")
 
 	return cmd
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/implementation.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/implementation.go
@@ -11,6 +11,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewTerraform())
+	cmd.AddCommand(NewHelm())
 
 	return cmd
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
@@ -13,14 +13,11 @@ import (
 var tfContentCfg manifestgen.TerraformConfig
 
 // NewTerraform returns a cobra.Command to bootstrap Terraform based manifests.
-// Issues:
-// - if user provides an empty parameter value for a string, it will be interpreted as null.
-// - if a key in Helm values.yaml contains a dot, then Jinja will have problem with interpreting it correctly.
 func NewTerraform() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "terraform [MANIFEST_PATH] [TERRAFORM_MODULE_PATH]",
 		Short: "Generate Terraform based manifests",
-		Long:  "Generate Terraform based manifests based on a Terraform module",
+		Long:  "Generate Implementation manifests based on a Terraform module",
 		Example: heredoc.WithCLIName(`
 		# Generate Implementation manifests 
 		<cli> alpha manifest-gen implementation terraform cap.implementation.aws.rds.deploy ./terraform-modules/aws-rds

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
@@ -13,6 +13,9 @@ import (
 var tfContentCfg manifestgen.TerraformConfig
 
 // NewTerraform returns a cobra.Command to bootstrap Terraform based manifests.
+// Issues:
+// - if user provides an empty parameter value for a string, it will be interpreted as null.
+// - if a key in Helm values.yaml contains a dot, then Jinja will have problem with interpreting it correctly.
 func NewTerraform() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "terraform [MANIFEST_PATH] [TERRAFORM_MODULE_PATH]",
@@ -54,7 +57,7 @@ func NewTerraform() *cobra.Command {
 				return errors.Wrap(err, "while reading output flag")
 			}
 
-			overrideManifests, err := cmd.Flags().GetBool("override")
+			overrideManifests, err := cmd.Flags().GetBool("overwrite")
 			if err != nil {
 				return errors.Wrap(err, "while overriding existing manifest")
 			}

--- a/cmd/cli/cmd/alpha/manifest-gen/interface.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/interface.go
@@ -46,7 +46,7 @@ func NewInterface() *cobra.Command {
 				return errors.Wrap(err, "while reading output flag")
 			}
 
-			overrideManifests, err := cmd.Flags().GetBool("override")
+			overrideManifests, err := cmd.Flags().GetBool("overwrite")
 			if err != nil {
 				return errors.Wrap(err, "while overriding existing manifest")
 			}

--- a/cmd/cli/cmd/alpha/manifest-gen/manifest-gen.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/manifest-gen.go
@@ -17,7 +17,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(implementation.NewCmd())
 
 	cmd.PersistentFlags().StringP("output", "o", "generated", "Path to the output directory for the generated manifests")
-	cmd.PersistentFlags().Bool("override", false, "Override existing manifest files")
+	cmd.PersistentFlags().Bool("overwrite", false, "Override existing manifest files")
 
 	return cmd
 }

--- a/cmd/cli/docs/capact_alpha_manifest-gen.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen.md
@@ -15,7 +15,7 @@ Subcommand for various manifest generation operations
 ```
   -h, --help            help for manifest-gen
   -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --override        Override existing manifest files
+      --overwrite       Override existing manifest files
 ```
 
 ### Options inherited from parent commands

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
@@ -21,7 +21,7 @@ Generate new Implementation manifests for various tools.
 ```
   -c, --config string   Path to the YAML config file
   -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --override        Override existing manifest files
+      --overwrite       Override existing manifest files
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
@@ -27,5 +27,6 @@ Generate new Implementation manifests for various tools.
 ### SEE ALSO
 
 * [capact alpha manifest-gen](capact_alpha_manifest-gen.md)	 - Manifests generation
+* [capact alpha manifest-gen implementation helm](capact_alpha_manifest-gen_implementation_helm.md)	 - Generate Helm chart based manifests
 * [capact alpha manifest-gen implementation terraform](capact_alpha_manifest-gen_implementation_terraform.md)	 - Generate Terraform based manifests
 

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
@@ -11,15 +11,17 @@ Generate Helm chart based manifests
 Generate Helm based manifests based on a Helm chart
 
 ```
-capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_PATH] [flags]
+capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_NAME] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help             help for helm
-  -r, --repo string      URL of the Helm repository
-  -v, --version string   Version of the Helm chart
+  -h, --help               help for helm
+  -i, --interface string   Path with revision of the Interface, which is implemented by this Implementation
+      --repo string        URL of the Helm repository
+  -r, --revision string    Revision of the Implementation manifest (default "0.1.0")
+  -v, --version string     Version of the Helm chart
 ```
 
 ### Options inherited from parent commands
@@ -27,7 +29,7 @@ capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_PATH] 
 ```
   -c, --config string   Path to the YAML config file
   -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --override        Override existing manifest files
+      --overwrite       Override existing manifest files
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
@@ -1,0 +1,36 @@
+---
+title: capact alpha manifest-gen implementation helm
+---
+
+## capact alpha manifest-gen implementation helm
+
+Generate Helm chart based manifests
+
+### Synopsis
+
+Generate Helm based manifests based on a Helm chart
+
+```
+capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_PATH] [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for helm
+  -r, --repo string      URL of the Helm repository
+  -v, --version string   Version of the Helm chart
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Path to the YAML config file
+  -o, --output string   Path to the output directory for the generated manifests (default "generated")
+      --override        Override existing manifest files
+```
+
+### SEE ALSO
+
+* [capact alpha manifest-gen implementation](capact_alpha_manifest-gen_implementation.md)	 - Generate new Implementation manifests
+

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
@@ -8,7 +8,7 @@ Generate Helm chart based manifests
 
 ### Synopsis
 
-Generate Helm based manifests based on a Helm chart
+Generate Implementation manifests based on a Helm chart
 
 ```
 capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_NAME] [flags]

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
@@ -8,7 +8,7 @@ Generate Terraform based manifests
 
 ### Synopsis
 
-Generate Terraform based manifests based on a Terraform module
+Generate Implementation manifests based on a Terraform module
 
 ```
 capact alpha manifest-gen implementation terraform [MANIFEST_PATH] [TERRAFORM_MODULE_PATH] [flags]

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
@@ -42,7 +42,7 @@ capact alpha manifest-gen implementation terraform cap.implementation.gcp.clouds
 ```
   -c, --config string   Path to the YAML config file
   -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --override        Override existing manifest files
+      --overwrite       Override existing manifest files
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
@@ -33,7 +33,7 @@ capact alpha content interface cap.interface.database.postgresql install
 ```
   -c, --config string   Path to the YAML config file
   -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --override        Override existing manifest files
+      --overwrite       Override existing manifest files
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc
 	github.com/argoproj/argo-workflows/v3 v3.1.0-rc1.0.20210811221840-88520891a037
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/hashicorp/terraform v0.11.12-beta1
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210625153042-09f34846faab
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519
+	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/iancoleman/strcase v0.1.2
 	github.com/machinebox/graphql v0.2.2
 	github.com/matryer/is v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/ahmetb/gen-crd-api-reference-docs v0.2.0/go.mod h1:P/XzJ+c2+khJKNKABc
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc h1:mT8qSzuyEAkxbv4GBln7yeuQZpBnfikr3PTuiPs6Z3k=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -843,6 +845,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.1.1/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.1.2 h1:gnomlvw9tnV3ITTAxzKSgTF+8kFWcU/f+TgttpXGz1U=
 github.com/iancoleman/strcase v0.1.2/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
@@ -1367,6 +1371,7 @@ github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/cli/alpha/manifestgen/helm.go
+++ b/internal/cli/alpha/manifestgen/helm.go
@@ -1,0 +1,222 @@
+package manifestgen
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+	"sigs.k8s.io/yaml"
+)
+
+// HelmConfig stores input parameters for Helm based content generation.
+type HelmConfig struct {
+	Config
+
+	ChartName string
+	RepoURL   string
+	Version   string
+
+	InterfacePathWithRevision string
+}
+
+type helmTemplatingInput struct {
+	templatingInput
+
+	InterfacePath     string
+	InterfaceRevision string
+
+	HelmChartName    string
+	HelmChartVersion string
+	HelmRepoURL      string
+
+	Values interface{}
+}
+
+// GenerateHelmManifests generates manifest files for a Helm module based Implementation
+func GenerateHelmManifests(cfg *HelmConfig) (map[string]string, error) {
+	input, err := getHelmTemplatingInput(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Helm templating input")
+	}
+
+	cfgs := []*templatingConfig{
+		{
+			Template: typeManifestTemplate,
+			Input:    input,
+		},
+		{
+			Template: helmImplementationManifestTemplate,
+			Input:    input,
+		},
+	}
+
+	generated, err := generateManifests(cfgs)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating manifests")
+	}
+
+	result := make(map[string]string, len(generated))
+
+	for _, m := range generated {
+		metadata, err := unmarshalMetadata([]byte(m))
+		if err != nil {
+			return nil, errors.Wrap(err, "while getting metadata for manifest")
+		}
+
+		manifestPath := fmt.Sprintf("%s.%s", metadata.Metadata.Prefix, metadata.Metadata.Name)
+
+		result[manifestPath] = m
+	}
+
+	return result, nil
+}
+
+func loadHelmChart(cfg *HelmConfig) (*chart.Chart, error) {
+	cpo := action.ChartPathOptions{}
+	cpo.RepoURL = cfg.RepoURL
+	cpo.Version = cfg.Version
+
+	chartLocation, err := cpo.LocateChart(cfg.ChartName, &cli.EnvSettings{
+		RepositoryCache: "/tmp/helm",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "while locating Helm chart")
+	}
+
+	chart, err := loader.Load(chartLocation)
+	if err != nil {
+		return nil, errors.Wrap(err, "while loading Helm chart")
+	}
+
+	return chart, nil
+}
+
+func getHelmTemplatingInput(cfg *HelmConfig) (*helmTemplatingInput, error) {
+	helmChart, err := loadHelmChart(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		interfacePath     = cfg.InterfacePathWithRevision
+		interfaceRevision = "0.1.0"
+		helmValues        = make(map[string]interface{})
+	)
+
+	pathSlice := strings.Split(cfg.InterfacePathWithRevision, ":")
+	if len(pathSlice) == 2 {
+		interfacePath = pathSlice[0]
+		interfaceRevision = pathSlice[1]
+	}
+
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
+	}
+
+	if err := deepCopy(&helmValues, helmChart.Values); err != nil {
+		return nil, errors.Wrap(err, "while deep copying Helm values")
+	}
+
+	if err := deepSetHelmValues(helmChart.Values, []string{}); err != nil {
+		return nil, errors.Wrap(err, "while setting values for Helm input values")
+	}
+
+	valuesBytes, err := yaml.Marshal(helmChart.Values)
+	if err != nil {
+		return nil, errors.Wrap(err, "while marshaling values YAML")
+	}
+
+	return &helmTemplatingInput{
+		templatingInput: templatingInput{
+			Name:     name,
+			Prefix:   prefix,
+			Revision: cfg.ManifestRevision,
+		},
+		InterfacePath:     interfacePath,
+		InterfaceRevision: interfaceRevision,
+		HelmChartName:     helmChart.Name(),
+		HelmChartVersion:  helmChart.Metadata.Version,
+		HelmRepoURL:       cfg.RepoURL,
+		Values:            string(valuesBytes),
+	}, err
+}
+
+func deepSetHelmValues(values map[string]interface{}, parentKeyPath []string) error {
+	for key, v := range values {
+		keyPath := append(parentKeyPath, key)
+		keyPathString := strings.Join(keyPath, ".")
+
+		switch value := v.(type) {
+		case map[string]interface{}:
+			if err := deepSetHelmValues(value, keyPath); err != nil {
+				return err
+			}
+		case string:
+			if value == "" {
+				// Needed, so empty string will not be interpreted as null in evaluated YAML.
+				// TODO: Unfortunately, it does not cover the scenario, where user provides empty string to a parameter.
+				value = "''"
+			}
+
+			values[key] = fmt.Sprintf(`<@ additionalInput.%s | default("%v") @>`, keyPathString, value)
+
+		case bool:
+			values[key] = fmt.Sprintf(`<@ additionalInput.%s | default(%v) | tojson @>`, keyPathString, value)
+		case float64:
+			values[key] = fmt.Sprintf(`<@ additionalInput.%s | default(%v) @>`, keyPathString, value)
+		case []interface{}:
+			sliceBytes, err := json.Marshal(value)
+			if err != nil {
+				return errors.Wrapf(err, "while marshaling slice %v", value)
+			}
+
+			values[key] = fmt.Sprintf(`<@ additionalInput.%s | default(%v) @>`, keyPathString, string(sliceBytes))
+		default:
+			values[key] = fmt.Sprintf(`<@ additionalInput.%s | default(%s) @>`, keyPathString, value)
+		}
+	}
+
+	return nil
+}
+
+//func generateValueJSONSchema(value interface{}, parentKeyPath []string) *jsonschema.Type {
+//	schema := &jsonschema.Type{
+//		Title: "",
+//	}
+//
+//	if len(parentKeyPath) > 0 {
+//		schema.Title = parentKeyPath[len(parentKeyPath)-1]
+//	}
+//
+//	switch v := value.(type) {
+//	case string:
+//		schema.Type = "string"
+//		schema.Default = v
+//
+//	case map[string]interface{}:
+//		schema.Properties = orderedmap.New()
+//
+//		for k, val := range v {
+//			propSchema := generateValueJSONSchema(val, append(parentKeyPath, k))
+//			schema.Properties.Set(k, propSchema)
+//		}
+//	}
+//
+//	return schema
+//}
+
+func deepCopy(dst, src interface{}) error {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(src); err != nil {
+		return err
+	}
+	return gob.NewDecoder(bytes.NewBuffer(buf.Bytes())).Decode(dst)
+}

--- a/internal/cli/alpha/manifestgen/helpers.go
+++ b/internal/cli/alpha/manifestgen/helpers.go
@@ -1,6 +1,8 @@
 package manifestgen
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"os"
 	"path"
@@ -34,4 +36,24 @@ func WriteManifestFiles(outputDir string, files map[string]string, override bool
 	}
 
 	return nil
+}
+
+func deepCopy(dst, src interface{}) error {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(src); err != nil {
+		return err
+	}
+	return gob.NewDecoder(bytes.NewBuffer(buf.Bytes())).Decode(dst)
+}
+
+func splitPathToPrefixAndName(path string) (string, string, error) {
+	parts := strings.Split(path, ".")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("manifest path must have prefix and name")
+	}
+
+	prefix := strings.Join(parts[2:len(parts)-1], ".")
+	name := parts[len(parts)-1]
+
+	return prefix, name, nil
 }

--- a/internal/cli/alpha/manifestgen/interface.go
+++ b/internal/cli/alpha/manifestgen/interface.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alecthomas/jsonschema"
 	"github.com/pkg/errors"
 )
 
@@ -111,6 +112,9 @@ func getInterfaceInputTypeTemplatingConfig(cfg *InterfaceConfig) (*templatingCon
 				Name:     name,
 				Prefix:   prefix,
 				Revision: cfg.ManifestRevision,
+			},
+			JSONSchema: &jsonschema.Type{
+				Type: "object",
 			},
 		},
 	}, nil

--- a/internal/cli/alpha/manifestgen/interface.go
+++ b/internal/cli/alpha/manifestgen/interface.go
@@ -8,11 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// InterfaceConfig stores the input parameters for Interface content generation
-type InterfaceConfig struct {
-	Config
-}
-
 // GenerateInterfaceManifests generates manifest files for a new Interface.
 func GenerateInterfaceManifests(cfg *InterfaceConfig) (map[string]string, error) {
 	cfgs := make([]*templatingConfig, 0, 4)

--- a/internal/cli/alpha/manifestgen/interface.go
+++ b/internal/cli/alpha/manifestgen/interface.go
@@ -14,47 +14,31 @@ type InterfaceConfig struct {
 
 // GenerateInterfaceManifests generates manifest files for a new Interface.
 func GenerateInterfaceManifests(cfg *InterfaceConfig) (map[string]string, error) {
-	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	cfgs := make([]*templatingConfig, 0, 4)
+
+	interfaceGroupCfg, err := getInterfaceGroupTemplatingConfig(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "while getting path and prefix for manifests")
+		return nil, errors.Wrap(err, "while getting InterfaceGroup templating config")
 	}
+	cfgs = append(cfgs, interfaceGroupCfg)
 
-	interfaceGroupPath := getInterfaceGroupPathFromInterfacePath(cfg.ManifestPath)
-	groupPrefix, groupName, err := splitPathToPrefixAndName(interfaceGroupPath)
+	interfaceCfg, err := getInterfaceTemplatingConfig(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "while getting InterfaceGroup prefix and path")
+		return nil, errors.Wrap(err, "while getting Interface templating config")
 	}
+	cfgs = append(cfgs, interfaceCfg)
 
-	interfaceInput := &templatingInput{
-		Name:     name,
-		Prefix:   prefix,
-		Revision: cfg.ManifestRevision,
+	inputTypeCfg, err := getInterfaceInputTypeTemplatingConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Interface input Type templating config")
 	}
+	cfgs = append(cfgs, inputTypeCfg)
 
-	interfaceGroupInput := &templatingInput{
-		Name:     groupName,
-		Prefix:   groupPrefix,
-		Revision: cfg.ManifestRevision,
+	outputTypeCfg, err := getInterfaceOutputTypeTemplatingConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Interface output Type templating config")
 	}
-
-	cfgs := []*templatingConfig{
-		{
-			Template: interfaceGroupManifestTemplate,
-			Input:    interfaceGroupInput,
-		},
-		{
-			Template: typeManifestTemplate,
-			Input:    interfaceInput,
-		},
-		{
-			Template: outputTypeManifestTemplate,
-			Input:    interfaceInput,
-		},
-		{
-			Template: interfaceManifestTemplate,
-			Input:    interfaceInput,
-		},
-	}
+	cfgs = append(cfgs, outputTypeCfg)
 
 	generated, err := generateManifests(cfgs)
 	if err != nil {
@@ -75,6 +59,79 @@ func GenerateInterfaceManifests(cfg *InterfaceConfig) (map[string]string, error)
 	}
 
 	return result, nil
+}
+
+func getInterfaceGroupTemplatingConfig(cfg *InterfaceConfig) (*templatingConfig, error) {
+	interfaceGroupPath := getInterfaceGroupPathFromInterfacePath(cfg.ManifestPath)
+	groupPrefix, groupName, err := splitPathToPrefixAndName(interfaceGroupPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting InterfaceGroup prefix and path")
+	}
+
+	return &templatingConfig{
+		Template: interfaceGroupManifestTemplate,
+		Input: &interfaceGroupTemplatingInput{
+			templatingInput: templatingInput{
+				Name:     groupName,
+				Prefix:   groupPrefix,
+				Revision: cfg.ManifestRevision,
+			},
+		},
+	}, nil
+}
+
+func getInterfaceTemplatingConfig(cfg *InterfaceConfig) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting path and prefix for manifests")
+	}
+
+	return &templatingConfig{
+		Template: interfaceManifestTemplate,
+		Input: &interfaceTemplatingInput{
+			templatingInput: templatingInput{
+				Name:     name,
+				Prefix:   prefix,
+				Revision: cfg.ManifestRevision,
+			},
+		},
+	}, nil
+}
+
+func getInterfaceInputTypeTemplatingConfig(cfg *InterfaceConfig) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting path and prefix for manifests")
+	}
+
+	return &templatingConfig{
+		Template: typeManifestTemplate,
+		Input: &typeTemplatingInput{
+			templatingInput: templatingInput{
+				Name:     name,
+				Prefix:   prefix,
+				Revision: cfg.ManifestRevision,
+			},
+		},
+	}, nil
+}
+
+func getInterfaceOutputTypeTemplatingConfig(cfg *InterfaceConfig) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting path and prefix for manifests")
+	}
+
+	return &templatingConfig{
+		Template: outputTypeManifestTemplate,
+		Input: &outputTypeTemplatingInput{
+			templatingInput: templatingInput{
+				Name:     name,
+				Prefix:   prefix,
+				Revision: cfg.ManifestRevision,
+			},
+		},
+	}, nil
 }
 
 func getInterfaceGroupPathFromInterfacePath(ifacePath string) string {

--- a/internal/cli/alpha/manifestgen/manifestgen.go
+++ b/internal/cli/alpha/manifestgen/manifestgen.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 )
 
@@ -18,30 +19,6 @@ type Config struct {
 type templatingConfig struct {
 	Template string
 	Input    interface{}
-}
-
-type templatingInput struct {
-	Name      string
-	Prefix    string
-	Revision  string
-	Variables []inputVariable
-}
-
-type inputVariable struct {
-	Name        string
-	Type        string
-	Description string
-	Default     interface{}
-}
-
-type outputVariable struct {
-	Name string
-}
-
-var tmplFuncs = template.FuncMap{
-	"add": func(a, b int) int {
-		return a + b
-	},
 }
 
 func generateManifests(cfgs []*templatingConfig) ([]string, error) {
@@ -61,7 +38,7 @@ func generateManifests(cfgs []*templatingConfig) ([]string, error) {
 
 func generateManifest(cfg *templatingConfig) (string, error) {
 	tmpl, err := template.New("manifest").
-		Funcs(tmplFuncs).
+		Funcs(template.FuncMap(sprig.FuncMap())).
 		Parse(cfg.Template)
 	if err != nil {
 		return "", errors.Wrap(err, "while creating new template")

--- a/internal/cli/alpha/manifestgen/manifestgen.go
+++ b/internal/cli/alpha/manifestgen/manifestgen.go
@@ -2,24 +2,11 @@ package manifestgen
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 )
-
-// Config stores the generic input parameters for content generation
-type Config struct {
-	ManifestPath     string
-	ManifestRevision string
-}
-
-type templatingConfig struct {
-	Template string
-	Input    interface{}
-}
 
 func generateManifests(cfgs []*templatingConfig) ([]string, error) {
 	manifests := make([]string, 0, len(cfgs))
@@ -50,16 +37,4 @@ func generateManifest(cfg *templatingConfig) (string, error) {
 	}
 
 	return manifest.String(), nil
-}
-
-func splitPathToPrefixAndName(path string) (string, string, error) {
-	parts := strings.Split(path, ".")
-	if len(parts) < 3 {
-		return "", "", fmt.Errorf("manifest path must have prefix and name")
-	}
-
-	prefix := strings.Join(parts[2:len(parts)-1], ".")
-	name := parts[len(parts)-1]
-
-	return prefix, name, nil
 }

--- a/internal/cli/alpha/manifestgen/manifestgen_test.go
+++ b/internal/cli/alpha/manifestgen/manifestgen_test.go
@@ -34,39 +34,45 @@ func TestGenerateTerraformImplementationManifests(t *testing.T) {
 		{
 			name: "Implementation manifests",
 			cfg: &manifestgen.TerraformConfig{
-				Config: manifestgen.Config{
-					ManifestPath:     "cap.implementation.terraform.generic.test",
-					ManifestRevision: "0.1.0",
+				ImplementationConfig: manifestgen.ImplementationConfig{
+					Config: manifestgen.Config{
+						ManifestPath:     "cap.implementation.terraform.generic.test",
+						ManifestRevision: "0.1.0",
+					},
+					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
-				ModulePath:                "./testdata/terraform",
-				ModuleSourceURL:           "https://example.com/module.tgz",
-				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+				ModulePath:      "./testdata/terraform",
+				ModuleSourceURL: "https://example.com/module.tgz",
 			},
 		},
 		{
 			name: "Implementation manifests with AWS provider",
 			cfg: &manifestgen.TerraformConfig{
-				Config: manifestgen.Config{
-					ManifestPath:     "cap.implementation.terraform.aws.test",
-					ManifestRevision: "0.1.0",
+				ImplementationConfig: manifestgen.ImplementationConfig{
+					Config: manifestgen.Config{
+						ManifestPath:     "cap.implementation.terraform.aws.test",
+						ManifestRevision: "0.1.0",
+					},
+					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
-				ModulePath:                "./testdata/terraform",
-				ModuleSourceURL:           "https://example.com/module.tgz",
-				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
-				Provider:                  manifestgen.ProviderAWS,
+				ModulePath:      "./testdata/terraform",
+				ModuleSourceURL: "https://example.com/module.tgz",
+				Provider:        manifestgen.ProviderAWS,
 			},
 		},
 		{
 			name: "Implementation manifests with GCP provider",
 			cfg: &manifestgen.TerraformConfig{
-				Config: manifestgen.Config{
-					ManifestPath:     "cap.implementation.terraform.gcp.test",
-					ManifestRevision: "0.1.0",
+				ImplementationConfig: manifestgen.ImplementationConfig{
+					Config: manifestgen.Config{
+						ManifestPath:     "cap.implementation.terraform.gcp.test",
+						ManifestRevision: "0.1.0",
+					},
+					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
-				ModulePath:                "./testdata/terraform",
-				ModuleSourceURL:           "https://example.com/module.tgz",
-				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
-				Provider:                  manifestgen.ProviderGCP,
+				ModulePath:      "./testdata/terraform",
+				ModuleSourceURL: "https://example.com/module.tgz",
+				Provider:        manifestgen.ProviderGCP,
 			},
 		},
 	}
@@ -86,14 +92,16 @@ func TestGenerateTerraformImplementationManifests(t *testing.T) {
 
 func TestGenerateHelmImplementationManifests(t *testing.T) {
 	cfg := &manifestgen.HelmConfig{
-		Config: manifestgen.Config{
-			ManifestPath:     "cap.implementation.helm.test",
-			ManifestRevision: "0.1.0",
+		ImplementationConfig: manifestgen.ImplementationConfig{
+			Config: manifestgen.Config{
+				ManifestPath:     "cap.implementation.helm.test",
+				ManifestRevision: "0.1.0",
+			},
+			InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 		},
-		ChartName:                 "postgresql",
-		RepoURL:                   "https://charts.bitnami.com/bitnami",
-		Version:                   "10.9.2",
-		InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+		ChartName:    "postgresql",
+		ChartRepoURL: "https://charts.bitnami.com/bitnami",
+		ChartVersion: "10.9.2",
 	}
 
 	manifests, err := manifestgen.GenerateHelmManifests(cfg)

--- a/internal/cli/alpha/manifestgen/manifestgen_test.go
+++ b/internal/cli/alpha/manifestgen/manifestgen_test.go
@@ -1,0 +1,106 @@
+package manifestgen_test
+
+import (
+	"fmt"
+	"testing"
+
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/golden"
+)
+
+func TestGenerateInterfaceManifests(t *testing.T) {
+	cfg := &manifestgen.InterfaceConfig{
+		Config: manifestgen.Config{
+			ManifestPath:     "cap.interface.group.test",
+			ManifestRevision: "0.2.0",
+		},
+	}
+
+	manifests, err := manifestgen.GenerateInterfaceManifests(cfg)
+	require.NoError(t, err)
+
+	for name, manifestData := range manifests {
+		filename := fmt.Sprintf("%s.yaml", name)
+		golden.Assert(t, manifestData, filename)
+	}
+}
+
+func TestGenerateTerraformImplementationManifests(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *manifestgen.TerraformConfig
+	}{
+		{
+			name: "Implementation manifests",
+			cfg: &manifestgen.TerraformConfig{
+				Config: manifestgen.Config{
+					ManifestPath:     "cap.implementation.terraform.generic.test",
+					ManifestRevision: "0.1.0",
+				},
+				ModulePath:                "./testdata/terraform",
+				ModuleSourceURL:           "https://example.com/module.tgz",
+				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+			},
+		},
+		{
+			name: "Implementation manifests with AWS provider",
+			cfg: &manifestgen.TerraformConfig{
+				Config: manifestgen.Config{
+					ManifestPath:     "cap.implementation.terraform.aws.test",
+					ManifestRevision: "0.1.0",
+				},
+				ModulePath:                "./testdata/terraform",
+				ModuleSourceURL:           "https://example.com/module.tgz",
+				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+				Provider:                  manifestgen.ProviderAWS,
+			},
+		},
+		{
+			name: "Implementation manifests with GCP provider",
+			cfg: &manifestgen.TerraformConfig{
+				Config: manifestgen.Config{
+					ManifestPath:     "cap.implementation.terraform.gcp.test",
+					ManifestRevision: "0.1.0",
+				},
+				ModulePath:                "./testdata/terraform",
+				ModuleSourceURL:           "https://example.com/module.tgz",
+				InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+				Provider:                  manifestgen.ProviderGCP,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manifests, err := manifestgen.GenerateTerraformManifests(test.cfg)
+			require.NoError(t, err)
+
+			for name, manifestData := range manifests {
+				filename := fmt.Sprintf("%s.yaml", name)
+				golden.Assert(t, manifestData, filename)
+			}
+		})
+	}
+}
+
+func TestGenerateHelmImplementationManifests(t *testing.T) {
+	cfg := &manifestgen.HelmConfig{
+		Config: manifestgen.Config{
+			ManifestPath:     "cap.implementation.helm.test",
+			ManifestRevision: "0.1.0",
+		},
+		ChartName:                 "postgresql",
+		RepoURL:                   "https://charts.bitnami.com/bitnami",
+		Version:                   "10.9.2",
+		InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+	}
+
+	manifests, err := manifestgen.GenerateHelmManifests(cfg)
+	require.NoError(t, err)
+
+	for name, manifestData := range manifests {
+		filename := fmt.Sprintf("%s.yaml", name)
+		golden.Assert(t, manifestData, filename)
+	}
+}

--- a/internal/cli/alpha/manifestgen/metadata.go
+++ b/internal/cli/alpha/manifestgen/metadata.go
@@ -15,7 +15,7 @@ type Metadata struct {
 	} `yaml:"metadata"`
 }
 
-// unmarshalMetadata reads the manifest metadata from a bytes lice of a Capact manifest.
+// unmarshalMetadata reads the manifest metadata from a bytes slice of a Capact manifest.
 func unmarshalMetadata(yamlBytes []byte) (Metadata, error) {
 	mm := Metadata{}
 	err := yaml.Unmarshal(yamlBytes, &mm)

--- a/internal/cli/alpha/manifestgen/templates.go
+++ b/internal/cli/alpha/manifestgen/templates.go
@@ -2,9 +2,6 @@ package manifestgen
 
 import (
 	_ "embed"
-
-	"github.com/alecthomas/jsonschema"
-	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
 var (
@@ -26,50 +23,3 @@ var (
 	//go:embed templates/helm-implementation.yaml.tmpl
 	helmImplementationManifestTemplate string
 )
-
-type templatingInput struct {
-	Name     string
-	Prefix   string
-	Revision string
-}
-
-type interfaceGroupTemplatingInput struct {
-	templatingInput
-}
-
-type interfaceTemplatingInput struct {
-	templatingInput
-}
-
-type outputTypeTemplatingInput struct {
-	templatingInput
-}
-
-type typeTemplatingInput struct {
-	templatingInput
-	JSONSchema *jsonschema.Type
-}
-
-type terraformImplementationTemplatingInput struct {
-	templatingInput
-
-	InterfacePath     string
-	InterfaceRevision string
-	ModuleSourceURL   string
-	Outputs           []*tfconfig.Output
-	Provider          Provider
-	Variables         []*tfconfig.Variable
-}
-
-type helmImplementationTemplatingInput struct {
-	templatingInput
-
-	InterfacePath     string
-	InterfaceRevision string
-
-	HelmChartName    string
-	HelmChartVersion string
-	HelmRepoURL      string
-
-	ValuesYAML string
-}

--- a/internal/cli/alpha/manifestgen/templates.go
+++ b/internal/cli/alpha/manifestgen/templates.go
@@ -61,6 +61,15 @@ type terraformImplementationTemplatingInput struct {
 	Variables         []*tfconfig.Variable
 }
 
-//type helmImplementationTemplatingInput struct {
-//	templatingInput
-//}
+type helmImplementationTemplatingInput struct {
+	templatingInput
+
+	InterfacePath     string
+	InterfaceRevision string
+
+	HelmChartName    string
+	HelmChartVersion string
+	HelmRepoURL      string
+
+	ValuesYAML string
+}

--- a/internal/cli/alpha/manifestgen/templates.go
+++ b/internal/cli/alpha/manifestgen/templates.go
@@ -1,6 +1,11 @@
 package manifestgen
 
-import _ "embed"
+import (
+	_ "embed"
+
+	"github.com/alecthomas/jsonschema"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+)
 
 var (
 	//go:embed templates/interface-group.yaml.tmpl
@@ -17,4 +22,45 @@ var (
 
 	//go:embed templates/terraform-implementation.yaml.tmpl
 	terraformImplementationManifestTemplate string
+
+	//go:embed templates/helm-implementation.yaml.tmpl
+	helmImplementationManifestTemplate string
 )
+
+type templatingInput struct {
+	Name     string
+	Prefix   string
+	Revision string
+}
+
+type interfaceGroupTemplatingInput struct {
+	templatingInput
+}
+
+type interfaceTemplatingInput struct {
+	templatingInput
+}
+
+type outputTypeTemplatingInput struct {
+	templatingInput
+}
+
+type typeTemplatingInput struct {
+	templatingInput
+	JSONSchema *jsonschema.Type
+}
+
+type terraformImplementationTemplatingInput struct {
+	templatingInput
+
+	InterfacePath     string
+	InterfaceRevision string
+	ModuleSourceURL   string
+	Outputs           []*tfconfig.Output
+	Provider          Provider
+	Variables         []*tfconfig.Variable
+}
+
+//type helmImplementationTemplatingInput struct {
+//	templatingInput
+//}

--- a/internal/cli/alpha/manifestgen/templates/helm-implementation.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/helm-implementation.yaml.tmpl
@@ -1,0 +1,151 @@
+ocfVersion: 0.0.1
+revision: {{ .Revision }}
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.{{ .Prefix }}"
+  name: {{ .Name }}
+  displayName: "{{ .Name }} Action"
+  description: "{{ .Name }} Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      typeRef:
+        path: "cap.type.{{ .Prefix }}.{{ .Name }}-input"
+        revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    config:
+      uses:
+        - terraform-release
+
+  implements:
+    - path: {{if .InterfacePath}}{{ .InterfacePath }}{{else}}"cap.interface..." # TODO(ContentDeveloper): Put here the path of the implemented Interface{{end}}
+      revision: {{if .InterfaceRevision}}{{ .InterfaceRevision }}{{else}}0.1.0{{end}}
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.runner.helm
+      alias: helm
+      methods:
+        - name: install
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: deploy
+        templates:
+          - name: deploy
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts: []
+            steps:
+              - - name: fill-default-input
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{"{{"}}inputs.artifacts.input-parameters{{"}}"}}"
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
+                          data: |
+                            my_property: <@ input.my_property | default("default_value") @>
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{"{{"}}inputs.artifacts.additional-parameters{{"}}"}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: additionalInput
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "{{ .HelmChartName }}"
+                              repo: "{{ .HelmRepoURL }}"
+                              version: "{{ .HelmChartVersion }}"
+                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
+{{ .Values | indent 30 }}
+                            output:
+                              goTemplate: |
+                                # TODO(ContentDeveloper): Add output template in YAML
+
+              - - name: fill-parameters
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{"{{"}}steps.create-module-args.outputs.artifacts.render{{"}}"}}"
+                      - name: input-parameters
+                        from: "{{"{{"}}steps.fill-default-input.outputs.artifacts.render{{"}}"}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              - - name: render-config
+                  capact-outputTypeInstances:
+                    - name: config
+                      from: render
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{"{{"}}steps.helm-install.outputs.artifacts.additional{{"}}"}}"
+                      - name: configuration
+                        raw:
+                          data: ""
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
+                          data: |
+                            property: value

--- a/internal/cli/alpha/manifestgen/templates/type.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/type.yaml.tmpl
@@ -14,20 +14,6 @@ metadata:
       url: https://example.com
 spec:
   jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
     value: |-
-      {
-        "$schema": "http://json-schema.org/draft-07/schema",
-        "type": "object",
-        "required": [],
-        "properties": {
-          {{ $length := len .Variables -}}
-          {{ range $index, $variable := .Variables -}}
-          "{{ $variable.Name }}": {
-            "$id": "#/properties/{{ $variable.Name }}",
-            "type": "{{ $variable.Type }}",
-            "description": "{{ $variable.Description }}"{{if $variable.Default }},
-            "default": "{{ $variable.Default }}"{{ end }}
-          }{{ if ne $index (add $length -1) }},{{ end }}
-          {{ end }}
-        }
-      }
+{{ .JSONSchema | toPrettyJson | indent 6 }}

--- a/internal/cli/alpha/manifestgen/terraform.go
+++ b/internal/cli/alpha/manifestgen/terraform.go
@@ -11,16 +11,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TerraformConfig stores input parameters for Terraform based content generation
-type TerraformConfig struct {
-	Config
-
-	ModulePath                string
-	ModuleSourceURL           string
-	InterfacePathWithRevision string
-	Provider                  Provider
-}
-
 // GenerateTerraformManifests generates manifest files for a Terraform module based Implementation
 func GenerateTerraformManifests(cfg *TerraformConfig) (map[string]string, error) {
 	module, diags := tfconfig.LoadModule(cfg.ModulePath)

--- a/internal/cli/alpha/manifestgen/terraform.go
+++ b/internal/cli/alpha/manifestgen/terraform.go
@@ -5,7 +5,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/alecthomas/jsonschema"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/iancoleman/orderedmap"
 	"github.com/pkg/errors"
 )
 
@@ -19,33 +21,26 @@ type TerraformConfig struct {
 	Provider                  Provider
 }
 
-type terraformTemplatingInput struct {
-	templatingInput
-
-	InterfacePath     string
-	InterfaceRevision string
-	ModuleSourceURL   string
-	Outputs           []outputVariable
-	Provider          Provider
-}
-
 // GenerateTerraformManifests generates manifest files for a Terraform module based Implementation
 func GenerateTerraformManifests(cfg *TerraformConfig) (map[string]string, error) {
-	input, err := getTerraformTemplatingInput(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "while getting templating input")
+	module, diags := tfconfig.LoadModule(cfg.ModulePath)
+	if diags.Err() != nil {
+		return nil, errors.Wrap(diags.Err(), "while loading Terraform module")
 	}
 
-	cfgs := []*templatingConfig{
-		{
-			Template: typeManifestTemplate,
-			Input:    input,
-		},
-		{
-			Template: terraformImplementationManifestTemplate,
-			Input:    input,
-		},
+	cfgs := make([]*templatingConfig, 0, 2)
+
+	inputTypeCfg, err := getTerraformInputTypeTemplatingConfig(cfg, module)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting input Type templating config")
 	}
+	cfgs = append(cfgs, inputTypeCfg)
+
+	implCfg, err := getTerraformImplementationTemplatingConfig(cfg, module)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Implementation templating config")
+	}
+	cfgs = append(cfgs, implCfg)
 
 	generated, err := generateManifests(cfgs)
 	if err != nil {
@@ -68,10 +63,31 @@ func GenerateTerraformManifests(cfg *TerraformConfig) (map[string]string, error)
 	return result, nil
 }
 
-func getTerraformTemplatingInput(cfg *TerraformConfig) (*terraformTemplatingInput, error) {
-	module, diags := tfconfig.LoadModule(cfg.ModulePath)
-	if diags.Err() != nil {
-		return nil, errors.Wrap(diags.Err(), "while loading Terraform module")
+func getTerraformInputTypeTemplatingConfig(cfg *TerraformConfig, module *tfconfig.Module) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
+	}
+
+	jsonSchema := getTerraformInputTypeJSONSchema(module.Variables)
+
+	return &templatingConfig{
+		Template: typeManifestTemplate,
+		Input: &typeTemplatingInput{
+			templatingInput: templatingInput{
+				Name:     name,
+				Prefix:   prefix,
+				Revision: cfg.ManifestRevision,
+			},
+			JSONSchema: jsonSchema,
+		},
+	}, nil
+}
+
+func getTerraformImplementationTemplatingConfig(cfg *TerraformConfig, module *tfconfig.Module) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
 	}
 
 	var (
@@ -85,49 +101,62 @@ func getTerraformTemplatingInput(cfg *TerraformConfig) (*terraformTemplatingInpu
 		interfaceRevision = pathSlice[1]
 	}
 
-	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
-	}
-
-	input := &terraformTemplatingInput{
+	input := &terraformImplementationTemplatingInput{
 		templatingInput: templatingInput{
-			Name:      name,
-			Prefix:    prefix,
-			Revision:  cfg.ManifestRevision,
-			Variables: make([]inputVariable, 0, len(module.Variables)),
+			Name:     name,
+			Prefix:   prefix,
+			Revision: cfg.ManifestRevision,
 		},
 		InterfacePath:     interfacePath,
 		InterfaceRevision: interfaceRevision,
 		ModuleSourceURL:   cfg.ModuleSourceURL,
-		Outputs:           make([]outputVariable, 0, len(module.Outputs)),
 		Provider:          cfg.Provider,
+		Outputs:           make([]*tfconfig.Output, 0, len(module.Outputs)),
+		Variables:         make([]*tfconfig.Variable, 0, len(module.Variables)),
 	}
 
-	for _, tfVar := range module.Variables {
-		// Skip default for now, as there are problems, when it is a multiline string or with doublequotes in it.
-		input.Variables = append(input.Variables, inputVariable{
-			Name:        tfVar.Name,
-			Type:        getTypeFromTerraformType(tfVar.Type),
-			Description: tfVar.Description,
-		})
+	for i := range module.Variables {
+		input.Variables = append(input.Variables, module.Variables[i])
 	}
 
 	sort.Slice(input.Variables, func(i, j int) bool {
 		return input.Variables[i].Name < input.Variables[j].Name
 	})
 
-	for _, tfOut := range module.Outputs {
-		input.Outputs = append(input.Outputs, outputVariable{
-			Name: tfOut.Name,
-		})
+	for i := range module.Outputs {
+		input.Outputs = append(input.Outputs, module.Outputs[i])
 	}
 
 	sort.Slice(input.Outputs, func(i, j int) bool {
 		return input.Outputs[i].Name < input.Outputs[j].Name
 	})
 
-	return input, nil
+	return &templatingConfig{
+		Template: terraformImplementationManifestTemplate,
+		Input:    input,
+	}, nil
+}
+
+func getTerraformInputTypeJSONSchema(variables map[string]*tfconfig.Variable) *jsonschema.Type {
+	schema := &jsonschema.Type{
+		Title:      "",
+		Properties: orderedmap.New(),
+	}
+
+	for _, value := range variables {
+		propSchema := &jsonschema.Type{
+			Title:       value.Name,
+			Type:        getTypeFromTerraformType(value.Type),
+			Description: value.Description,
+		}
+		schema.Properties.Set(value.Name, propSchema)
+	}
+
+	schema.Properties.Sort(func(a, b *orderedmap.Pair) bool {
+		return a.Key() < b.Key()
+	})
+
+	return schema
 }
 
 // Terraform types: https://www.terraform.io/docs/language/expressions/types.html

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.group.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.group.test.yaml
@@ -1,0 +1,436 @@
+ocfVersion: 0.0.1
+revision: 0.2.0
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.group"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      typeRef:
+        path: "cap.type.group.test-input"
+        revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    config:
+      uses:
+        - helm-release
+
+  implements:
+    - path: cap.interface.group.test
+      revision: 0.2.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.runner.helm
+      alias: helm
+      methods:
+        - name: install
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: deploy
+        templates:
+          - name: deploy
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts: []
+            steps:
+              - - name: fill-default-input
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
+                          data: |
+                            my_property: <@ input.my_property | default("default_value") @>
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.additional-parameters}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: additionalInput
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "postgresql"
+                              repo: "https://charts.bitnami.com/bitnami"
+                              version: "10.9.2"
+                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
+                              audit:
+                                clientMinMessages: <@ additionalInput.audit.clientMinMessages | default("error") @>
+                                logConnections: <@ additionalInput.audit.logConnections | default(false) | tojson @>
+                                logDisconnections: <@ additionalInput.audit.logDisconnections | default(false) | tojson @>
+                                logHostname: <@ additionalInput.audit.logHostname | default(false) | tojson @>
+                                logLinePrefix: <@ additionalInput.audit.logLinePrefix | default("''") @>
+                                logTimezone: <@ additionalInput.audit.logTimezone | default("''") @>
+                                pgAuditLog: <@ additionalInput.audit.pgAuditLog | default("''") @>
+                                pgAuditLogCatalog: <@ additionalInput.audit.pgAuditLogCatalog | default("off") @>
+                              commonAnnotations: {}
+                              configurationConfigMap: <@ additionalInput.configurationConfigMap | default("''") @>
+                              containerSecurityContext:
+                                enabled: <@ additionalInput.containerSecurityContext.enabled | default(true) | tojson @>
+                                runAsUser: <@ additionalInput.containerSecurityContext.runAsUser | default(1001) @>
+                              customLivenessProbe: {}
+                              customReadinessProbe: {}
+                              customStartupProbe: {}
+                              diagnosticMode:
+                                args: <@ additionalInput.diagnosticMode.args | default(["infinity"]) @>
+                                command: <@ additionalInput.diagnosticMode.command | default(["sleep"]) @>
+                                enabled: <@ additionalInput.diagnosticMode.enabled | default(false) | tojson @>
+                              existingSecret: <@ additionalInput.existingSecret | default("''") @>
+                              extendedConfConfigMap: <@ additionalInput.extendedConfConfigMap | default("''") @>
+                              extraDeploy: <@ additionalInput.extraDeploy | default(None | tojson) @>
+                              extraEnv: <@ additionalInput.extraEnv | default(None | tojson) @>
+                              extraEnvVarsCM: <@ additionalInput.extraEnvVarsCM | default("''") @>
+                              fullnameOverride: <@ additionalInput.fullnameOverride | default("''") @>
+                              global:
+                                imagePullSecrets: <@ additionalInput.global.imagePullSecrets | default(None | tojson) @>
+                                imageRegistry: <@ additionalInput.global.imageRegistry | default("''") @>
+                                postgresql:
+                                  existingSecret: <@ additionalInput.global.postgresql.existingSecret | default("''") @>
+                                  postgresqlDatabase: <@ additionalInput.global.postgresql.postgresqlDatabase | default("''") @>
+                                  postgresqlPassword: <@ additionalInput.global.postgresql.postgresqlPassword | default("''") @>
+                                  postgresqlUsername: <@ additionalInput.global.postgresql.postgresqlUsername | default("''") @>
+                                  replicationPassword: <@ additionalInput.global.postgresql.replicationPassword | default("''") @>
+                                  servicePort: <@ additionalInput.global.postgresql.servicePort | default("''") @>
+                                storageClass: <@ additionalInput.global.storageClass | default("''") @>
+                              image:
+                                debug: <@ additionalInput.image.debug | default(false) | tojson @>
+                                pullPolicy: <@ additionalInput.image.pullPolicy | default("IfNotPresent") @>
+                                pullSecrets: <@ additionalInput.image.pullSecrets | default(None | tojson) @>
+                                registry: <@ additionalInput.image.registry | default("docker.io") @>
+                                repository: <@ additionalInput.image.repository | default("bitnami/postgresql") @>
+                                tag: <@ additionalInput.image.tag | default("11.13.0-debian-10-r0") @>
+                              initdbPassword: <@ additionalInput.initdbPassword | default("''") @>
+                              initdbScripts: {}
+                              initdbScriptsConfigMap: <@ additionalInput.initdbScriptsConfigMap | default("''") @>
+                              initdbScriptsSecret: <@ additionalInput.initdbScriptsSecret | default("''") @>
+                              initdbUser: <@ additionalInput.initdbUser | default("''") @>
+                              ldap:
+                                baseDN: <@ additionalInput.ldap.baseDN | default("''") @>
+                                bind_password: <@ additionalInput.ldap.bind_password | default("''") @>
+                                bindDN: <@ additionalInput.ldap.bindDN | default("''") @>
+                                enabled: <@ additionalInput.ldap.enabled | default(false) | tojson @>
+                                port: <@ additionalInput.ldap.port | default("''") @>
+                                prefix: <@ additionalInput.ldap.prefix | default("''") @>
+                                scheme: <@ additionalInput.ldap.scheme | default("''") @>
+                                search_attr: <@ additionalInput.ldap.search_attr | default("''") @>
+                                search_filter: <@ additionalInput.ldap.search_filter | default("''") @>
+                                server: <@ additionalInput.ldap.server | default("''") @>
+                                suffix: <@ additionalInput.ldap.suffix | default("''") @>
+                                tls: <@ additionalInput.ldap.tls | default("''") @>
+                                url: <@ additionalInput.ldap.url | default("''") @>
+                              lifecycleHooks: {}
+                              livenessProbe:
+                                enabled: <@ additionalInput.livenessProbe.enabled | default(true) | tojson @>
+                                failureThreshold: <@ additionalInput.livenessProbe.failureThreshold | default(6) @>
+                                initialDelaySeconds: <@ additionalInput.livenessProbe.initialDelaySeconds | default(30) @>
+                                periodSeconds: <@ additionalInput.livenessProbe.periodSeconds | default(10) @>
+                                successThreshold: <@ additionalInput.livenessProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.livenessProbe.timeoutSeconds | default(5) @>
+                              metrics:
+                                customMetrics: {}
+                                enabled: <@ additionalInput.metrics.enabled | default(false) | tojson @>
+                                extraEnvVars: <@ additionalInput.metrics.extraEnvVars | default(None | tojson) @>
+                                image:
+                                  pullPolicy: <@ additionalInput.metrics.image.pullPolicy | default("IfNotPresent") @>
+                                  pullSecrets: <@ additionalInput.metrics.image.pullSecrets | default(None | tojson) @>
+                                  registry: <@ additionalInput.metrics.image.registry | default("docker.io") @>
+                                  repository: <@ additionalInput.metrics.image.repository | default("bitnami/postgres-exporter") @>
+                                  tag: <@ additionalInput.metrics.image.tag | default("0.10.0-debian-10-r27") @>
+                                livenessProbe:
+                                  enabled: <@ additionalInput.metrics.livenessProbe.enabled | default(true) | tojson @>
+                                  failureThreshold: <@ additionalInput.metrics.livenessProbe.failureThreshold | default(6) @>
+                                  initialDelaySeconds: <@ additionalInput.metrics.livenessProbe.initialDelaySeconds | default(5) @>
+                                  periodSeconds: <@ additionalInput.metrics.livenessProbe.periodSeconds | default(10) @>
+                                  successThreshold: <@ additionalInput.metrics.livenessProbe.successThreshold | default(1) @>
+                                  timeoutSeconds: <@ additionalInput.metrics.livenessProbe.timeoutSeconds | default(5) @>
+                                prometheusRule:
+                                  additionalLabels: {}
+                                  enabled: <@ additionalInput.metrics.prometheusRule.enabled | default(false) | tojson @>
+                                  namespace: <@ additionalInput.metrics.prometheusRule.namespace | default("''") @>
+                                  rules: <@ additionalInput.metrics.prometheusRule.rules | default(None | tojson) @>
+                                readinessProbe:
+                                  enabled: <@ additionalInput.metrics.readinessProbe.enabled | default(true) | tojson @>
+                                  failureThreshold: <@ additionalInput.metrics.readinessProbe.failureThreshold | default(6) @>
+                                  initialDelaySeconds: <@ additionalInput.metrics.readinessProbe.initialDelaySeconds | default(5) @>
+                                  periodSeconds: <@ additionalInput.metrics.readinessProbe.periodSeconds | default(10) @>
+                                  successThreshold: <@ additionalInput.metrics.readinessProbe.successThreshold | default(1) @>
+                                  timeoutSeconds: <@ additionalInput.metrics.readinessProbe.timeoutSeconds | default(5) @>
+                                resources: {}
+                                securityContext:
+                                  enabled: <@ additionalInput.metrics.securityContext.enabled | default(false) | tojson @>
+                                  runAsUser: <@ additionalInput.metrics.securityContext.runAsUser | default(1001) @>
+                                service:
+                                  annotations:
+                                    prometheus.io/port: <@ additionalInput.metrics.service.annotations["prometheus.io/port"] | default("9187") @>
+                                    prometheus.io/scrape: <@ additionalInput.metrics.service.annotations["prometheus.io/scrape"] | default("true") @>
+                                  loadBalancerIP: <@ additionalInput.metrics.service.loadBalancerIP | default("''") @>
+                                  type: <@ additionalInput.metrics.service.type | default("ClusterIP") @>
+                                serviceMonitor:
+                                  additionalLabels: {}
+                                  enabled: <@ additionalInput.metrics.serviceMonitor.enabled | default(false) | tojson @>
+                                  interval: <@ additionalInput.metrics.serviceMonitor.interval | default("''") @>
+                                  metricRelabelings: <@ additionalInput.metrics.serviceMonitor.metricRelabelings | default(None | tojson) @>
+                                  namespace: <@ additionalInput.metrics.serviceMonitor.namespace | default("''") @>
+                                  relabelings: <@ additionalInput.metrics.serviceMonitor.relabelings | default(None | tojson) @>
+                                  scrapeTimeout: <@ additionalInput.metrics.serviceMonitor.scrapeTimeout | default("''") @>
+                              nameOverride: <@ additionalInput.nameOverride | default("''") @>
+                              networkPolicy:
+                                allowExternal: <@ additionalInput.networkPolicy.allowExternal | default(true) | tojson @>
+                                enabled: <@ additionalInput.networkPolicy.enabled | default(false) | tojson @>
+                                explicitNamespacesSelector: {}
+                              persistence:
+                                accessModes: <@ additionalInput.persistence.accessModes | default(["ReadWriteOnce"]) @>
+                                annotations: {}
+                                enabled: <@ additionalInput.persistence.enabled | default(true) | tojson @>
+                                existingClaim: <@ additionalInput.persistence.existingClaim | default("''") @>
+                                mountPath: <@ additionalInput.persistence.mountPath | default("/bitnami/postgresql") @>
+                                selector: {}
+                                size: <@ additionalInput.persistence.size | default("8Gi") @>
+                                storageClass: <@ additionalInput.persistence.storageClass | default("''") @>
+                                subPath: <@ additionalInput.persistence.subPath | default("''") @>
+                              pgHbaConfiguration: <@ additionalInput.pgHbaConfiguration | default("''") @>
+                              postgresqlConfiguration: {}
+                              postgresqlDataDir: <@ additionalInput.postgresqlDataDir | default("/bitnami/postgresql/data") @>
+                              postgresqlDatabase: <@ additionalInput.postgresqlDatabase | default("''") @>
+                              postgresqlDbUserConnectionLimit: <@ additionalInput.postgresqlDbUserConnectionLimit | default("''") @>
+                              postgresqlExtendedConf: {}
+                              postgresqlInitdbArgs: <@ additionalInput.postgresqlInitdbArgs | default("''") @>
+                              postgresqlInitdbWalDir: <@ additionalInput.postgresqlInitdbWalDir | default("''") @>
+                              postgresqlMaxConnections: <@ additionalInput.postgresqlMaxConnections | default("''") @>
+                              postgresqlPassword: <@ additionalInput.postgresqlPassword | default("''") @>
+                              postgresqlPghbaRemoveFilters: <@ additionalInput.postgresqlPghbaRemoveFilters | default("''") @>
+                              postgresqlPostgresConnectionLimit: <@ additionalInput.postgresqlPostgresConnectionLimit | default("''") @>
+                              postgresqlPostgresPassword: <@ additionalInput.postgresqlPostgresPassword | default("''") @>
+                              postgresqlSharedPreloadLibraries: <@ additionalInput.postgresqlSharedPreloadLibraries | default("pgaudit") @>
+                              postgresqlStatementTimeout: <@ additionalInput.postgresqlStatementTimeout | default("''") @>
+                              postgresqlTcpKeepalivesCount: <@ additionalInput.postgresqlTcpKeepalivesCount | default("''") @>
+                              postgresqlTcpKeepalivesIdle: <@ additionalInput.postgresqlTcpKeepalivesIdle | default("''") @>
+                              postgresqlTcpKeepalivesInterval: <@ additionalInput.postgresqlTcpKeepalivesInterval | default("''") @>
+                              postgresqlUsername: <@ additionalInput.postgresqlUsername | default("postgres") @>
+                              primary:
+                                affinity: {}
+                                annotations: {}
+                                extraInitContainers: <@ additionalInput.primary.extraInitContainers | default(None | tojson) @>
+                                extraVolumeMounts: <@ additionalInput.primary.extraVolumeMounts | default(None | tojson) @>
+                                extraVolumes: <@ additionalInput.primary.extraVolumes | default(None | tojson) @>
+                                labels: {}
+                                nodeAffinityPreset:
+                                  key: <@ additionalInput.primary.nodeAffinityPreset.key | default("''") @>
+                                  type: <@ additionalInput.primary.nodeAffinityPreset.type | default("''") @>
+                                  values: <@ additionalInput.primary.nodeAffinityPreset.values | default(None | tojson) @>
+                                nodeSelector: {}
+                                podAffinityPreset: <@ additionalInput.primary.podAffinityPreset | default("''") @>
+                                podAnnotations: {}
+                                podAntiAffinityPreset: <@ additionalInput.primary.podAntiAffinityPreset | default("soft") @>
+                                podLabels: {}
+                                priorityClassName: <@ additionalInput.primary.priorityClassName | default("''") @>
+                                service:
+                                  clusterIP: <@ additionalInput.primary.service.clusterIP | default("''") @>
+                                  nodePort: <@ additionalInput.primary.service.nodePort | default("''") @>
+                                  type: <@ additionalInput.primary.service.type | default("''") @>
+                                sidecars: <@ additionalInput.primary.sidecars | default(None | tojson) @>
+                                tolerations: <@ additionalInput.primary.tolerations | default(None | tojson) @>
+                              primaryAsStandBy:
+                                enabled: <@ additionalInput.primaryAsStandBy.enabled | default(false) | tojson @>
+                                primaryHost: <@ additionalInput.primaryAsStandBy.primaryHost | default("''") @>
+                                primaryPort: <@ additionalInput.primaryAsStandBy.primaryPort | default("''") @>
+                              psp:
+                                create: <@ additionalInput.psp.create | default(false) | tojson @>
+                              rbac:
+                                create: <@ additionalInput.rbac.create | default(false) | tojson @>
+                              readReplicas:
+                                affinity: {}
+                                annotations: {}
+                                extraInitContainers: <@ additionalInput.readReplicas.extraInitContainers | default(None | tojson) @>
+                                extraVolumeMounts: <@ additionalInput.readReplicas.extraVolumeMounts | default(None | tojson) @>
+                                extraVolumes: <@ additionalInput.readReplicas.extraVolumes | default(None | tojson) @>
+                                labels: {}
+                                nodeAffinityPreset:
+                                  key: <@ additionalInput.readReplicas.nodeAffinityPreset.key | default("''") @>
+                                  type: <@ additionalInput.readReplicas.nodeAffinityPreset.type | default("''") @>
+                                  values: <@ additionalInput.readReplicas.nodeAffinityPreset.values | default(None | tojson) @>
+                                nodeSelector: {}
+                                persistence:
+                                  enabled: <@ additionalInput.readReplicas.persistence.enabled | default(true) | tojson @>
+                                podAffinityPreset: <@ additionalInput.readReplicas.podAffinityPreset | default("''") @>
+                                podAnnotations: {}
+                                podAntiAffinityPreset: <@ additionalInput.readReplicas.podAntiAffinityPreset | default("soft") @>
+                                podLabels: {}
+                                priorityClassName: <@ additionalInput.readReplicas.priorityClassName | default("''") @>
+                                resources: {}
+                                service:
+                                  clusterIP: <@ additionalInput.readReplicas.service.clusterIP | default("''") @>
+                                  nodePort: <@ additionalInput.readReplicas.service.nodePort | default("''") @>
+                                  type: <@ additionalInput.readReplicas.service.type | default("''") @>
+                                sidecars: <@ additionalInput.readReplicas.sidecars | default(None | tojson) @>
+                                tolerations: <@ additionalInput.readReplicas.tolerations | default(None | tojson) @>
+                              readinessProbe:
+                                enabled: <@ additionalInput.readinessProbe.enabled | default(true) | tojson @>
+                                failureThreshold: <@ additionalInput.readinessProbe.failureThreshold | default(6) @>
+                                initialDelaySeconds: <@ additionalInput.readinessProbe.initialDelaySeconds | default(5) @>
+                                periodSeconds: <@ additionalInput.readinessProbe.periodSeconds | default(10) @>
+                                successThreshold: <@ additionalInput.readinessProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.readinessProbe.timeoutSeconds | default(5) @>
+                              replication:
+                                applicationName: <@ additionalInput.replication.applicationName | default("my_application") @>
+                                enabled: <@ additionalInput.replication.enabled | default(false) | tojson @>
+                                numSynchronousReplicas: <@ additionalInput.replication.numSynchronousReplicas | default(0) @>
+                                password: <@ additionalInput.replication.password | default("repl_password") @>
+                                readReplicas: <@ additionalInput.replication.readReplicas | default(1) @>
+                                singleService: <@ additionalInput.replication.singleService | default(true) | tojson @>
+                                synchronousCommit: <@ additionalInput.replication.synchronousCommit | default("off") @>
+                                uniqueServices: <@ additionalInput.replication.uniqueServices | default(false) | tojson @>
+                                user: <@ additionalInput.replication.user | default("repl_user") @>
+                              resources:
+                                requests:
+                                  cpu: <@ additionalInput.resources.requests.cpu | default("250m") @>
+                                  memory: <@ additionalInput.resources.requests.memory | default("256Mi") @>
+                              schedulerName: <@ additionalInput.schedulerName | default("''") @>
+                              securityContext:
+                                enabled: <@ additionalInput.securityContext.enabled | default(true) | tojson @>
+                                fsGroup: <@ additionalInput.securityContext.fsGroup | default(1001) @>
+                              service:
+                                annotations: {}
+                                clusterIP: <@ additionalInput.service.clusterIP | default("''") @>
+                                loadBalancerIP: <@ additionalInput.service.loadBalancerIP | default("''") @>
+                                loadBalancerSourceRanges: <@ additionalInput.service.loadBalancerSourceRanges | default(None | tojson) @>
+                                nodePort: <@ additionalInput.service.nodePort | default("''") @>
+                                port: <@ additionalInput.service.port | default(5432) @>
+                                type: <@ additionalInput.service.type | default("ClusterIP") @>
+                              serviceAccount:
+                                autoMount: <@ additionalInput.serviceAccount.autoMount | default(false) | tojson @>
+                                enabled: <@ additionalInput.serviceAccount.enabled | default(false) | tojson @>
+                                name: <@ additionalInput.serviceAccount.name | default("''") @>
+                              shmVolume:
+                                chmod:
+                                  enabled: <@ additionalInput.shmVolume.chmod.enabled | default(true) | tojson @>
+                                enabled: <@ additionalInput.shmVolume.enabled | default(true) | tojson @>
+                                sizeLimit: <@ additionalInput.shmVolume.sizeLimit | default("''") @>
+                              startupProbe:
+                                enabled: <@ additionalInput.startupProbe.enabled | default(false) | tojson @>
+                                failureThreshold: <@ additionalInput.startupProbe.failureThreshold | default(10) @>
+                                initialDelaySeconds: <@ additionalInput.startupProbe.initialDelaySeconds | default(30) @>
+                                periodSeconds: <@ additionalInput.startupProbe.periodSeconds | default(15) @>
+                                successThreshold: <@ additionalInput.startupProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.startupProbe.timeoutSeconds | default(5) @>
+                              terminationGracePeriodSeconds: <@ additionalInput.terminationGracePeriodSeconds | default("''") @>
+                              tls:
+                                autoGenerated: <@ additionalInput.tls.autoGenerated | default(false) | tojson @>
+                                certCAFilename: <@ additionalInput.tls.certCAFilename | default("''") @>
+                                certFilename: <@ additionalInput.tls.certFilename | default("''") @>
+                                certKeyFilename: <@ additionalInput.tls.certKeyFilename | default("''") @>
+                                certificatesSecret: <@ additionalInput.tls.certificatesSecret | default("''") @>
+                                crlFilename: <@ additionalInput.tls.crlFilename | default("''") @>
+                                enabled: <@ additionalInput.tls.enabled | default(false) | tojson @>
+                                preferServerCiphers: <@ additionalInput.tls.preferServerCiphers | default(true) | tojson @>
+                              updateStrategy:
+                                type: <@ additionalInput.updateStrategy.type | default("RollingUpdate") @>
+                              usePasswordFile: <@ additionalInput.usePasswordFile | default(false) | tojson @>
+                              volumePermissions:
+                                enabled: <@ additionalInput.volumePermissions.enabled | default(false) | tojson @>
+                                image:
+                                  pullPolicy: <@ additionalInput.volumePermissions.image.pullPolicy | default("Always") @>
+                                  pullSecrets: <@ additionalInput.volumePermissions.image.pullSecrets | default(None | tojson) @>
+                                  registry: <@ additionalInput.volumePermissions.image.registry | default("docker.io") @>
+                                  repository: <@ additionalInput.volumePermissions.image.repository | default("bitnami/bitnami-shell") @>
+                                  tag: <@ additionalInput.volumePermissions.image.tag | default("10-debian-10-r159") @>
+                                securityContext:
+                                  runAsUser: <@ additionalInput.volumePermissions.securityContext.runAsUser | default(0) @>
+                              
+                            output:
+                              goTemplate: |
+                                # TODO(ContentDeveloper): Add output template in YAML
+
+              - - name: fill-parameters
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.create-helm-args.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: helm-release
+                      from: helm-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              - - name: render-config
+                  capact-outputTypeInstances:
+                    - name: config
+                      from: render
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: configuration
+                        raw:
+                          data: ""
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
+                          data: |
+                            property: value

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.helm.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.helm.test.yaml
@@ -1,0 +1,436 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.helm"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      typeRef:
+        path: "cap.type.helm.test-input"
+        revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    config:
+      uses:
+        - helm-release
+
+  implements:
+    - path: cap.interface.group.test
+      revision: 0.2.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.runner.helm
+      alias: helm
+      methods:
+        - name: install
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: deploy
+        templates:
+          - name: deploy
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts: []
+            steps:
+              - - name: fill-default-input
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
+                          data: |
+                            my_property: <@ input.my_property | default("default_value") @>
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.additional-parameters}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: additionalInput
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "postgresql"
+                              repo: "https://charts.bitnami.com/bitnami"
+                              version: "10.9.2"
+                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
+                              audit:
+                                clientMinMessages: <@ additionalInput.audit.clientMinMessages | default("error") @>
+                                logConnections: <@ additionalInput.audit.logConnections | default(false) | tojson @>
+                                logDisconnections: <@ additionalInput.audit.logDisconnections | default(false) | tojson @>
+                                logHostname: <@ additionalInput.audit.logHostname | default(false) | tojson @>
+                                logLinePrefix: <@ additionalInput.audit.logLinePrefix | default("''") @>
+                                logTimezone: <@ additionalInput.audit.logTimezone | default("''") @>
+                                pgAuditLog: <@ additionalInput.audit.pgAuditLog | default("''") @>
+                                pgAuditLogCatalog: <@ additionalInput.audit.pgAuditLogCatalog | default("off") @>
+                              commonAnnotations: {}
+                              configurationConfigMap: <@ additionalInput.configurationConfigMap | default("''") @>
+                              containerSecurityContext:
+                                enabled: <@ additionalInput.containerSecurityContext.enabled | default(true) | tojson @>
+                                runAsUser: <@ additionalInput.containerSecurityContext.runAsUser | default(1001) @>
+                              customLivenessProbe: {}
+                              customReadinessProbe: {}
+                              customStartupProbe: {}
+                              diagnosticMode:
+                                args: <@ additionalInput.diagnosticMode.args | default(["infinity"]) @>
+                                command: <@ additionalInput.diagnosticMode.command | default(["sleep"]) @>
+                                enabled: <@ additionalInput.diagnosticMode.enabled | default(false) | tojson @>
+                              existingSecret: <@ additionalInput.existingSecret | default("''") @>
+                              extendedConfConfigMap: <@ additionalInput.extendedConfConfigMap | default("''") @>
+                              extraDeploy: <@ additionalInput.extraDeploy | default(None | tojson) @>
+                              extraEnv: <@ additionalInput.extraEnv | default(None | tojson) @>
+                              extraEnvVarsCM: <@ additionalInput.extraEnvVarsCM | default("''") @>
+                              fullnameOverride: <@ additionalInput.fullnameOverride | default("''") @>
+                              global:
+                                imagePullSecrets: <@ additionalInput.global.imagePullSecrets | default(None | tojson) @>
+                                imageRegistry: <@ additionalInput.global.imageRegistry | default("''") @>
+                                postgresql:
+                                  existingSecret: <@ additionalInput.global.postgresql.existingSecret | default("''") @>
+                                  postgresqlDatabase: <@ additionalInput.global.postgresql.postgresqlDatabase | default("''") @>
+                                  postgresqlPassword: <@ additionalInput.global.postgresql.postgresqlPassword | default("''") @>
+                                  postgresqlUsername: <@ additionalInput.global.postgresql.postgresqlUsername | default("''") @>
+                                  replicationPassword: <@ additionalInput.global.postgresql.replicationPassword | default("''") @>
+                                  servicePort: <@ additionalInput.global.postgresql.servicePort | default("''") @>
+                                storageClass: <@ additionalInput.global.storageClass | default("''") @>
+                              image:
+                                debug: <@ additionalInput.image.debug | default(false) | tojson @>
+                                pullPolicy: <@ additionalInput.image.pullPolicy | default("IfNotPresent") @>
+                                pullSecrets: <@ additionalInput.image.pullSecrets | default(None | tojson) @>
+                                registry: <@ additionalInput.image.registry | default("docker.io") @>
+                                repository: <@ additionalInput.image.repository | default("bitnami/postgresql") @>
+                                tag: <@ additionalInput.image.tag | default("11.13.0-debian-10-r0") @>
+                              initdbPassword: <@ additionalInput.initdbPassword | default("''") @>
+                              initdbScripts: {}
+                              initdbScriptsConfigMap: <@ additionalInput.initdbScriptsConfigMap | default("''") @>
+                              initdbScriptsSecret: <@ additionalInput.initdbScriptsSecret | default("''") @>
+                              initdbUser: <@ additionalInput.initdbUser | default("''") @>
+                              ldap:
+                                baseDN: <@ additionalInput.ldap.baseDN | default("''") @>
+                                bind_password: <@ additionalInput.ldap.bind_password | default("''") @>
+                                bindDN: <@ additionalInput.ldap.bindDN | default("''") @>
+                                enabled: <@ additionalInput.ldap.enabled | default(false) | tojson @>
+                                port: <@ additionalInput.ldap.port | default("''") @>
+                                prefix: <@ additionalInput.ldap.prefix | default("''") @>
+                                scheme: <@ additionalInput.ldap.scheme | default("''") @>
+                                search_attr: <@ additionalInput.ldap.search_attr | default("''") @>
+                                search_filter: <@ additionalInput.ldap.search_filter | default("''") @>
+                                server: <@ additionalInput.ldap.server | default("''") @>
+                                suffix: <@ additionalInput.ldap.suffix | default("''") @>
+                                tls: <@ additionalInput.ldap.tls | default("''") @>
+                                url: <@ additionalInput.ldap.url | default("''") @>
+                              lifecycleHooks: {}
+                              livenessProbe:
+                                enabled: <@ additionalInput.livenessProbe.enabled | default(true) | tojson @>
+                                failureThreshold: <@ additionalInput.livenessProbe.failureThreshold | default(6) @>
+                                initialDelaySeconds: <@ additionalInput.livenessProbe.initialDelaySeconds | default(30) @>
+                                periodSeconds: <@ additionalInput.livenessProbe.periodSeconds | default(10) @>
+                                successThreshold: <@ additionalInput.livenessProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.livenessProbe.timeoutSeconds | default(5) @>
+                              metrics:
+                                customMetrics: {}
+                                enabled: <@ additionalInput.metrics.enabled | default(false) | tojson @>
+                                extraEnvVars: <@ additionalInput.metrics.extraEnvVars | default(None | tojson) @>
+                                image:
+                                  pullPolicy: <@ additionalInput.metrics.image.pullPolicy | default("IfNotPresent") @>
+                                  pullSecrets: <@ additionalInput.metrics.image.pullSecrets | default(None | tojson) @>
+                                  registry: <@ additionalInput.metrics.image.registry | default("docker.io") @>
+                                  repository: <@ additionalInput.metrics.image.repository | default("bitnami/postgres-exporter") @>
+                                  tag: <@ additionalInput.metrics.image.tag | default("0.10.0-debian-10-r27") @>
+                                livenessProbe:
+                                  enabled: <@ additionalInput.metrics.livenessProbe.enabled | default(true) | tojson @>
+                                  failureThreshold: <@ additionalInput.metrics.livenessProbe.failureThreshold | default(6) @>
+                                  initialDelaySeconds: <@ additionalInput.metrics.livenessProbe.initialDelaySeconds | default(5) @>
+                                  periodSeconds: <@ additionalInput.metrics.livenessProbe.periodSeconds | default(10) @>
+                                  successThreshold: <@ additionalInput.metrics.livenessProbe.successThreshold | default(1) @>
+                                  timeoutSeconds: <@ additionalInput.metrics.livenessProbe.timeoutSeconds | default(5) @>
+                                prometheusRule:
+                                  additionalLabels: {}
+                                  enabled: <@ additionalInput.metrics.prometheusRule.enabled | default(false) | tojson @>
+                                  namespace: <@ additionalInput.metrics.prometheusRule.namespace | default("''") @>
+                                  rules: <@ additionalInput.metrics.prometheusRule.rules | default(None | tojson) @>
+                                readinessProbe:
+                                  enabled: <@ additionalInput.metrics.readinessProbe.enabled | default(true) | tojson @>
+                                  failureThreshold: <@ additionalInput.metrics.readinessProbe.failureThreshold | default(6) @>
+                                  initialDelaySeconds: <@ additionalInput.metrics.readinessProbe.initialDelaySeconds | default(5) @>
+                                  periodSeconds: <@ additionalInput.metrics.readinessProbe.periodSeconds | default(10) @>
+                                  successThreshold: <@ additionalInput.metrics.readinessProbe.successThreshold | default(1) @>
+                                  timeoutSeconds: <@ additionalInput.metrics.readinessProbe.timeoutSeconds | default(5) @>
+                                resources: {}
+                                securityContext:
+                                  enabled: <@ additionalInput.metrics.securityContext.enabled | default(false) | tojson @>
+                                  runAsUser: <@ additionalInput.metrics.securityContext.runAsUser | default(1001) @>
+                                service:
+                                  annotations:
+                                    prometheus.io/port: <@ additionalInput.metrics.service.annotations["prometheus.io/port"] | default("9187") @>
+                                    prometheus.io/scrape: <@ additionalInput.metrics.service.annotations["prometheus.io/scrape"] | default("true") @>
+                                  loadBalancerIP: <@ additionalInput.metrics.service.loadBalancerIP | default("''") @>
+                                  type: <@ additionalInput.metrics.service.type | default("ClusterIP") @>
+                                serviceMonitor:
+                                  additionalLabels: {}
+                                  enabled: <@ additionalInput.metrics.serviceMonitor.enabled | default(false) | tojson @>
+                                  interval: <@ additionalInput.metrics.serviceMonitor.interval | default("''") @>
+                                  metricRelabelings: <@ additionalInput.metrics.serviceMonitor.metricRelabelings | default(None | tojson) @>
+                                  namespace: <@ additionalInput.metrics.serviceMonitor.namespace | default("''") @>
+                                  relabelings: <@ additionalInput.metrics.serviceMonitor.relabelings | default(None | tojson) @>
+                                  scrapeTimeout: <@ additionalInput.metrics.serviceMonitor.scrapeTimeout | default("''") @>
+                              nameOverride: <@ additionalInput.nameOverride | default("''") @>
+                              networkPolicy:
+                                allowExternal: <@ additionalInput.networkPolicy.allowExternal | default(true) | tojson @>
+                                enabled: <@ additionalInput.networkPolicy.enabled | default(false) | tojson @>
+                                explicitNamespacesSelector: {}
+                              persistence:
+                                accessModes: <@ additionalInput.persistence.accessModes | default(["ReadWriteOnce"]) @>
+                                annotations: {}
+                                enabled: <@ additionalInput.persistence.enabled | default(true) | tojson @>
+                                existingClaim: <@ additionalInput.persistence.existingClaim | default("''") @>
+                                mountPath: <@ additionalInput.persistence.mountPath | default("/bitnami/postgresql") @>
+                                selector: {}
+                                size: <@ additionalInput.persistence.size | default("8Gi") @>
+                                storageClass: <@ additionalInput.persistence.storageClass | default("''") @>
+                                subPath: <@ additionalInput.persistence.subPath | default("''") @>
+                              pgHbaConfiguration: <@ additionalInput.pgHbaConfiguration | default("''") @>
+                              postgresqlConfiguration: {}
+                              postgresqlDataDir: <@ additionalInput.postgresqlDataDir | default("/bitnami/postgresql/data") @>
+                              postgresqlDatabase: <@ additionalInput.postgresqlDatabase | default("''") @>
+                              postgresqlDbUserConnectionLimit: <@ additionalInput.postgresqlDbUserConnectionLimit | default("''") @>
+                              postgresqlExtendedConf: {}
+                              postgresqlInitdbArgs: <@ additionalInput.postgresqlInitdbArgs | default("''") @>
+                              postgresqlInitdbWalDir: <@ additionalInput.postgresqlInitdbWalDir | default("''") @>
+                              postgresqlMaxConnections: <@ additionalInput.postgresqlMaxConnections | default("''") @>
+                              postgresqlPassword: <@ additionalInput.postgresqlPassword | default("''") @>
+                              postgresqlPghbaRemoveFilters: <@ additionalInput.postgresqlPghbaRemoveFilters | default("''") @>
+                              postgresqlPostgresConnectionLimit: <@ additionalInput.postgresqlPostgresConnectionLimit | default("''") @>
+                              postgresqlPostgresPassword: <@ additionalInput.postgresqlPostgresPassword | default("''") @>
+                              postgresqlSharedPreloadLibraries: <@ additionalInput.postgresqlSharedPreloadLibraries | default("pgaudit") @>
+                              postgresqlStatementTimeout: <@ additionalInput.postgresqlStatementTimeout | default("''") @>
+                              postgresqlTcpKeepalivesCount: <@ additionalInput.postgresqlTcpKeepalivesCount | default("''") @>
+                              postgresqlTcpKeepalivesIdle: <@ additionalInput.postgresqlTcpKeepalivesIdle | default("''") @>
+                              postgresqlTcpKeepalivesInterval: <@ additionalInput.postgresqlTcpKeepalivesInterval | default("''") @>
+                              postgresqlUsername: <@ additionalInput.postgresqlUsername | default("postgres") @>
+                              primary:
+                                affinity: {}
+                                annotations: {}
+                                extraInitContainers: <@ additionalInput.primary.extraInitContainers | default(None | tojson) @>
+                                extraVolumeMounts: <@ additionalInput.primary.extraVolumeMounts | default(None | tojson) @>
+                                extraVolumes: <@ additionalInput.primary.extraVolumes | default(None | tojson) @>
+                                labels: {}
+                                nodeAffinityPreset:
+                                  key: <@ additionalInput.primary.nodeAffinityPreset.key | default("''") @>
+                                  type: <@ additionalInput.primary.nodeAffinityPreset.type | default("''") @>
+                                  values: <@ additionalInput.primary.nodeAffinityPreset.values | default(None | tojson) @>
+                                nodeSelector: {}
+                                podAffinityPreset: <@ additionalInput.primary.podAffinityPreset | default("''") @>
+                                podAnnotations: {}
+                                podAntiAffinityPreset: <@ additionalInput.primary.podAntiAffinityPreset | default("soft") @>
+                                podLabels: {}
+                                priorityClassName: <@ additionalInput.primary.priorityClassName | default("''") @>
+                                service:
+                                  clusterIP: <@ additionalInput.primary.service.clusterIP | default("''") @>
+                                  nodePort: <@ additionalInput.primary.service.nodePort | default("''") @>
+                                  type: <@ additionalInput.primary.service.type | default("''") @>
+                                sidecars: <@ additionalInput.primary.sidecars | default(None | tojson) @>
+                                tolerations: <@ additionalInput.primary.tolerations | default(None | tojson) @>
+                              primaryAsStandBy:
+                                enabled: <@ additionalInput.primaryAsStandBy.enabled | default(false) | tojson @>
+                                primaryHost: <@ additionalInput.primaryAsStandBy.primaryHost | default("''") @>
+                                primaryPort: <@ additionalInput.primaryAsStandBy.primaryPort | default("''") @>
+                              psp:
+                                create: <@ additionalInput.psp.create | default(false) | tojson @>
+                              rbac:
+                                create: <@ additionalInput.rbac.create | default(false) | tojson @>
+                              readReplicas:
+                                affinity: {}
+                                annotations: {}
+                                extraInitContainers: <@ additionalInput.readReplicas.extraInitContainers | default(None | tojson) @>
+                                extraVolumeMounts: <@ additionalInput.readReplicas.extraVolumeMounts | default(None | tojson) @>
+                                extraVolumes: <@ additionalInput.readReplicas.extraVolumes | default(None | tojson) @>
+                                labels: {}
+                                nodeAffinityPreset:
+                                  key: <@ additionalInput.readReplicas.nodeAffinityPreset.key | default("''") @>
+                                  type: <@ additionalInput.readReplicas.nodeAffinityPreset.type | default("''") @>
+                                  values: <@ additionalInput.readReplicas.nodeAffinityPreset.values | default(None | tojson) @>
+                                nodeSelector: {}
+                                persistence:
+                                  enabled: <@ additionalInput.readReplicas.persistence.enabled | default(true) | tojson @>
+                                podAffinityPreset: <@ additionalInput.readReplicas.podAffinityPreset | default("''") @>
+                                podAnnotations: {}
+                                podAntiAffinityPreset: <@ additionalInput.readReplicas.podAntiAffinityPreset | default("soft") @>
+                                podLabels: {}
+                                priorityClassName: <@ additionalInput.readReplicas.priorityClassName | default("''") @>
+                                resources: {}
+                                service:
+                                  clusterIP: <@ additionalInput.readReplicas.service.clusterIP | default("''") @>
+                                  nodePort: <@ additionalInput.readReplicas.service.nodePort | default("''") @>
+                                  type: <@ additionalInput.readReplicas.service.type | default("''") @>
+                                sidecars: <@ additionalInput.readReplicas.sidecars | default(None | tojson) @>
+                                tolerations: <@ additionalInput.readReplicas.tolerations | default(None | tojson) @>
+                              readinessProbe:
+                                enabled: <@ additionalInput.readinessProbe.enabled | default(true) | tojson @>
+                                failureThreshold: <@ additionalInput.readinessProbe.failureThreshold | default(6) @>
+                                initialDelaySeconds: <@ additionalInput.readinessProbe.initialDelaySeconds | default(5) @>
+                                periodSeconds: <@ additionalInput.readinessProbe.periodSeconds | default(10) @>
+                                successThreshold: <@ additionalInput.readinessProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.readinessProbe.timeoutSeconds | default(5) @>
+                              replication:
+                                applicationName: <@ additionalInput.replication.applicationName | default("my_application") @>
+                                enabled: <@ additionalInput.replication.enabled | default(false) | tojson @>
+                                numSynchronousReplicas: <@ additionalInput.replication.numSynchronousReplicas | default(0) @>
+                                password: <@ additionalInput.replication.password | default("repl_password") @>
+                                readReplicas: <@ additionalInput.replication.readReplicas | default(1) @>
+                                singleService: <@ additionalInput.replication.singleService | default(true) | tojson @>
+                                synchronousCommit: <@ additionalInput.replication.synchronousCommit | default("off") @>
+                                uniqueServices: <@ additionalInput.replication.uniqueServices | default(false) | tojson @>
+                                user: <@ additionalInput.replication.user | default("repl_user") @>
+                              resources:
+                                requests:
+                                  cpu: <@ additionalInput.resources.requests.cpu | default("250m") @>
+                                  memory: <@ additionalInput.resources.requests.memory | default("256Mi") @>
+                              schedulerName: <@ additionalInput.schedulerName | default("''") @>
+                              securityContext:
+                                enabled: <@ additionalInput.securityContext.enabled | default(true) | tojson @>
+                                fsGroup: <@ additionalInput.securityContext.fsGroup | default(1001) @>
+                              service:
+                                annotations: {}
+                                clusterIP: <@ additionalInput.service.clusterIP | default("''") @>
+                                loadBalancerIP: <@ additionalInput.service.loadBalancerIP | default("''") @>
+                                loadBalancerSourceRanges: <@ additionalInput.service.loadBalancerSourceRanges | default(None | tojson) @>
+                                nodePort: <@ additionalInput.service.nodePort | default("''") @>
+                                port: <@ additionalInput.service.port | default(5432) @>
+                                type: <@ additionalInput.service.type | default("ClusterIP") @>
+                              serviceAccount:
+                                autoMount: <@ additionalInput.serviceAccount.autoMount | default(false) | tojson @>
+                                enabled: <@ additionalInput.serviceAccount.enabled | default(false) | tojson @>
+                                name: <@ additionalInput.serviceAccount.name | default("''") @>
+                              shmVolume:
+                                chmod:
+                                  enabled: <@ additionalInput.shmVolume.chmod.enabled | default(true) | tojson @>
+                                enabled: <@ additionalInput.shmVolume.enabled | default(true) | tojson @>
+                                sizeLimit: <@ additionalInput.shmVolume.sizeLimit | default("''") @>
+                              startupProbe:
+                                enabled: <@ additionalInput.startupProbe.enabled | default(false) | tojson @>
+                                failureThreshold: <@ additionalInput.startupProbe.failureThreshold | default(10) @>
+                                initialDelaySeconds: <@ additionalInput.startupProbe.initialDelaySeconds | default(30) @>
+                                periodSeconds: <@ additionalInput.startupProbe.periodSeconds | default(15) @>
+                                successThreshold: <@ additionalInput.startupProbe.successThreshold | default(1) @>
+                                timeoutSeconds: <@ additionalInput.startupProbe.timeoutSeconds | default(5) @>
+                              terminationGracePeriodSeconds: <@ additionalInput.terminationGracePeriodSeconds | default("''") @>
+                              tls:
+                                autoGenerated: <@ additionalInput.tls.autoGenerated | default(false) | tojson @>
+                                certCAFilename: <@ additionalInput.tls.certCAFilename | default("''") @>
+                                certFilename: <@ additionalInput.tls.certFilename | default("''") @>
+                                certKeyFilename: <@ additionalInput.tls.certKeyFilename | default("''") @>
+                                certificatesSecret: <@ additionalInput.tls.certificatesSecret | default("''") @>
+                                crlFilename: <@ additionalInput.tls.crlFilename | default("''") @>
+                                enabled: <@ additionalInput.tls.enabled | default(false) | tojson @>
+                                preferServerCiphers: <@ additionalInput.tls.preferServerCiphers | default(true) | tojson @>
+                              updateStrategy:
+                                type: <@ additionalInput.updateStrategy.type | default("RollingUpdate") @>
+                              usePasswordFile: <@ additionalInput.usePasswordFile | default(false) | tojson @>
+                              volumePermissions:
+                                enabled: <@ additionalInput.volumePermissions.enabled | default(false) | tojson @>
+                                image:
+                                  pullPolicy: <@ additionalInput.volumePermissions.image.pullPolicy | default("Always") @>
+                                  pullSecrets: <@ additionalInput.volumePermissions.image.pullSecrets | default(None | tojson) @>
+                                  registry: <@ additionalInput.volumePermissions.image.registry | default("docker.io") @>
+                                  repository: <@ additionalInput.volumePermissions.image.repository | default("bitnami/bitnami-shell") @>
+                                  tag: <@ additionalInput.volumePermissions.image.tag | default("10-debian-10-r159") @>
+                                securityContext:
+                                  runAsUser: <@ additionalInput.volumePermissions.securityContext.runAsUser | default(0) @>
+                              
+                            output:
+                              goTemplate: |
+                                # TODO(ContentDeveloper): Add output template in YAML
+
+              - - name: fill-parameters
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.create-helm-args.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: helm-release
+                      from: helm-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              - - name: render-config
+                  capact-outputTypeInstances:
+                    - name: config
+                      from: render
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: configuration
+                        raw:
+                          data: ""
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
+                          data: |
+                            property: value

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.aws.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.aws.test.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.1.0
 kind: Implementation
 metadata:
-  prefix: "cap.implementation.{{ .Prefix }}"
-  name: {{ .Name }}
-  displayName: "{{ .Name }} Action"
-  description: "{{ .Name }} Action"
+  prefix: "cap.implementation.terraform.aws"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
   documentationURL: https://example.com
   supportURL: https://example.com
   maintainers:
@@ -20,22 +20,23 @@ spec:
   additionalInput:
     parameters:
       typeRef:
-        path: "cap.type.{{ .Prefix }}.{{ .Name }}-input"
+        path: "cap.type.terraform.aws.test-input"
         revision: 0.1.0
 
   outputTypeInstanceRelations:
     config:
       uses:
-        - helm-release
+        - terraform-release
 
   implements:
-    - path: {{if .InterfacePath}}{{ .InterfacePath }}{{else}}"cap.interface..." # TODO(ContentDeveloper): Put here the path of the implemented Interface{{end}}
-      revision: {{if .InterfaceRevision}}{{ .InterfaceRevision }}{{else}}0.1.0{{end}}
+    - path: cap.interface.group.test
+      revision: 0.2.0
 
-  requires:
-    cap.core.type.platform:
-      oneOf:
-        - name: kubernetes
+  requires: 
+    cap.type.aws.auth:
+      allOf:
+        - name: credentials
+          alias: aws-credentials
           revision: 0.1.0
 
   imports:
@@ -49,10 +50,10 @@ spec:
       methods:
         - name: template
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.runner.helm
-      alias: helm
+    - interfaceGroupPath: cap.interface.runner.terraform
+      alias: terraform
       methods:
-        - name: install
+        - name: apply
           revision: 0.1.0
 
   action:
@@ -75,7 +76,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.input-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.input-parameters}}"
                       - name: template
                         raw:
                           # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
@@ -86,12 +87,12 @@ spec:
                           data: |
                             prefix: input
 
-              - - name: create-helm-args
+              - - name: create-module-args
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.additional-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.additional-parameters}}"
                       - name: configuration
                         raw:
                           data: |
@@ -99,41 +100,65 @@ spec:
                       - name: template
                         raw:
                           data: |
-                            generateName: true
-                            chart:
-                              name: "{{ .HelmChartName }}"
-                              repo: "{{ .HelmRepoURL }}"
-                              version: "{{ .HelmChartVersion }}"
-                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
-{{ .ValuesYAML | indent 30 }}
+                            command: "apply"
+                            module:
+                              name: "test"
+                              source: "https://example.com/module.tgz"
+                            env: 
+                              - AWS_ACCESS_KEY_ID=<@ creds.accessKeyID @>
+                              - AWS_SECRET_ACCESS_KEY=<@ creds.secretAccessKey @>
                             output:
-                              goTemplate: |
-                                # TODO(ContentDeveloper): Add output template in YAML
+                              goTemplate:
+                                instance_ids: "{{ .instance_ids }}"
+                                random_number: "{{ .random_number }}"
+                                
+                            variables: |+
+                              <% if additionalInput.count -%>
+                              count = "<@ additionalInput.count @>"
+                              <%- endif %>
 
+                              <% if additionalInput.name -%>
+                              name = "<@ additionalInput.name @>"
+                              <%- endif %>
+
+                              
               - - name: fill-parameters
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: template
-                        from: "{{"{{"}}steps.create-helm-args.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.create-module-args.outputs.artifacts.render}}"
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-default-input.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
                       - name: configuration
                         raw:
                           data: |
                             prefix: input
-
-              - - name: helm-install
-                  capact-action: helm.install
+              
+              - - name: fill-creds
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{workflow.outputs.artifacts.aws-credentials}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: creds
+              
+              - - name: terraform-apply
+                  capact-action: terraform.apply
                   capact-outputTypeInstances:
-                    - name: helm-release
-                      from: helm-release
+                    - name: terraform-release
+                      from: terraform-release
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-parameters.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-creds.outputs.artifacts.render}}"
                       - name: runner-context
-                        from: "{{"{{"}}workflow.outputs.artifacts.runner-context{{"}}"}}"
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
 
               - - name: render-config
                   capact-outputTypeInstances:
@@ -143,7 +168,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.helm-install.outputs.artifacts.additional{{"}}"}}"
+                        from: "{{steps.terraform-apply.outputs.artifacts.additional}}"
                       - name: configuration
                         raw:
                           data: ""
@@ -152,3 +177,4 @@ spec:
                           # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
                           data: |
                             property: value
+          

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.gcp.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.gcp.test.yaml
@@ -1,0 +1,203 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.terraform.gcp"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      typeRef:
+        path: "cap.type.terraform.gcp.test-input"
+        revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    config:
+      uses:
+        - terraform-release
+
+  implements:
+    - path: cap.interface.group.test
+      revision: 0.2.0
+
+  requires: 
+    cap.type.gcp.auth:
+      allOf:
+        - name: service-account
+          alias: gcp-sa
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.runner.terraform
+      alias: terraform
+      methods:
+        - name: apply
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: deploy
+        templates:
+          - name: deploy
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts: []
+            steps:
+              - - name: fill-default-input
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
+                          data: |
+                            my_property: <@ input.my_property | default("default_value") @>
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+
+              - - name: create-module-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.additional-parameters}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: additionalInput
+                      - name: template
+                        raw:
+                          data: |
+                            command: "apply"
+                            module:
+                              name: "test"
+                              source: "https://example.com/module.tgz"
+                            env: 
+                              - GOOGLE_PROJECT=<@ creds.project_id @>
+                              - GOOGLE_APPLICATION_CREDENTIALS=/additional
+                            output:
+                              goTemplate:
+                                instance_ids: "{{ .instance_ids }}"
+                                random_number: "{{ .random_number }}"
+                                
+                            variables: |+
+                              <% if additionalInput.count -%>
+                              count = "<@ additionalInput.count @>"
+                              <%- endif %>
+
+                              <% if additionalInput.name -%>
+                              name = "<@ additionalInput.name @>"
+                              <%- endif %>
+
+                              
+              - - name: fill-parameters
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.create-module-args.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: input
+              
+              - - name: convert-gcp-yaml-to-json
+                  template: convert-yaml-to-json
+                  arguments:
+                    artifacts:
+                      - name: in
+                        from: "{{workflow.outputs.artifacts.gcp-sa}}"
+              
+              - - name: fill-creds
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{workflow.outputs.artifacts.gcp-sa}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: creds
+              
+              - - name: terraform-apply
+                  capact-action: terraform.apply
+                  capact-outputTypeInstances:
+                    - name: terraform-release
+                      from: terraform-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.fill-creds.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+                      - name: additional
+                        from: "{{steps.convert-gcp-yaml-to-json.outputs.artifacts.out}}"
+
+              - - name: render-config
+                  capact-outputTypeInstances:
+                    - name: config
+                      from: render
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.terraform-apply.outputs.artifacts.additional}}"
+                      - name: configuration
+                        raw:
+                          data: ""
+                      - name: template
+                        raw:
+                          # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
+                          data: |
+                            property: value
+          
+          - name: convert-yaml-to-json
+            inputs:
+              artifacts:
+                - name: in
+                  path: /file
+            container:
+              image: ghcr.io/capactio/yq:4 # Original image: mikefarah/yq:4
+              command: ["sh", "-c"]
+              args: ["sleep 1 && yq eval -j -i /file"]
+            outputs:
+              artifacts:
+                - name: out
+                  path: /file
+          

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.generic.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.generic.test.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.1.0
 kind: Implementation
 metadata:
-  prefix: "cap.implementation.{{ .Prefix }}"
-  name: {{ .Name }}
-  displayName: "{{ .Name }} Action"
-  description: "{{ .Name }} Action"
+  prefix: "cap.implementation.terraform.generic"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
   documentationURL: https://example.com
   supportURL: https://example.com
   maintainers:
@@ -20,23 +20,19 @@ spec:
   additionalInput:
     parameters:
       typeRef:
-        path: "cap.type.{{ .Prefix }}.{{ .Name }}-input"
+        path: "cap.type.terraform.generic.test-input"
         revision: 0.1.0
 
   outputTypeInstanceRelations:
     config:
       uses:
-        - helm-release
+        - terraform-release
 
   implements:
-    - path: {{if .InterfacePath}}{{ .InterfacePath }}{{else}}"cap.interface..." # TODO(ContentDeveloper): Put here the path of the implemented Interface{{end}}
-      revision: {{if .InterfaceRevision}}{{ .InterfaceRevision }}{{else}}0.1.0{{end}}
+    - path: cap.interface.group.test
+      revision: 0.2.0
 
-  requires:
-    cap.core.type.platform:
-      oneOf:
-        - name: kubernetes
-          revision: 0.1.0
+  requires: {}
 
   imports:
     - interfaceGroupPath: cap.interface.runner.argo
@@ -49,10 +45,10 @@ spec:
       methods:
         - name: template
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.runner.helm
-      alias: helm
+    - interfaceGroupPath: cap.interface.runner.terraform
+      alias: terraform
       methods:
-        - name: install
+        - name: apply
           revision: 0.1.0
 
   action:
@@ -75,7 +71,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.input-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.input-parameters}}"
                       - name: template
                         raw:
                           # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
@@ -86,12 +82,12 @@ spec:
                           data: |
                             prefix: input
 
-              - - name: create-helm-args
+              - - name: create-module-args
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.additional-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.additional-parameters}}"
                       - name: configuration
                         raw:
                           data: |
@@ -99,41 +95,50 @@ spec:
                       - name: template
                         raw:
                           data: |
-                            generateName: true
-                            chart:
-                              name: "{{ .HelmChartName }}"
-                              repo: "{{ .HelmRepoURL }}"
-                              version: "{{ .HelmChartVersion }}"
-                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
-{{ .ValuesYAML | indent 30 }}
+                            command: "apply"
+                            module:
+                              name: "test"
+                              source: "https://example.com/module.tgz"
+                            env: []
                             output:
-                              goTemplate: |
-                                # TODO(ContentDeveloper): Add output template in YAML
+                              goTemplate:
+                                instance_ids: "{{ .instance_ids }}"
+                                random_number: "{{ .random_number }}"
+                                
+                            variables: |+
+                              <% if additionalInput.count -%>
+                              count = "<@ additionalInput.count @>"
+                              <%- endif %>
 
+                              <% if additionalInput.name -%>
+                              name = "<@ additionalInput.name @>"
+                              <%- endif %>
+
+                              
               - - name: fill-parameters
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: template
-                        from: "{{"{{"}}steps.create-helm-args.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.create-module-args.outputs.artifacts.render}}"
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-default-input.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
                       - name: configuration
                         raw:
                           data: |
                             prefix: input
-
-              - - name: helm-install
-                  capact-action: helm.install
+              
+              - - name: terraform-apply
+                  capact-action: terraform.apply
                   capact-outputTypeInstances:
-                    - name: helm-release
-                      from: helm-release
+                    - name: terraform-release
+                      from: terraform-release
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-parameters.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
                       - name: runner-context
-                        from: "{{"{{"}}workflow.outputs.artifacts.runner-context{{"}}"}}"
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
 
               - - name: render-config
                   capact-outputTypeInstances:
@@ -143,7 +148,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.helm-install.outputs.artifacts.additional{{"}}"}}"
+                        from: "{{steps.terraform-apply.outputs.artifacts.additional}}"
                       - name: configuration
                         raw:
                           data: ""
@@ -152,3 +157,4 @@ spec:
                           # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
                           data: |
                             property: value
+          

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.terraform.test.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.1.0
 kind: Implementation
 metadata:
-  prefix: "cap.implementation.{{ .Prefix }}"
-  name: {{ .Name }}
-  displayName: "{{ .Name }} Action"
-  description: "{{ .Name }} Action"
+  prefix: "cap.implementation.terraform"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
   documentationURL: https://example.com
   supportURL: https://example.com
   maintainers:
@@ -20,22 +20,23 @@ spec:
   additionalInput:
     parameters:
       typeRef:
-        path: "cap.type.{{ .Prefix }}.{{ .Name }}-input"
+        path: "cap.type.terraform.test-input"
         revision: 0.1.0
 
   outputTypeInstanceRelations:
     config:
       uses:
-        - helm-release
+        - terraform-release
 
   implements:
-    - path: {{if .InterfacePath}}{{ .InterfacePath }}{{else}}"cap.interface..." # TODO(ContentDeveloper): Put here the path of the implemented Interface{{end}}
-      revision: {{if .InterfaceRevision}}{{ .InterfaceRevision }}{{else}}0.1.0{{end}}
+    - path: cap.interface.group.test
+      revision: 0.2.0
 
-  requires:
-    cap.core.type.platform:
-      oneOf:
-        - name: kubernetes
+  requires: 
+    cap.type.aws.auth:
+      allOf:
+        - name: credentials
+          alias: aws-credentials
           revision: 0.1.0
 
   imports:
@@ -49,10 +50,10 @@ spec:
       methods:
         - name: template
           revision: 0.1.0
-    - interfaceGroupPath: cap.interface.runner.helm
-      alias: helm
+    - interfaceGroupPath: cap.interface.runner.terraform
+      alias: terraform
       methods:
-        - name: install
+        - name: apply
           revision: 0.1.0
 
   action:
@@ -75,7 +76,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.input-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.input-parameters}}"
                       - name: template
                         raw:
                           # TODO(ContentDeveloper): Put the input parameters from the Interface here and set default values for it:
@@ -86,12 +87,12 @@ spec:
                           data: |
                             prefix: input
 
-              - - name: create-helm-args
+              - - name: create-module-args
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}inputs.artifacts.additional-parameters{{"}}"}}"
+                        from: "{{inputs.artifacts.additional-parameters}}"
                       - name: configuration
                         raw:
                           data: |
@@ -99,41 +100,65 @@ spec:
                       - name: template
                         raw:
                           data: |
-                            generateName: true
-                            chart:
-                              name: "{{ .HelmChartName }}"
-                              repo: "{{ .HelmRepoURL }}"
-                              version: "{{ .HelmChartVersion }}"
-                            values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
-{{ .ValuesYAML | indent 30 }}
+                            command: "apply"
+                            module:
+                              name: "test"
+                              source: "https://example.com/module.tgz"
+                            env: 
+                              - AWS_ACCESS_KEY_ID=<@ creds.accessKeyID @>
+                              - AWS_SECRET_ACCESS_KEY=<@ creds.secretAccessKey @>
                             output:
-                              goTemplate: |
-                                # TODO(ContentDeveloper): Add output template in YAML
+                              goTemplate:
+                                instance_ids: "{{ .instance_ids }}"
+                                random_number: "{{ .random_number }}"
+                                
+                            variables: |+
+                              <% if additionalInput.count -%>
+                              count = "<@ additionalInput.count @>"
+                              <%- endif %>
 
+                              <% if additionalInput.name -%>
+                              name = "<@ additionalInput.name @>"
+                              <%- endif %>
+
+                              
               - - name: fill-parameters
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: template
-                        from: "{{"{{"}}steps.create-helm-args.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.create-module-args.outputs.artifacts.render}}"
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-default-input.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-default-input.outputs.artifacts.render}}"
                       - name: configuration
                         raw:
                           data: |
                             prefix: input
-
-              - - name: helm-install
-                  capact-action: helm.install
+              
+              - - name: fill-creds
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        from: "{{steps.fill-parameters.outputs.artifacts.render}}"
+                      - name: input-parameters
+                        from: "{{workflow.outputs.artifacts.aws-credentials}}"
+                      - name: configuration
+                        raw:
+                          data: |
+                            prefix: creds
+              
+              - - name: terraform-apply
+                  capact-action: terraform.apply
                   capact-outputTypeInstances:
-                    - name: helm-release
-                      from: helm-release
+                    - name: terraform-release
+                      from: terraform-release
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.fill-parameters.outputs.artifacts.render{{"}}"}}"
+                        from: "{{steps.fill-creds.outputs.artifacts.render}}"
                       - name: runner-context
-                        from: "{{"{{"}}workflow.outputs.artifacts.runner-context{{"}}"}}"
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
 
               - - name: render-config
                   capact-outputTypeInstances:
@@ -143,7 +168,7 @@ spec:
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{"{{"}}steps.helm-install.outputs.artifacts.additional{{"}}"}}"
+                        from: "{{steps.terraform-apply.outputs.artifacts.additional}}"
                       - name: configuration
                         raw:
                           data: ""
@@ -152,3 +177,4 @@ spec:
                           # TODO(ContentDeveloper): Fill the properties of the output TypeInstance here
                           data: |
                             property: value
+          

--- a/internal/cli/alpha/manifestgen/testdata/cap.interface.group.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.interface.group.test.yaml
@@ -1,0 +1,31 @@
+ocfVersion: 0.0.1
+revision: 0.2.0
+kind: Interface
+metadata:
+  prefix: "cap.interface.group"
+  name: "test"
+  displayName: "test"
+  description: "test action for group"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  iconURL: https://example.com/icon.png
+  maintainers:
+    - email: dev@example.cop
+      name: Example Dev
+      url: https://example.com
+
+spec:
+  input:
+    parameters:
+      input-parameters:
+        typeRef:
+          path: cap.type.group.test-input
+          revision: 0.1.0
+    typeInstances: {}
+
+  output:
+    typeInstances:
+      config:
+        typeRef:
+          path: cap.type.group.config
+          revision: 0.1.0

--- a/internal/cli/alpha/manifestgen/testdata/cap.interface.group.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.interface.group.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.2.0
 kind: InterfaceGroup
 metadata:
-  prefix: "cap.interface{{ if .Prefix }}.{{ .Prefix }}{{ end }}"
-  name: "{{ .Name }}"
-  displayName: "{{ .Name }}"
-  description: "{{ .Name }} related Interfaces"
+  prefix: "cap.interface"
+  name: "group"
+  displayName: "group"
+  description: "group related Interfaces"
   documentationURL: https://example.com
   supportURL: https://example.com
   iconURL: https://example.com/icon.png

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.group.config.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.group.config.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.2.0
 kind: Type
 metadata:
-  prefix: "cap.type.{{ .Prefix }}"
+  prefix: "cap.type.group"
   name: config
-  displayName: "{{.Prefix }} config"
-  description: "Type representing a {{ .Prefix }} config"
+  displayName: "group config"
+  description: "Type representing a group config"
   documentationURL: https://example.com
   supportURL: https://example.com
   maintainers:

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.group.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.group.test-input.yaml
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
-revision: {{ .Revision }}
+revision: 0.2.0
 kind: Type
 metadata:
-  prefix: "cap.type.{{ .Prefix }}"
-  name: {{ .Name }}-input
-  displayName: "Input for {{ .Prefix }}.{{ .Name }}"
-  description: Input for the "{{ .Prefix }}.{{ .Name }} Action"
+  prefix: "cap.type.group"
+  name: test-input
+  displayName: "Input for group.test"
+  description: Input for the "group.test Action"
   documentationURL: https://example.com
   supportURL: https://example.com
   maintainers:
@@ -16,4 +16,6 @@ spec:
   jsonSchema:
     # TODO(ContentDeveloper): Adjust the JSON schema if needed.
     value: |-
-{{ .JSONSchema | toPrettyJson | indent 6 }}
+      {
+        "type": "object"
+      }

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.helm.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.helm.test-input.yaml
@@ -1,0 +1,1499 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.helm"
+  name: test-input
+  displayName: "Input for helm.test"
+  description: Input for the "helm.test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+spec:
+  jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
+    value: |-
+      {
+        "properties": {
+          "audit": {
+            "properties": {
+              "clientMinMessages": {
+                "type": "string",
+                "title": "clientMinMessages",
+                "default": "error",
+                "$id": "#/properties/audit/properties/clientMinMessages"
+              },
+              "logConnections": {
+                "title": "logConnections",
+                "$id": "#/properties/audit/properties/logConnections"
+              },
+              "logDisconnections": {
+                "title": "logDisconnections",
+                "$id": "#/properties/audit/properties/logDisconnections"
+              },
+              "logHostname": {
+                "title": "logHostname",
+                "$id": "#/properties/audit/properties/logHostname"
+              },
+              "logLinePrefix": {
+                "type": "string",
+                "title": "logLinePrefix",
+                "default": "",
+                "$id": "#/properties/audit/properties/logLinePrefix"
+              },
+              "logTimezone": {
+                "type": "string",
+                "title": "logTimezone",
+                "default": "",
+                "$id": "#/properties/audit/properties/logTimezone"
+              },
+              "pgAuditLog": {
+                "type": "string",
+                "title": "pgAuditLog",
+                "default": "",
+                "$id": "#/properties/audit/properties/pgAuditLog"
+              },
+              "pgAuditLogCatalog": {
+                "type": "string",
+                "title": "pgAuditLogCatalog",
+                "default": "off",
+                "$id": "#/properties/audit/properties/pgAuditLogCatalog"
+              }
+            },
+            "title": "audit",
+            "$id": "#/properties/audit"
+          },
+          "commonAnnotations": {
+            "properties": {},
+            "title": "commonAnnotations",
+            "$id": "#/properties/commonAnnotations"
+          },
+          "configurationConfigMap": {
+            "type": "string",
+            "title": "configurationConfigMap",
+            "default": "",
+            "$id": "#/properties/configurationConfigMap"
+          },
+          "containerSecurityContext": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/containerSecurityContext/properties/enabled"
+              },
+              "runAsUser": {
+                "title": "runAsUser",
+                "$id": "#/properties/containerSecurityContext/properties/runAsUser"
+              }
+            },
+            "title": "containerSecurityContext",
+            "$id": "#/properties/containerSecurityContext"
+          },
+          "customLivenessProbe": {
+            "properties": {},
+            "title": "customLivenessProbe",
+            "$id": "#/properties/customLivenessProbe"
+          },
+          "customReadinessProbe": {
+            "properties": {},
+            "title": "customReadinessProbe",
+            "$id": "#/properties/customReadinessProbe"
+          },
+          "customStartupProbe": {
+            "properties": {},
+            "title": "customStartupProbe",
+            "$id": "#/properties/customStartupProbe"
+          },
+          "diagnosticMode": {
+            "properties": {
+              "args": {
+                "title": "args",
+                "$id": "#/properties/diagnosticMode/properties/args"
+              },
+              "command": {
+                "title": "command",
+                "$id": "#/properties/diagnosticMode/properties/command"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/diagnosticMode/properties/enabled"
+              }
+            },
+            "title": "diagnosticMode",
+            "$id": "#/properties/diagnosticMode"
+          },
+          "existingSecret": {
+            "type": "string",
+            "title": "existingSecret",
+            "default": "",
+            "$id": "#/properties/existingSecret"
+          },
+          "extendedConfConfigMap": {
+            "type": "string",
+            "title": "extendedConfConfigMap",
+            "default": "",
+            "$id": "#/properties/extendedConfConfigMap"
+          },
+          "extraDeploy": {
+            "title": "extraDeploy",
+            "$id": "#/properties/extraDeploy"
+          },
+          "extraEnv": {
+            "title": "extraEnv",
+            "$id": "#/properties/extraEnv"
+          },
+          "extraEnvVarsCM": {
+            "type": "string",
+            "title": "extraEnvVarsCM",
+            "default": "",
+            "$id": "#/properties/extraEnvVarsCM"
+          },
+          "fullnameOverride": {
+            "type": "string",
+            "title": "fullnameOverride",
+            "default": "",
+            "$id": "#/properties/fullnameOverride"
+          },
+          "global": {
+            "properties": {
+              "imagePullSecrets": {
+                "title": "imagePullSecrets",
+                "$id": "#/properties/global/properties/imagePullSecrets"
+              },
+              "imageRegistry": {
+                "type": "string",
+                "title": "imageRegistry",
+                "default": "",
+                "$id": "#/properties/global/properties/imageRegistry"
+              },
+              "postgresql": {
+                "properties": {
+                  "existingSecret": {
+                    "type": "string",
+                    "title": "existingSecret",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/existingSecret"
+                  },
+                  "postgresqlDatabase": {
+                    "type": "string",
+                    "title": "postgresqlDatabase",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/postgresqlDatabase"
+                  },
+                  "postgresqlPassword": {
+                    "type": "string",
+                    "title": "postgresqlPassword",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/postgresqlPassword"
+                  },
+                  "postgresqlUsername": {
+                    "type": "string",
+                    "title": "postgresqlUsername",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/postgresqlUsername"
+                  },
+                  "replicationPassword": {
+                    "type": "string",
+                    "title": "replicationPassword",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/replicationPassword"
+                  },
+                  "servicePort": {
+                    "type": "string",
+                    "title": "servicePort",
+                    "default": "",
+                    "$id": "#/properties/global/properties/postgresql/properties/servicePort"
+                  }
+                },
+                "title": "postgresql",
+                "$id": "#/properties/global/properties/postgresql"
+              },
+              "storageClass": {
+                "type": "string",
+                "title": "storageClass",
+                "default": "",
+                "$id": "#/properties/global/properties/storageClass"
+              }
+            },
+            "title": "global",
+            "$id": "#/properties/global"
+          },
+          "image": {
+            "properties": {
+              "debug": {
+                "title": "debug",
+                "$id": "#/properties/image/properties/debug"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "title": "pullPolicy",
+                "default": "IfNotPresent",
+                "$id": "#/properties/image/properties/pullPolicy"
+              },
+              "pullSecrets": {
+                "title": "pullSecrets",
+                "$id": "#/properties/image/properties/pullSecrets"
+              },
+              "registry": {
+                "type": "string",
+                "title": "registry",
+                "default": "docker.io",
+                "$id": "#/properties/image/properties/registry"
+              },
+              "repository": {
+                "type": "string",
+                "title": "repository",
+                "default": "bitnami/postgresql",
+                "$id": "#/properties/image/properties/repository"
+              },
+              "tag": {
+                "type": "string",
+                "title": "tag",
+                "default": "11.13.0-debian-10-r0",
+                "$id": "#/properties/image/properties/tag"
+              }
+            },
+            "title": "image",
+            "$id": "#/properties/image"
+          },
+          "initdbPassword": {
+            "type": "string",
+            "title": "initdbPassword",
+            "default": "",
+            "$id": "#/properties/initdbPassword"
+          },
+          "initdbScripts": {
+            "properties": {},
+            "title": "initdbScripts",
+            "$id": "#/properties/initdbScripts"
+          },
+          "initdbScriptsConfigMap": {
+            "type": "string",
+            "title": "initdbScriptsConfigMap",
+            "default": "",
+            "$id": "#/properties/initdbScriptsConfigMap"
+          },
+          "initdbScriptsSecret": {
+            "type": "string",
+            "title": "initdbScriptsSecret",
+            "default": "",
+            "$id": "#/properties/initdbScriptsSecret"
+          },
+          "initdbUser": {
+            "type": "string",
+            "title": "initdbUser",
+            "default": "",
+            "$id": "#/properties/initdbUser"
+          },
+          "ldap": {
+            "properties": {
+              "baseDN": {
+                "type": "string",
+                "title": "baseDN",
+                "default": "",
+                "$id": "#/properties/ldap/properties/baseDN"
+              },
+              "bindDN": {
+                "type": "string",
+                "title": "bindDN",
+                "default": "",
+                "$id": "#/properties/ldap/properties/bindDN"
+              },
+              "bind_password": {
+                "type": "string",
+                "title": "bind_password",
+                "default": "",
+                "$id": "#/properties/ldap/properties/bind_password"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/ldap/properties/enabled"
+              },
+              "port": {
+                "type": "string",
+                "title": "port",
+                "default": "",
+                "$id": "#/properties/ldap/properties/port"
+              },
+              "prefix": {
+                "type": "string",
+                "title": "prefix",
+                "default": "",
+                "$id": "#/properties/ldap/properties/prefix"
+              },
+              "scheme": {
+                "type": "string",
+                "title": "scheme",
+                "default": "",
+                "$id": "#/properties/ldap/properties/scheme"
+              },
+              "search_attr": {
+                "type": "string",
+                "title": "search_attr",
+                "default": "",
+                "$id": "#/properties/ldap/properties/search_attr"
+              },
+              "search_filter": {
+                "type": "string",
+                "title": "search_filter",
+                "default": "",
+                "$id": "#/properties/ldap/properties/search_filter"
+              },
+              "server": {
+                "type": "string",
+                "title": "server",
+                "default": "",
+                "$id": "#/properties/ldap/properties/server"
+              },
+              "suffix": {
+                "type": "string",
+                "title": "suffix",
+                "default": "",
+                "$id": "#/properties/ldap/properties/suffix"
+              },
+              "tls": {
+                "type": "string",
+                "title": "tls",
+                "default": "",
+                "$id": "#/properties/ldap/properties/tls"
+              },
+              "url": {
+                "type": "string",
+                "title": "url",
+                "default": "",
+                "$id": "#/properties/ldap/properties/url"
+              }
+            },
+            "title": "ldap",
+            "$id": "#/properties/ldap"
+          },
+          "lifecycleHooks": {
+            "properties": {},
+            "title": "lifecycleHooks",
+            "$id": "#/properties/lifecycleHooks"
+          },
+          "livenessProbe": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/livenessProbe/properties/enabled"
+              },
+              "failureThreshold": {
+                "title": "failureThreshold",
+                "$id": "#/properties/livenessProbe/properties/failureThreshold"
+              },
+              "initialDelaySeconds": {
+                "title": "initialDelaySeconds",
+                "$id": "#/properties/livenessProbe/properties/initialDelaySeconds"
+              },
+              "periodSeconds": {
+                "title": "periodSeconds",
+                "$id": "#/properties/livenessProbe/properties/periodSeconds"
+              },
+              "successThreshold": {
+                "title": "successThreshold",
+                "$id": "#/properties/livenessProbe/properties/successThreshold"
+              },
+              "timeoutSeconds": {
+                "title": "timeoutSeconds",
+                "$id": "#/properties/livenessProbe/properties/timeoutSeconds"
+              }
+            },
+            "title": "livenessProbe",
+            "$id": "#/properties/livenessProbe"
+          },
+          "metrics": {
+            "properties": {
+              "customMetrics": {
+                "properties": {},
+                "title": "customMetrics",
+                "$id": "#/properties/metrics/properties/customMetrics"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/metrics/properties/enabled"
+              },
+              "extraEnvVars": {
+                "title": "extraEnvVars",
+                "$id": "#/properties/metrics/properties/extraEnvVars"
+              },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string",
+                    "title": "pullPolicy",
+                    "default": "IfNotPresent",
+                    "$id": "#/properties/metrics/properties/image/properties/pullPolicy"
+                  },
+                  "pullSecrets": {
+                    "title": "pullSecrets",
+                    "$id": "#/properties/metrics/properties/image/properties/pullSecrets"
+                  },
+                  "registry": {
+                    "type": "string",
+                    "title": "registry",
+                    "default": "docker.io",
+                    "$id": "#/properties/metrics/properties/image/properties/registry"
+                  },
+                  "repository": {
+                    "type": "string",
+                    "title": "repository",
+                    "default": "bitnami/postgres-exporter",
+                    "$id": "#/properties/metrics/properties/image/properties/repository"
+                  },
+                  "tag": {
+                    "type": "string",
+                    "title": "tag",
+                    "default": "0.10.0-debian-10-r27",
+                    "$id": "#/properties/metrics/properties/image/properties/tag"
+                  }
+                },
+                "title": "image",
+                "$id": "#/properties/metrics/properties/image"
+              },
+              "livenessProbe": {
+                "properties": {
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/enabled"
+                  },
+                  "failureThreshold": {
+                    "title": "failureThreshold",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/failureThreshold"
+                  },
+                  "initialDelaySeconds": {
+                    "title": "initialDelaySeconds",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/initialDelaySeconds"
+                  },
+                  "periodSeconds": {
+                    "title": "periodSeconds",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/periodSeconds"
+                  },
+                  "successThreshold": {
+                    "title": "successThreshold",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/successThreshold"
+                  },
+                  "timeoutSeconds": {
+                    "title": "timeoutSeconds",
+                    "$id": "#/properties/metrics/properties/livenessProbe/properties/timeoutSeconds"
+                  }
+                },
+                "title": "livenessProbe",
+                "$id": "#/properties/metrics/properties/livenessProbe"
+              },
+              "prometheusRule": {
+                "properties": {
+                  "additionalLabels": {
+                    "properties": {},
+                    "title": "additionalLabels",
+                    "$id": "#/properties/metrics/properties/prometheusRule/properties/additionalLabels"
+                  },
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/metrics/properties/prometheusRule/properties/enabled"
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "title": "namespace",
+                    "default": "",
+                    "$id": "#/properties/metrics/properties/prometheusRule/properties/namespace"
+                  },
+                  "rules": {
+                    "title": "rules",
+                    "$id": "#/properties/metrics/properties/prometheusRule/properties/rules"
+                  }
+                },
+                "title": "prometheusRule",
+                "$id": "#/properties/metrics/properties/prometheusRule"
+              },
+              "readinessProbe": {
+                "properties": {
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/enabled"
+                  },
+                  "failureThreshold": {
+                    "title": "failureThreshold",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/failureThreshold"
+                  },
+                  "initialDelaySeconds": {
+                    "title": "initialDelaySeconds",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/initialDelaySeconds"
+                  },
+                  "periodSeconds": {
+                    "title": "periodSeconds",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/periodSeconds"
+                  },
+                  "successThreshold": {
+                    "title": "successThreshold",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/successThreshold"
+                  },
+                  "timeoutSeconds": {
+                    "title": "timeoutSeconds",
+                    "$id": "#/properties/metrics/properties/readinessProbe/properties/timeoutSeconds"
+                  }
+                },
+                "title": "readinessProbe",
+                "$id": "#/properties/metrics/properties/readinessProbe"
+              },
+              "resources": {
+                "properties": {},
+                "title": "resources",
+                "$id": "#/properties/metrics/properties/resources"
+              },
+              "securityContext": {
+                "properties": {
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/metrics/properties/securityContext/properties/enabled"
+                  },
+                  "runAsUser": {
+                    "title": "runAsUser",
+                    "$id": "#/properties/metrics/properties/securityContext/properties/runAsUser"
+                  }
+                },
+                "title": "securityContext",
+                "$id": "#/properties/metrics/properties/securityContext"
+              },
+              "service": {
+                "properties": {
+                  "annotations": {
+                    "properties": {
+                      "prometheus.io/port": {
+                        "type": "string",
+                        "title": "prometheus.io/port",
+                        "default": "9187",
+                        "$id": "#/properties/metrics/properties/service/properties/annotations/properties/prometheus.io/port"
+                      },
+                      "prometheus.io/scrape": {
+                        "type": "string",
+                        "title": "prometheus.io/scrape",
+                        "default": "true",
+                        "$id": "#/properties/metrics/properties/service/properties/annotations/properties/prometheus.io/scrape"
+                      }
+                    },
+                    "title": "annotations",
+                    "$id": "#/properties/metrics/properties/service/properties/annotations"
+                  },
+                  "loadBalancerIP": {
+                    "type": "string",
+                    "title": "loadBalancerIP",
+                    "default": "",
+                    "$id": "#/properties/metrics/properties/service/properties/loadBalancerIP"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "type",
+                    "default": "ClusterIP",
+                    "$id": "#/properties/metrics/properties/service/properties/type"
+                  }
+                },
+                "title": "service",
+                "$id": "#/properties/metrics/properties/service"
+              },
+              "serviceMonitor": {
+                "properties": {
+                  "additionalLabels": {
+                    "properties": {},
+                    "title": "additionalLabels",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/additionalLabels"
+                  },
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/enabled"
+                  },
+                  "interval": {
+                    "type": "string",
+                    "title": "interval",
+                    "default": "",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/interval"
+                  },
+                  "metricRelabelings": {
+                    "title": "metricRelabelings",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/metricRelabelings"
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "title": "namespace",
+                    "default": "",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/namespace"
+                  },
+                  "relabelings": {
+                    "title": "relabelings",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/relabelings"
+                  },
+                  "scrapeTimeout": {
+                    "type": "string",
+                    "title": "scrapeTimeout",
+                    "default": "",
+                    "$id": "#/properties/metrics/properties/serviceMonitor/properties/scrapeTimeout"
+                  }
+                },
+                "title": "serviceMonitor",
+                "$id": "#/properties/metrics/properties/serviceMonitor"
+              }
+            },
+            "title": "metrics",
+            "$id": "#/properties/metrics"
+          },
+          "nameOverride": {
+            "type": "string",
+            "title": "nameOverride",
+            "default": "",
+            "$id": "#/properties/nameOverride"
+          },
+          "networkPolicy": {
+            "properties": {
+              "allowExternal": {
+                "title": "allowExternal",
+                "$id": "#/properties/networkPolicy/properties/allowExternal"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/networkPolicy/properties/enabled"
+              },
+              "explicitNamespacesSelector": {
+                "properties": {},
+                "title": "explicitNamespacesSelector",
+                "$id": "#/properties/networkPolicy/properties/explicitNamespacesSelector"
+              }
+            },
+            "title": "networkPolicy",
+            "$id": "#/properties/networkPolicy"
+          },
+          "persistence": {
+            "properties": {
+              "accessModes": {
+                "title": "accessModes",
+                "$id": "#/properties/persistence/properties/accessModes"
+              },
+              "annotations": {
+                "properties": {},
+                "title": "annotations",
+                "$id": "#/properties/persistence/properties/annotations"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/persistence/properties/enabled"
+              },
+              "existingClaim": {
+                "type": "string",
+                "title": "existingClaim",
+                "default": "",
+                "$id": "#/properties/persistence/properties/existingClaim"
+              },
+              "mountPath": {
+                "type": "string",
+                "title": "mountPath",
+                "default": "/bitnami/postgresql",
+                "$id": "#/properties/persistence/properties/mountPath"
+              },
+              "selector": {
+                "properties": {},
+                "title": "selector",
+                "$id": "#/properties/persistence/properties/selector"
+              },
+              "size": {
+                "type": "string",
+                "title": "size",
+                "default": "8Gi",
+                "$id": "#/properties/persistence/properties/size"
+              },
+              "storageClass": {
+                "type": "string",
+                "title": "storageClass",
+                "default": "",
+                "$id": "#/properties/persistence/properties/storageClass"
+              },
+              "subPath": {
+                "type": "string",
+                "title": "subPath",
+                "default": "",
+                "$id": "#/properties/persistence/properties/subPath"
+              }
+            },
+            "title": "persistence",
+            "$id": "#/properties/persistence"
+          },
+          "pgHbaConfiguration": {
+            "type": "string",
+            "title": "pgHbaConfiguration",
+            "default": "",
+            "$id": "#/properties/pgHbaConfiguration"
+          },
+          "postgresqlConfiguration": {
+            "properties": {},
+            "title": "postgresqlConfiguration",
+            "$id": "#/properties/postgresqlConfiguration"
+          },
+          "postgresqlDataDir": {
+            "type": "string",
+            "title": "postgresqlDataDir",
+            "default": "/bitnami/postgresql/data",
+            "$id": "#/properties/postgresqlDataDir"
+          },
+          "postgresqlDatabase": {
+            "type": "string",
+            "title": "postgresqlDatabase",
+            "default": "",
+            "$id": "#/properties/postgresqlDatabase"
+          },
+          "postgresqlDbUserConnectionLimit": {
+            "type": "string",
+            "title": "postgresqlDbUserConnectionLimit",
+            "default": "",
+            "$id": "#/properties/postgresqlDbUserConnectionLimit"
+          },
+          "postgresqlExtendedConf": {
+            "properties": {},
+            "title": "postgresqlExtendedConf",
+            "$id": "#/properties/postgresqlExtendedConf"
+          },
+          "postgresqlInitdbArgs": {
+            "type": "string",
+            "title": "postgresqlInitdbArgs",
+            "default": "",
+            "$id": "#/properties/postgresqlInitdbArgs"
+          },
+          "postgresqlInitdbWalDir": {
+            "type": "string",
+            "title": "postgresqlInitdbWalDir",
+            "default": "",
+            "$id": "#/properties/postgresqlInitdbWalDir"
+          },
+          "postgresqlMaxConnections": {
+            "type": "string",
+            "title": "postgresqlMaxConnections",
+            "default": "",
+            "$id": "#/properties/postgresqlMaxConnections"
+          },
+          "postgresqlPassword": {
+            "type": "string",
+            "title": "postgresqlPassword",
+            "default": "",
+            "$id": "#/properties/postgresqlPassword"
+          },
+          "postgresqlPghbaRemoveFilters": {
+            "type": "string",
+            "title": "postgresqlPghbaRemoveFilters",
+            "default": "",
+            "$id": "#/properties/postgresqlPghbaRemoveFilters"
+          },
+          "postgresqlPostgresConnectionLimit": {
+            "type": "string",
+            "title": "postgresqlPostgresConnectionLimit",
+            "default": "",
+            "$id": "#/properties/postgresqlPostgresConnectionLimit"
+          },
+          "postgresqlPostgresPassword": {
+            "type": "string",
+            "title": "postgresqlPostgresPassword",
+            "default": "",
+            "$id": "#/properties/postgresqlPostgresPassword"
+          },
+          "postgresqlSharedPreloadLibraries": {
+            "type": "string",
+            "title": "postgresqlSharedPreloadLibraries",
+            "default": "pgaudit",
+            "$id": "#/properties/postgresqlSharedPreloadLibraries"
+          },
+          "postgresqlStatementTimeout": {
+            "type": "string",
+            "title": "postgresqlStatementTimeout",
+            "default": "",
+            "$id": "#/properties/postgresqlStatementTimeout"
+          },
+          "postgresqlTcpKeepalivesCount": {
+            "type": "string",
+            "title": "postgresqlTcpKeepalivesCount",
+            "default": "",
+            "$id": "#/properties/postgresqlTcpKeepalivesCount"
+          },
+          "postgresqlTcpKeepalivesIdle": {
+            "type": "string",
+            "title": "postgresqlTcpKeepalivesIdle",
+            "default": "",
+            "$id": "#/properties/postgresqlTcpKeepalivesIdle"
+          },
+          "postgresqlTcpKeepalivesInterval": {
+            "type": "string",
+            "title": "postgresqlTcpKeepalivesInterval",
+            "default": "",
+            "$id": "#/properties/postgresqlTcpKeepalivesInterval"
+          },
+          "postgresqlUsername": {
+            "type": "string",
+            "title": "postgresqlUsername",
+            "default": "postgres",
+            "$id": "#/properties/postgresqlUsername"
+          },
+          "primary": {
+            "properties": {
+              "affinity": {
+                "properties": {},
+                "title": "affinity",
+                "$id": "#/properties/primary/properties/affinity"
+              },
+              "annotations": {
+                "properties": {},
+                "title": "annotations",
+                "$id": "#/properties/primary/properties/annotations"
+              },
+              "extraInitContainers": {
+                "title": "extraInitContainers",
+                "$id": "#/properties/primary/properties/extraInitContainers"
+              },
+              "extraVolumeMounts": {
+                "title": "extraVolumeMounts",
+                "$id": "#/properties/primary/properties/extraVolumeMounts"
+              },
+              "extraVolumes": {
+                "title": "extraVolumes",
+                "$id": "#/properties/primary/properties/extraVolumes"
+              },
+              "labels": {
+                "properties": {},
+                "title": "labels",
+                "$id": "#/properties/primary/properties/labels"
+              },
+              "nodeAffinityPreset": {
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "title": "key",
+                    "default": "",
+                    "$id": "#/properties/primary/properties/nodeAffinityPreset/properties/key"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "type",
+                    "default": "",
+                    "$id": "#/properties/primary/properties/nodeAffinityPreset/properties/type"
+                  },
+                  "values": {
+                    "title": "values",
+                    "$id": "#/properties/primary/properties/nodeAffinityPreset/properties/values"
+                  }
+                },
+                "title": "nodeAffinityPreset",
+                "$id": "#/properties/primary/properties/nodeAffinityPreset"
+              },
+              "nodeSelector": {
+                "properties": {},
+                "title": "nodeSelector",
+                "$id": "#/properties/primary/properties/nodeSelector"
+              },
+              "podAffinityPreset": {
+                "type": "string",
+                "title": "podAffinityPreset",
+                "default": "",
+                "$id": "#/properties/primary/properties/podAffinityPreset"
+              },
+              "podAnnotations": {
+                "properties": {},
+                "title": "podAnnotations",
+                "$id": "#/properties/primary/properties/podAnnotations"
+              },
+              "podAntiAffinityPreset": {
+                "type": "string",
+                "title": "podAntiAffinityPreset",
+                "default": "soft",
+                "$id": "#/properties/primary/properties/podAntiAffinityPreset"
+              },
+              "podLabels": {
+                "properties": {},
+                "title": "podLabels",
+                "$id": "#/properties/primary/properties/podLabels"
+              },
+              "priorityClassName": {
+                "type": "string",
+                "title": "priorityClassName",
+                "default": "",
+                "$id": "#/properties/primary/properties/priorityClassName"
+              },
+              "service": {
+                "properties": {
+                  "clusterIP": {
+                    "type": "string",
+                    "title": "clusterIP",
+                    "default": "",
+                    "$id": "#/properties/primary/properties/service/properties/clusterIP"
+                  },
+                  "nodePort": {
+                    "type": "string",
+                    "title": "nodePort",
+                    "default": "",
+                    "$id": "#/properties/primary/properties/service/properties/nodePort"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "type",
+                    "default": "",
+                    "$id": "#/properties/primary/properties/service/properties/type"
+                  }
+                },
+                "title": "service",
+                "$id": "#/properties/primary/properties/service"
+              },
+              "sidecars": {
+                "title": "sidecars",
+                "$id": "#/properties/primary/properties/sidecars"
+              },
+              "tolerations": {
+                "title": "tolerations",
+                "$id": "#/properties/primary/properties/tolerations"
+              }
+            },
+            "title": "primary",
+            "$id": "#/properties/primary"
+          },
+          "primaryAsStandBy": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/primaryAsStandBy/properties/enabled"
+              },
+              "primaryHost": {
+                "type": "string",
+                "title": "primaryHost",
+                "default": "",
+                "$id": "#/properties/primaryAsStandBy/properties/primaryHost"
+              },
+              "primaryPort": {
+                "type": "string",
+                "title": "primaryPort",
+                "default": "",
+                "$id": "#/properties/primaryAsStandBy/properties/primaryPort"
+              }
+            },
+            "title": "primaryAsStandBy",
+            "$id": "#/properties/primaryAsStandBy"
+          },
+          "psp": {
+            "properties": {
+              "create": {
+                "title": "create",
+                "$id": "#/properties/psp/properties/create"
+              }
+            },
+            "title": "psp",
+            "$id": "#/properties/psp"
+          },
+          "rbac": {
+            "properties": {
+              "create": {
+                "title": "create",
+                "$id": "#/properties/rbac/properties/create"
+              }
+            },
+            "title": "rbac",
+            "$id": "#/properties/rbac"
+          },
+          "readReplicas": {
+            "properties": {
+              "affinity": {
+                "properties": {},
+                "title": "affinity",
+                "$id": "#/properties/readReplicas/properties/affinity"
+              },
+              "annotations": {
+                "properties": {},
+                "title": "annotations",
+                "$id": "#/properties/readReplicas/properties/annotations"
+              },
+              "extraInitContainers": {
+                "title": "extraInitContainers",
+                "$id": "#/properties/readReplicas/properties/extraInitContainers"
+              },
+              "extraVolumeMounts": {
+                "title": "extraVolumeMounts",
+                "$id": "#/properties/readReplicas/properties/extraVolumeMounts"
+              },
+              "extraVolumes": {
+                "title": "extraVolumes",
+                "$id": "#/properties/readReplicas/properties/extraVolumes"
+              },
+              "labels": {
+                "properties": {},
+                "title": "labels",
+                "$id": "#/properties/readReplicas/properties/labels"
+              },
+              "nodeAffinityPreset": {
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "title": "key",
+                    "default": "",
+                    "$id": "#/properties/readReplicas/properties/nodeAffinityPreset/properties/key"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "type",
+                    "default": "",
+                    "$id": "#/properties/readReplicas/properties/nodeAffinityPreset/properties/type"
+                  },
+                  "values": {
+                    "title": "values",
+                    "$id": "#/properties/readReplicas/properties/nodeAffinityPreset/properties/values"
+                  }
+                },
+                "title": "nodeAffinityPreset",
+                "$id": "#/properties/readReplicas/properties/nodeAffinityPreset"
+              },
+              "nodeSelector": {
+                "properties": {},
+                "title": "nodeSelector",
+                "$id": "#/properties/readReplicas/properties/nodeSelector"
+              },
+              "persistence": {
+                "properties": {
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/readReplicas/properties/persistence/properties/enabled"
+                  }
+                },
+                "title": "persistence",
+                "$id": "#/properties/readReplicas/properties/persistence"
+              },
+              "podAffinityPreset": {
+                "type": "string",
+                "title": "podAffinityPreset",
+                "default": "",
+                "$id": "#/properties/readReplicas/properties/podAffinityPreset"
+              },
+              "podAnnotations": {
+                "properties": {},
+                "title": "podAnnotations",
+                "$id": "#/properties/readReplicas/properties/podAnnotations"
+              },
+              "podAntiAffinityPreset": {
+                "type": "string",
+                "title": "podAntiAffinityPreset",
+                "default": "soft",
+                "$id": "#/properties/readReplicas/properties/podAntiAffinityPreset"
+              },
+              "podLabels": {
+                "properties": {},
+                "title": "podLabels",
+                "$id": "#/properties/readReplicas/properties/podLabels"
+              },
+              "priorityClassName": {
+                "type": "string",
+                "title": "priorityClassName",
+                "default": "",
+                "$id": "#/properties/readReplicas/properties/priorityClassName"
+              },
+              "resources": {
+                "properties": {},
+                "title": "resources",
+                "$id": "#/properties/readReplicas/properties/resources"
+              },
+              "service": {
+                "properties": {
+                  "clusterIP": {
+                    "type": "string",
+                    "title": "clusterIP",
+                    "default": "",
+                    "$id": "#/properties/readReplicas/properties/service/properties/clusterIP"
+                  },
+                  "nodePort": {
+                    "type": "string",
+                    "title": "nodePort",
+                    "default": "",
+                    "$id": "#/properties/readReplicas/properties/service/properties/nodePort"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "type",
+                    "default": "",
+                    "$id": "#/properties/readReplicas/properties/service/properties/type"
+                  }
+                },
+                "title": "service",
+                "$id": "#/properties/readReplicas/properties/service"
+              },
+              "sidecars": {
+                "title": "sidecars",
+                "$id": "#/properties/readReplicas/properties/sidecars"
+              },
+              "tolerations": {
+                "title": "tolerations",
+                "$id": "#/properties/readReplicas/properties/tolerations"
+              }
+            },
+            "title": "readReplicas",
+            "$id": "#/properties/readReplicas"
+          },
+          "readinessProbe": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/readinessProbe/properties/enabled"
+              },
+              "failureThreshold": {
+                "title": "failureThreshold",
+                "$id": "#/properties/readinessProbe/properties/failureThreshold"
+              },
+              "initialDelaySeconds": {
+                "title": "initialDelaySeconds",
+                "$id": "#/properties/readinessProbe/properties/initialDelaySeconds"
+              },
+              "periodSeconds": {
+                "title": "periodSeconds",
+                "$id": "#/properties/readinessProbe/properties/periodSeconds"
+              },
+              "successThreshold": {
+                "title": "successThreshold",
+                "$id": "#/properties/readinessProbe/properties/successThreshold"
+              },
+              "timeoutSeconds": {
+                "title": "timeoutSeconds",
+                "$id": "#/properties/readinessProbe/properties/timeoutSeconds"
+              }
+            },
+            "title": "readinessProbe",
+            "$id": "#/properties/readinessProbe"
+          },
+          "replication": {
+            "properties": {
+              "applicationName": {
+                "type": "string",
+                "title": "applicationName",
+                "default": "my_application",
+                "$id": "#/properties/replication/properties/applicationName"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/replication/properties/enabled"
+              },
+              "numSynchronousReplicas": {
+                "title": "numSynchronousReplicas",
+                "$id": "#/properties/replication/properties/numSynchronousReplicas"
+              },
+              "password": {
+                "type": "string",
+                "title": "password",
+                "default": "repl_password",
+                "$id": "#/properties/replication/properties/password"
+              },
+              "readReplicas": {
+                "title": "readReplicas",
+                "$id": "#/properties/replication/properties/readReplicas"
+              },
+              "singleService": {
+                "title": "singleService",
+                "$id": "#/properties/replication/properties/singleService"
+              },
+              "synchronousCommit": {
+                "type": "string",
+                "title": "synchronousCommit",
+                "default": "off",
+                "$id": "#/properties/replication/properties/synchronousCommit"
+              },
+              "uniqueServices": {
+                "title": "uniqueServices",
+                "$id": "#/properties/replication/properties/uniqueServices"
+              },
+              "user": {
+                "type": "string",
+                "title": "user",
+                "default": "repl_user",
+                "$id": "#/properties/replication/properties/user"
+              }
+            },
+            "title": "replication",
+            "$id": "#/properties/replication"
+          },
+          "resources": {
+            "properties": {
+              "requests": {
+                "properties": {
+                  "cpu": {
+                    "type": "string",
+                    "title": "cpu",
+                    "default": "250m",
+                    "$id": "#/properties/resources/properties/requests/properties/cpu"
+                  },
+                  "memory": {
+                    "type": "string",
+                    "title": "memory",
+                    "default": "256Mi",
+                    "$id": "#/properties/resources/properties/requests/properties/memory"
+                  }
+                },
+                "title": "requests",
+                "$id": "#/properties/resources/properties/requests"
+              }
+            },
+            "title": "resources",
+            "$id": "#/properties/resources"
+          },
+          "schedulerName": {
+            "type": "string",
+            "title": "schedulerName",
+            "default": "",
+            "$id": "#/properties/schedulerName"
+          },
+          "securityContext": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/securityContext/properties/enabled"
+              },
+              "fsGroup": {
+                "title": "fsGroup",
+                "$id": "#/properties/securityContext/properties/fsGroup"
+              }
+            },
+            "title": "securityContext",
+            "$id": "#/properties/securityContext"
+          },
+          "service": {
+            "properties": {
+              "annotations": {
+                "properties": {},
+                "title": "annotations",
+                "$id": "#/properties/service/properties/annotations"
+              },
+              "clusterIP": {
+                "type": "string",
+                "title": "clusterIP",
+                "default": "",
+                "$id": "#/properties/service/properties/clusterIP"
+              },
+              "loadBalancerIP": {
+                "type": "string",
+                "title": "loadBalancerIP",
+                "default": "",
+                "$id": "#/properties/service/properties/loadBalancerIP"
+              },
+              "loadBalancerSourceRanges": {
+                "title": "loadBalancerSourceRanges",
+                "$id": "#/properties/service/properties/loadBalancerSourceRanges"
+              },
+              "nodePort": {
+                "type": "string",
+                "title": "nodePort",
+                "default": "",
+                "$id": "#/properties/service/properties/nodePort"
+              },
+              "port": {
+                "title": "port",
+                "$id": "#/properties/service/properties/port"
+              },
+              "type": {
+                "type": "string",
+                "title": "type",
+                "default": "ClusterIP",
+                "$id": "#/properties/service/properties/type"
+              }
+            },
+            "title": "service",
+            "$id": "#/properties/service"
+          },
+          "serviceAccount": {
+            "properties": {
+              "autoMount": {
+                "title": "autoMount",
+                "$id": "#/properties/serviceAccount/properties/autoMount"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/serviceAccount/properties/enabled"
+              },
+              "name": {
+                "type": "string",
+                "title": "name",
+                "default": "",
+                "$id": "#/properties/serviceAccount/properties/name"
+              }
+            },
+            "title": "serviceAccount",
+            "$id": "#/properties/serviceAccount"
+          },
+          "shmVolume": {
+            "properties": {
+              "chmod": {
+                "properties": {
+                  "enabled": {
+                    "title": "enabled",
+                    "$id": "#/properties/shmVolume/properties/chmod/properties/enabled"
+                  }
+                },
+                "title": "chmod",
+                "$id": "#/properties/shmVolume/properties/chmod"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/shmVolume/properties/enabled"
+              },
+              "sizeLimit": {
+                "type": "string",
+                "title": "sizeLimit",
+                "default": "",
+                "$id": "#/properties/shmVolume/properties/sizeLimit"
+              }
+            },
+            "title": "shmVolume",
+            "$id": "#/properties/shmVolume"
+          },
+          "startupProbe": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/startupProbe/properties/enabled"
+              },
+              "failureThreshold": {
+                "title": "failureThreshold",
+                "$id": "#/properties/startupProbe/properties/failureThreshold"
+              },
+              "initialDelaySeconds": {
+                "title": "initialDelaySeconds",
+                "$id": "#/properties/startupProbe/properties/initialDelaySeconds"
+              },
+              "periodSeconds": {
+                "title": "periodSeconds",
+                "$id": "#/properties/startupProbe/properties/periodSeconds"
+              },
+              "successThreshold": {
+                "title": "successThreshold",
+                "$id": "#/properties/startupProbe/properties/successThreshold"
+              },
+              "timeoutSeconds": {
+                "title": "timeoutSeconds",
+                "$id": "#/properties/startupProbe/properties/timeoutSeconds"
+              }
+            },
+            "title": "startupProbe",
+            "$id": "#/properties/startupProbe"
+          },
+          "terminationGracePeriodSeconds": {
+            "type": "string",
+            "title": "terminationGracePeriodSeconds",
+            "default": "",
+            "$id": "#/properties/terminationGracePeriodSeconds"
+          },
+          "tls": {
+            "properties": {
+              "autoGenerated": {
+                "title": "autoGenerated",
+                "$id": "#/properties/tls/properties/autoGenerated"
+              },
+              "certCAFilename": {
+                "type": "string",
+                "title": "certCAFilename",
+                "default": "",
+                "$id": "#/properties/tls/properties/certCAFilename"
+              },
+              "certFilename": {
+                "type": "string",
+                "title": "certFilename",
+                "default": "",
+                "$id": "#/properties/tls/properties/certFilename"
+              },
+              "certKeyFilename": {
+                "type": "string",
+                "title": "certKeyFilename",
+                "default": "",
+                "$id": "#/properties/tls/properties/certKeyFilename"
+              },
+              "certificatesSecret": {
+                "type": "string",
+                "title": "certificatesSecret",
+                "default": "",
+                "$id": "#/properties/tls/properties/certificatesSecret"
+              },
+              "crlFilename": {
+                "type": "string",
+                "title": "crlFilename",
+                "default": "",
+                "$id": "#/properties/tls/properties/crlFilename"
+              },
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/tls/properties/enabled"
+              },
+              "preferServerCiphers": {
+                "title": "preferServerCiphers",
+                "$id": "#/properties/tls/properties/preferServerCiphers"
+              }
+            },
+            "title": "tls",
+            "$id": "#/properties/tls"
+          },
+          "updateStrategy": {
+            "properties": {
+              "type": {
+                "type": "string",
+                "title": "type",
+                "default": "RollingUpdate",
+                "$id": "#/properties/updateStrategy/properties/type"
+              }
+            },
+            "title": "updateStrategy",
+            "$id": "#/properties/updateStrategy"
+          },
+          "usePasswordFile": {
+            "title": "usePasswordFile",
+            "$id": "#/properties/usePasswordFile"
+          },
+          "volumePermissions": {
+            "properties": {
+              "enabled": {
+                "title": "enabled",
+                "$id": "#/properties/volumePermissions/properties/enabled"
+              },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string",
+                    "title": "pullPolicy",
+                    "default": "Always",
+                    "$id": "#/properties/volumePermissions/properties/image/properties/pullPolicy"
+                  },
+                  "pullSecrets": {
+                    "title": "pullSecrets",
+                    "$id": "#/properties/volumePermissions/properties/image/properties/pullSecrets"
+                  },
+                  "registry": {
+                    "type": "string",
+                    "title": "registry",
+                    "default": "docker.io",
+                    "$id": "#/properties/volumePermissions/properties/image/properties/registry"
+                  },
+                  "repository": {
+                    "type": "string",
+                    "title": "repository",
+                    "default": "bitnami/bitnami-shell",
+                    "$id": "#/properties/volumePermissions/properties/image/properties/repository"
+                  },
+                  "tag": {
+                    "type": "string",
+                    "title": "tag",
+                    "default": "10-debian-10-r159",
+                    "$id": "#/properties/volumePermissions/properties/image/properties/tag"
+                  }
+                },
+                "title": "image",
+                "$id": "#/properties/volumePermissions/properties/image"
+              },
+              "securityContext": {
+                "properties": {
+                  "runAsUser": {
+                    "title": "runAsUser",
+                    "$id": "#/properties/volumePermissions/properties/securityContext/properties/runAsUser"
+                  }
+                },
+                "title": "securityContext",
+                "$id": "#/properties/volumePermissions/properties/securityContext"
+              }
+            },
+            "title": "volumePermissions",
+            "$id": "#/properties/volumePermissions"
+          }
+        },
+        "title": "#",
+        "$id": "#"
+      }

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.aws.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.aws.test-input.yaml
@@ -1,0 +1,32 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.terraform.aws"
+  name: test-input
+  displayName: "Input for terraform.aws.test"
+  description: Input for the "terraform.aws.test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+spec:
+  jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
+    value: |-
+      {
+        "properties": {
+          "count": {
+            "type": "number",
+            "title": "count",
+            "description": "Number of instances"
+          },
+          "name": {
+            "type": "string",
+            "title": "name",
+            "description": "Name of environment"
+          }
+        }
+      }

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.gcp.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.gcp.test-input.yaml
@@ -1,0 +1,32 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.terraform.gcp"
+  name: test-input
+  displayName: "Input for terraform.gcp.test"
+  description: Input for the "terraform.gcp.test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+spec:
+  jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
+    value: |-
+      {
+        "properties": {
+          "count": {
+            "type": "number",
+            "title": "count",
+            "description": "Number of instances"
+          },
+          "name": {
+            "type": "string",
+            "title": "name",
+            "description": "Name of environment"
+          }
+        }
+      }

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.generic.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.generic.test-input.yaml
@@ -1,0 +1,32 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.terraform.generic"
+  name: test-input
+  displayName: "Input for terraform.generic.test"
+  description: Input for the "terraform.generic.test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+spec:
+  jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
+    value: |-
+      {
+        "properties": {
+          "count": {
+            "type": "number",
+            "title": "count",
+            "description": "Number of instances"
+          },
+          "name": {
+            "type": "string",
+            "title": "name",
+            "description": "Name of environment"
+          }
+        }
+      }

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.terraform.test-input.yaml
@@ -1,0 +1,32 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.terraform"
+  name: test-input
+  displayName: "Input for terraform.test"
+  description: Input for the "terraform.test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+spec:
+  jsonSchema:
+    # TODO(ContentDeveloper): Adjust the JSON schema if needed.
+    value: |-
+      {
+        "properties": {
+          "count": {
+            "type": "number",
+            "title": "count",
+            "description": "Number if instance"
+          },
+          "name": {
+            "type": "string",
+            "title": "name",
+            "description": "Name of environment"
+          }
+        }
+      }

--- a/internal/cli/alpha/manifestgen/testdata/terraform/outputs.tf
+++ b/internal/cli/alpha/manifestgen/testdata/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_ids" {
+  description = "IDs of created instances"
+  value       = [1, 2, 3]
+}
+
+output "random_number" {
+  description = "Some random number. Chosen by fair dice roll. Guaranteed to be random."
+  value       = 4
+}

--- a/internal/cli/alpha/manifestgen/testdata/terraform/variables.tf
+++ b/internal/cli/alpha/manifestgen/testdata/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type        = string
+  description = "Name of environment"
+  default     = "test"
+}
+
+variable "count" {
+  type        = number
+  description = "Number of instances"
+  default     = 3
+}

--- a/internal/cli/alpha/manifestgen/types.go
+++ b/internal/cli/alpha/manifestgen/types.go
@@ -1,0 +1,93 @@
+package manifestgen
+
+import (
+	"github.com/alecthomas/jsonschema"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+)
+
+// Config stores generic input parameters for content generation
+type Config struct {
+	ManifestPath     string
+	ManifestRevision string
+}
+
+// InterfaceConfig stores input parameters for Interface content generation
+type InterfaceConfig struct {
+	Config
+}
+
+// ImplementationConfig stores input parameters for Implementation content generation
+type ImplementationConfig struct {
+	Config
+	InterfacePathWithRevision string
+}
+
+// TerraformConfig stores input parameters for Terraform-based Implementation content generation
+type TerraformConfig struct {
+	ImplementationConfig
+
+	ModulePath      string
+	ModuleSourceURL string
+	Provider        Provider
+}
+
+// HelmConfig stores input parameters for Helm-based Implementation content generation.
+type HelmConfig struct {
+	ImplementationConfig
+
+	ChartName    string
+	ChartRepoURL string
+	ChartVersion string
+}
+
+type templatingConfig struct {
+	Template string
+	Input    interface{}
+}
+
+type templatingInput struct {
+	Name     string
+	Prefix   string
+	Revision string
+}
+
+type interfaceGroupTemplatingInput struct {
+	templatingInput
+}
+
+type interfaceTemplatingInput struct {
+	templatingInput
+}
+
+type outputTypeTemplatingInput struct {
+	templatingInput
+}
+
+type typeTemplatingInput struct {
+	templatingInput
+	JSONSchema *jsonschema.Type
+}
+
+type terraformImplementationTemplatingInput struct {
+	templatingInput
+
+	InterfacePath     string
+	InterfaceRevision string
+	ModuleSourceURL   string
+	Outputs           []*tfconfig.Output
+	Provider          Provider
+	Variables         []*tfconfig.Variable
+}
+
+type helmImplementationTemplatingInput struct {
+	templatingInput
+
+	InterfacePath     string
+	InterfaceRevision string
+
+	HelmChartName    string
+	HelmChartVersion string
+	HelmRepoURL      string
+
+	ValuesYAML string
+}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add `capact alpha manifest-gen implementation helm` command
- Rename `--override` flag to `--overwrite`
- Add unit tests for the manifest generation code

### Testing

You can use the following command to generate manifests for the `bitnami/postgresql` Helm chart:
```bash
go run cmd/cli/main.go alpha manifest-gen implementation helm cap.implementation.bitnami.postgresql.install postgresql --repo "https://charts.bitnami.com/bitnami" -i cap.interface.database.postgresql.install
```
### Problems

1. If user provides an empty parameter value for a string, it will be interpreted as null, when evaluating values in workflow.
   The values of the parameters are transformed to strings in format:
   ```yaml
   key: <@ additionalInput.key | default("some_default") @>
   # becomes, if user provides an empty string as value
   key:        # interpreted as null in YAML
   ```
   I couldn't find a way to make `yaml.Marshal` add double quotes to every string value so it would be 

2. If a key in Helm values.yaml contains a dot, then Jinja will have problem with interpreting it correctly. I'm not sure if this is a problem in Jinja as changing it to `object[key]` instead of `object.key` does not work also.
   ```yaml
   # does not work
   annotations:
      prometheus.scrape: <@ additionalInput.annotations.prometheus.scrape @>

   # also does not work
   annotations:
      prometheus.scrape: <@ additionalInput.annotations["prometheus.scrape"] @>
   ```

## Related issue(s)

Closes https://github.com/capactio/capact/issues/417

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
