### PR TITLE
Fix k8s controller test, add retry for createObject, revert hub-manifest sources

### DIFF
--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -46,7 +46,7 @@ readonly CAPACT_USE_TEST_SETUP="false"
 #
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/mszostok/hub-manifests"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/capactio/hub-manifests"
 # The git ref to checkout. It can point to a commit SHA, a branch name, or a tag.
 # If you want to use your forked version, remember to update CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL  respectively.
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="additional-params"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="main"

--- a/internal/cli/capact/components_test.go
+++ b/internal/cli/capact/components_test.go
@@ -1,0 +1,132 @@
+package capact
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/kube"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+func TestCreateObjectRetrySuccess(t *testing.T) {
+	tests := map[string]struct {
+		givenError error
+	}{
+		"Should pass on nil error": {
+			givenError: nil,
+		},
+		"Should ignore AlreadyExist error": {
+			givenError: apierrors.NewAlreadyExists(schema.GroupResource{}, "test-object"),
+		},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			failingCli := &FailingKubeClient{
+				CreateError: tc.givenError,
+			}
+
+			actionCfg := &action.Configuration{
+				KubeClient: failingCli,
+			}
+
+			objToCreate := fmt.Sprintf(issuerTemplate, clusterIssuerName, certManagerSecretName)
+
+			// when
+			err := createObject(actionCfg, []byte(objToCreate))
+
+			// then
+			assert.NoError(t, err)
+			assert.Equal(t, 1, failingCli.CreateCallsCnt)
+		})
+	}
+}
+
+func TestCreateObjectRetryFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping TestCreateObjectRetry as it takes up to 2s")
+	}
+
+	// given
+	expTotalRetryDurationInSec := 1.6
+
+	internalError := apierrors.NewInternalError(errors.New("simulate internal error"))
+	failingCli := &FailingKubeClient{
+		CreateError: internalError,
+	}
+
+	actionCfg := &action.Configuration{
+		KubeClient: failingCli,
+	}
+
+	objToCreate := fmt.Sprintf(issuerTemplate, clusterIssuerName, certManagerSecretName)
+
+	// when
+	startedCall := time.Now()
+	err := createObject(actionCfg, []byte(objToCreate))
+
+	// then
+	assert.EqualError(t, err, internalError.Error())
+	assert.Equal(t, 5, failingCli.CreateCallsCnt)
+	assert.InDelta(t, expTotalRetryDurationInSec, time.Since(startedCall).Seconds(), 0.2)
+}
+
+// FailingKubeClient implements KubeClient for testing purposes.
+type FailingKubeClient struct {
+	CreateError    error
+	CreateCallsCnt int
+}
+
+// Create returns the configured error if set or prints
+func (f *FailingKubeClient) Create(resources kube.ResourceList) (*kube.Result, error) {
+	f.CreateCallsCnt++
+	return nil, f.CreateError
+}
+
+// Build returns the configured error if set or prints
+func (f *FailingKubeClient) Build(r io.Reader, _ bool) (kube.ResourceList, error) {
+	return []*resource.Info{}, nil
+}
+
+// Wait returns the configured error if set or prints
+func (f *FailingKubeClient) Wait(resources kube.ResourceList, d time.Duration) error {
+	return errors.New("not implemented")
+}
+
+// WaitWithJobs returns the configured error if set or prints
+func (f *FailingKubeClient) WaitWithJobs(resources kube.ResourceList, d time.Duration) error {
+	return errors.New("not implemented")
+}
+
+// Delete returns the configured error if set or prints
+func (f *FailingKubeClient) Delete(resources kube.ResourceList) (*kube.Result, []error) {
+	return nil, []error{errors.New("not implemented")}
+}
+
+// WatchUntilReady returns the configured error if set or prints
+func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.Duration) error {
+	return errors.New("not implemented")
+}
+
+// Update returns the configured error if set or prints
+func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+// WaitAndGetCompletedPodPhase returns the configured error if set or prints
+func (f *FailingKubeClient) WaitAndGetCompletedPodPhase(s string, d time.Duration) (v1.PodPhase, error) {
+	return v1.PodFailed, errors.New("not implemented")
+}
+
+// IsReachable checks if the cluster is reachable
+func (f *FailingKubeClient) IsReachable() error {
+	return nil
+}

--- a/internal/cli/capact/components_test.go
+++ b/internal/cli/capact/components_test.go
@@ -85,48 +85,40 @@ type FailingKubeClient struct {
 	CreateCallsCnt int
 }
 
-// Create returns the configured error if set or prints
+// Create returns the configured error.
 func (f *FailingKubeClient) Create(resources kube.ResourceList) (*kube.Result, error) {
 	f.CreateCallsCnt++
 	return nil, f.CreateError
 }
 
-// Build returns the configured error if set or prints
 func (f *FailingKubeClient) Build(r io.Reader, _ bool) (kube.ResourceList, error) {
 	return []*resource.Info{}, nil
 }
 
-// Wait returns the configured error if set or prints
 func (f *FailingKubeClient) Wait(resources kube.ResourceList, d time.Duration) error {
 	return errors.New("not implemented")
 }
 
-// WaitWithJobs returns the configured error if set or prints
 func (f *FailingKubeClient) WaitWithJobs(resources kube.ResourceList, d time.Duration) error {
 	return errors.New("not implemented")
 }
 
-// Delete returns the configured error if set or prints
 func (f *FailingKubeClient) Delete(resources kube.ResourceList) (*kube.Result, []error) {
 	return nil, []error{errors.New("not implemented")}
 }
 
-// WatchUntilReady returns the configured error if set or prints
 func (f *FailingKubeClient) WatchUntilReady(resources kube.ResourceList, d time.Duration) error {
 	return errors.New("not implemented")
 }
 
-// Update returns the configured error if set or prints
 func (f *FailingKubeClient) Update(r, modified kube.ResourceList, ignoreMe bool) (*kube.Result, error) {
 	return nil, errors.New("not implemented")
 }
 
-// WaitAndGetCompletedPodPhase returns the configured error if set or prints
 func (f *FailingKubeClient) WaitAndGetCompletedPodPhase(s string, d time.Duration) (v1.PodPhase, error) {
 	return v1.PodFailed, errors.New("not implemented")
 }
 
-// IsReachable checks if the cluster is reachable
 func (f *FailingKubeClient) IsReachable() error {
 	return nil
 }

--- a/internal/cli/capact/components_test.go
+++ b/internal/cli/capact/components_test.go
@@ -52,7 +52,7 @@ func TestCreateObjectRetrySuccess(t *testing.T) {
 
 func TestCreateObjectRetryFailed(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping TestCreateObjectRetry as it takes up to 2s")
+		t.Skip("Skipping TestCreateObjectRetry as it takes up to 1.5s")
 	}
 
 	// given
@@ -74,7 +74,7 @@ func TestCreateObjectRetryFailed(t *testing.T) {
 	err := createObject(actionCfg, []byte(objToCreate))
 
 	// then
-	assert.EqualError(t, err, internalError.Error())
+	assert.Contains(t, err.Error(), internalError.Error())
 	assert.Equal(t, 5, failingCli.CreateCallsCnt)
 	assert.InDelta(t, expTotalRetryDurationInSec, time.Since(startedCall).Seconds(), 0.2)
 }

--- a/internal/cli/schema/embed_schema.go
+++ b/internal/cli/schema/embed_schema.go
@@ -1,3 +1,4 @@
+//go:build generate
 // +build generate
 
 package main

--- a/internal/k8s-engine/controller/action_controller_test.go
+++ b/internal/k8s-engine/controller/action_controller_test.go
@@ -1,4 +1,5 @@
-//+build controllertests
+//go:build controllertests
+// +build controllertests
 
 package controller
 

--- a/internal/k8s-engine/controller/suite_test.go
+++ b/internal/k8s-engine/controller/suite_test.go
@@ -1,4 +1,5 @@
-//+build controllertests
+//go:build controllertests
+// +build controllertests
 
 package controller
 
@@ -81,12 +82,12 @@ var _ = BeforeSuite(func(done Done) {
 			Image:   "not-needed",
 		},
 	}
-	err = (&ActionReconciler{
-		log: ctrl.Log.WithName("controllers").WithName("Action"),
-		svc: NewActionService(zap.NewRaw(zap.WriteTo(ioutil.Discard)), mgr.GetClient(),
-			&argoRendererFake{}, &actionValidatorFake{}, &policyServiceFake{}, policy.MergeOrder{policy.Action, policy.Global}, &typeInstanceLockerFake{},
-			&typeInstanceGetterFake{}, cfg),
-	}).SetupWithManager(mgr, maxConcurrentReconciles)
+
+	svc := NewActionService(zap.NewRaw(zap.WriteTo(ioutil.Discard)), mgr.GetClient(),
+		&argoRendererFake{}, &actionValidatorFake{}, &policyServiceFake{}, policy.MergeOrder{policy.Action, policy.Global}, &typeInstanceLockerFake{},
+		&typeInstanceGetterFake{}, cfg)
+
+	err = NewActionReconciler(ctrl.Log, svc, 25).SetupWithManager(mgr, maxConcurrentReconciles)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION


## Description

Changes proposed in this pull request:

- Fix k8s controller test,
- Add retry for createObject, 
- Revert hub-manifest sources

## Related issue(s)

- https://github.com/capactio/capact/issues/438

