### PR TITLE
Add global verbose flag to CLI, add spent time info

### DIFF
--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/helm.go
@@ -58,7 +58,7 @@ func NewHelm() *cobra.Command {
 	cmd.Flags().StringVarP(&helmCfg.InterfacePathWithRevision, "interface", "i", "", "Path with revision of the Interface, which is implemented by this Implementation")
 	cmd.Flags().StringVarP(&helmCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Implementation manifest")
 	cmd.Flags().StringVar(&helmCfg.ChartRepoURL, "repo", "", "URL of the Helm repository")
-	cmd.Flags().StringVarP(&helmCfg.ChartVersion, "version", "v", "", "Version of the Helm chart")
+	cmd.Flags().StringVar(&helmCfg.ChartVersion, "version", "", "Version of the Helm chart")
 
 	return cmd
 }

--- a/cmd/cli/cmd/install.go
+++ b/cmd/cli/cmd/install.go
@@ -56,7 +56,6 @@ func NewInstall() *cobra.Command {
 	flags.DurationVar(&opts.Timeout, "timeout", 10*time.Minute, `Maximum time during which the upgrade process is being watched, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	flags.BoolVar(&opts.UpdateHostsFile, "update-hosts-file", true, "Updates /etc/hosts with entry for Capact GraphQL Gateway.")
 	flags.BoolVar(&opts.UpdateTrustedCerts, "update-trusted-certs", true, "Add Capact GraphQL Gateway certificate.")
-	flags.BoolVar(&opts.Verbose, "verbose", false, "Prints more verbose output.")
 	flags.StringVar(&opts.Parameters.Override.HelmRepoURL, "helm-repo-url", capact.HelmRepoStable, fmt.Sprintf("Capact Helm chart repository URL. Use %s tag to select repository which holds the latest Helm chart versions.", capact.LatestVersionTag))
 	flags.StringSliceVar(&opts.Parameters.Override.CapactStringOverrides, "capact-overrides", []string{}, "Overrides for Capact component.")
 	flags.StringSliceVar(&opts.Parameters.Override.IngressStringOverrides, "ingress-controller-overrides", []string{}, "Overrides for Ingress controller component.")

--- a/cmd/cli/cmd/manifest/validate.go
+++ b/cmd/cli/cmd/manifest/validate.go
@@ -44,7 +44,6 @@ func NewValidate() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.SchemaLocation, "schemas", "s", "", "Path to the local directory with OCF JSONSchemas. If not provided, built-in JSONSchemas are used.")
-	flags.BoolVarP(&opts.Verbose, "verbose", "v", false, "Prints more verbose output.")
 	flags.BoolVar(&opts.ServerSide, "server-side", false, "Executes additional manifests checks against Capact Hub.")
 	flags.IntVar(&opts.MaxConcurrency, "concurrency", defaultMaxConcurrency, "Maximum number of concurrent workers.")
 

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -75,6 +75,7 @@ func NewRoot() *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Path to the YAML config file")
+	cli.RegisterVerboseModeFlag(rootCmd.PersistentFlags())
 
 	rootCmd.AddCommand(
 		NewDocs(),

--- a/cmd/cli/docs/capact.md
+++ b/cmd/cli/docs/capact.md
@@ -51,8 +51,9 @@ capact [flags]
 ### Options
 
 ```
-  -c, --config string   Path to the YAML config file
-  -h, --help            help for capact
+  -c, --config string                 Path to the YAML config file
+  -h, --help                          help for capact
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action.md
+++ b/cmd/cli/docs/capact_action.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with target Actions
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action_create.md
+++ b/cmd/cli/docs/capact_action_create.md
@@ -31,7 +31,8 @@ capact action create INTERFACE [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action_delete.md
+++ b/cmd/cli/docs/capact_action_delete.md
@@ -35,7 +35,8 @@ capact action delete --name-regex='upgrade-*' --namespace=foo
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action_get.md
+++ b/cmd/cli/docs/capact_action_get.md
@@ -33,7 +33,8 @@ capact action get funny-stallman -ojson
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action_run.md
+++ b/cmd/cli/docs/capact_action_run.md
@@ -21,7 +21,8 @@ capact action run ACTION [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_action_watch.md
+++ b/cmd/cli/docs/capact_action_watch.md
@@ -43,7 +43,8 @@ capact action watch @latest
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha.md
+++ b/cmd/cli/docs/capact_alpha.md
@@ -19,7 +19,8 @@ Subcommand for alpha features in the CLI
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen.md
@@ -21,7 +21,8 @@ Subcommand for various manifest generation operations
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation.md
@@ -19,9 +19,10 @@ Generate new Implementation manifests for various tools.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
-  -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --overwrite       Overwrite existing manifest files
+  -c, --config string                 Path to the YAML config file
+  -o, --output string                 Path to the output directory for the generated manifests (default "generated")
+      --overwrite                     Overwrite existing manifest files
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_helm.md
@@ -21,15 +21,16 @@ capact alpha manifest-gen implementation helm [MANIFEST_PATH] [HELM_CHART_NAME] 
   -i, --interface string   Path with revision of the Interface, which is implemented by this Implementation
       --repo string        URL of the Helm repository
   -r, --revision string    Revision of the Implementation manifest (default "0.1.0")
-  -v, --version string     Version of the Helm chart
+      --version string     Version of the Helm chart
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
-  -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --overwrite       Overwrite existing manifest files
+  -c, --config string                 Path to the YAML config file
+  -o, --output string                 Path to the output directory for the generated manifests (default "generated")
+      --overwrite                     Overwrite existing manifest files
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_implementation_terraform.md
@@ -40,9 +40,10 @@ capact alpha manifest-gen implementation terraform cap.implementation.gcp.clouds
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
-  -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --overwrite       Overwrite existing manifest files
+  -c, --config string                 Path to the YAML config file
+  -o, --output string                 Path to the output directory for the generated manifests (default "generated")
+      --overwrite                     Overwrite existing manifest files
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
@@ -31,9 +31,10 @@ capact alpha content interface cap.interface.database.postgresql install
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
-  -o, --output string   Path to the output directory for the generated manifests (default "generated")
-      --overwrite       Overwrite existing manifest files
+  -c, --config string                 Path to the YAML config file
+  -o, --output string                 Path to the output directory for the generated manifests (default "generated")
+      --overwrite                     Overwrite existing manifest files
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_completion.md
+++ b/cmd/cli/docs/capact_completion.md
@@ -46,7 +46,8 @@ capact completion [bash|zsh|fish|powershell] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_config.md
+++ b/cmd/cli/docs/capact_config.md
@@ -19,7 +19,8 @@ Display or change configuration settings for the Hub
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_config_get-contexts.md
+++ b/cmd/cli/docs/capact_config_get-contexts.md
@@ -27,7 +27,8 @@ capact config get-contexts
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_config_set-context.md
+++ b/cmd/cli/docs/capact_config_set-context.md
@@ -30,7 +30,8 @@ capact config set-context localhost:8080
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_environment.md
+++ b/cmd/cli/docs/capact_environment.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with a Capact environm
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_environment_create.md
+++ b/cmd/cli/docs/capact_environment_create.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to create a Capact environment
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_environment_create_kind.md
+++ b/cmd/cli/docs/capact_environment_create_kind.md
@@ -25,7 +25,8 @@ capact environment create kind [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_environment_delete.md
+++ b/cmd/cli/docs/capact_environment_delete.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to delete created Capact environme
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_environment_delete_kind.md
+++ b/cmd/cli/docs/capact_environment_delete_kind.md
@@ -20,7 +20,8 @@ capact environment delete kind [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub.md
+++ b/cmd/cli/docs/capact_hub.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with Hub server.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub_implementation.md
+++ b/cmd/cli/docs/capact_hub_implementation.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with Implementations s
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub_implementation_get.md
+++ b/cmd/cli/docs/capact_hub_implementation_get.md
@@ -32,7 +32,8 @@ capact hub implementations get cap.interface.database.postgresql.install -oyaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub_interface.md
+++ b/cmd/cli/docs/capact_hub_interface.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with Interfaces stored
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub_interface_browse.md
+++ b/cmd/cli/docs/capact_hub_interface_browse.md
@@ -29,7 +29,8 @@ capact hub interface browse [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_hub_interface_get.md
+++ b/cmd/cli/docs/capact_hub_interface_get.md
@@ -32,7 +32,8 @@ capact hub interfaces get cap.interface.database.postgresql.install -ojson
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_install.md
+++ b/cmd/cli/docs/capact_install.md
@@ -44,14 +44,14 @@ capact install --version @local
       --timeout duration                       Maximum time during which the upgrade process is being watched, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 10m0s)
       --update-hosts-file                      Updates /etc/hosts with entry for Capact GraphQL Gateway. (default true)
       --update-trusted-certs                   Add Capact GraphQL Gateway certificate. (default true)
-      --verbose                                Prints more verbose output.
       --version string                         Capact version. Possible values @latest, @local, 0.3.0, ... (default "@latest")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_login.md
+++ b/cmd/cli/docs/capact_login.md
@@ -33,7 +33,8 @@ capact login localhost:8080 -u user
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_logout.md
+++ b/cmd/cli/docs/capact_logout.md
@@ -30,7 +30,8 @@ capact logout localhost:8080
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_manifest.md
+++ b/cmd/cli/docs/capact_manifest.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with OCF manifests
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_manifest_validate.md
+++ b/cmd/cli/docs/capact_manifest_validate.md
@@ -33,13 +33,13 @@ capact manifest validate -s my/ocf/spec/directory ocf-spec/0.0.1/examples/interf
   -h, --help              help for validate
   -s, --schemas string    Path to the local directory with OCF JSONSchemas. If not provided, built-in JSONSchemas are used.
       --server-side       Executes additional manifests checks against Capact Hub.
-  -v, --verbose           Prints more verbose output.
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_policy.md
+++ b/cmd/cli/docs/capact_policy.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with Policy
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_policy_apply.md
+++ b/cmd/cli/docs/capact_policy_apply.md
@@ -29,7 +29,8 @@ capact policy apply -f /tmp/policy.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_policy_edit.md
+++ b/cmd/cli/docs/capact_policy_edit.md
@@ -28,7 +28,8 @@ capact policy edit
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_policy_get.md
+++ b/cmd/cli/docs/capact_policy_get.md
@@ -21,7 +21,8 @@ capact policy get [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance.md
+++ b/cmd/cli/docs/capact_typeinstance.md
@@ -15,7 +15,8 @@ This command consists of multiple subcommands to interact with target TypeInstan
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance_apply.md
+++ b/cmd/cli/docs/capact_typeinstance_apply.md
@@ -36,7 +36,8 @@ capact typeinstance apply -f /tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance_create.md
+++ b/cmd/cli/docs/capact_typeinstance_create.md
@@ -56,7 +56,8 @@ capact typeinstance create -f ./tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance_delete.md
+++ b/cmd/cli/docs/capact_typeinstance_delete.md
@@ -28,7 +28,8 @@ capact typeinstance delete c49b 4793
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance_edit.md
+++ b/cmd/cli/docs/capact_typeinstance_edit.md
@@ -26,7 +26,8 @@ capact typeinstance edit TYPE_INSTANCE_ID [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_typeinstance_get.md
+++ b/cmd/cli/docs/capact_typeinstance_get.md
@@ -34,7 +34,8 @@ capact typeinstance get c49b 4793 -oyaml --export > /tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_upgrade.md
+++ b/cmd/cli/docs/capact_upgrade.md
@@ -44,7 +44,8 @@ capact upgrade --version 0.1.0
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/cmd/cli/docs/capact_version.md
+++ b/cmd/cli/docs/capact_version.md
@@ -20,7 +20,8 @@ capact version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the YAML config file
+  -c, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - tracing (default 0 - disable)
 ```
 
 ### SEE ALSO

--- a/internal/cli/capact/capact.go
+++ b/internal/cli/capact/capact.go
@@ -59,5 +59,4 @@ type Options struct {
 	Parameters         InputParameters
 	UpdateHostsFile    bool
 	UpdateTrustedCerts bool
-	Verbose            bool
 }

--- a/internal/cli/capact/components.go
+++ b/internal/cli/capact/components.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"time"
 
+	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/printer"
 	"capact.io/capact/internal/maps"
 	"capact.io/capact/internal/ptr"
@@ -20,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/cli"
+	helmcli "helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"helm.sh/helm/v3/pkg/strvals"
@@ -144,7 +145,7 @@ func (c *ComponentData) runUpgrade(upgradeCli *action.Upgrade, values map[string
 		location = c.Chart()
 	}
 
-	chartPath, err = upgradeCli.ChartPathOptions.LocateChart(location, &cli.EnvSettings{
+	chartPath, err = upgradeCli.ChartPathOptions.LocateChart(location, &helmcli.EnvSettings{
 		RepositoryCache: RepositoryCache,
 	})
 	if err != nil {
@@ -174,7 +175,7 @@ func (c *ComponentData) runInstall(installCli *action.Install, values map[string
 		location = c.Chart()
 	}
 
-	chartPath, err = installCli.ChartPathOptions.LocateChart(location, &cli.EnvSettings{
+	chartPath, err = installCli.ChartPathOptions.LocateChart(location, &helmcli.EnvSettings{
 		RepositoryCache: RepositoryCache,
 	})
 	if err != nil {
@@ -585,7 +586,7 @@ func NewHelm(configuration *action.Configuration, opts Options) *Helm {
 
 // InstallComponents installs Helm components
 func (h *Helm) InstallComponents(ctx context.Context, w io.Writer, status *printer.Status) error {
-	if h.opts.Verbose {
+	if cli.VerboseMode.IsEnabled() {
 		status.Step("Resolving installation config")
 		status.End(true)
 		h.writeHelmDetails(w)
@@ -606,7 +607,7 @@ func (h *Helm) InstallComponents(ctx context.Context, w io.Writer, status *print
 		if err != nil {
 			return err
 		}
-		if h.opts.Verbose {
+		if cli.VerboseMode.IsEnabled() {
 			h.writeStatus(w, newRelease)
 		}
 	}

--- a/internal/cli/client/cluster.go
+++ b/internal/cli/client/cluster.go
@@ -3,7 +3,10 @@ package client
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 
+	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/credstore"
 	enginegraphql "capact.io/capact/pkg/engine/api/graphql"
 	"capact.io/capact/pkg/engine/client"
@@ -60,9 +63,13 @@ func NewClusterWithCreds(server string, creds *credstore.Credentials) (ClusterCl
 		httputil.WithTimeout(timeout))
 
 	gqlClient := graphql.NewClient(endpoint, graphql.WithHTTPClient(httpClient))
+	if cli.VerboseMode.IsTracing() {
+		logger := log.New(os.Stdout, "\nGraphQL client: ", log.LstdFlags)
+		gqlClient.Log = func(s string) { logger.Println(s) }
+	}
 
 	return &clusterClient{
 		TypeInstanceClient: local.NewClient(gqlClient),
-		EngineClient:       client.New(endpoint, httpClient),
+		EngineClient:       client.New(gqlClient),
 	}, nil
 }

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"capact.io/capact/internal/cli"
 	"capact.io/capact/pkg/sdk/validation/manifest"
 
 	"github.com/fatih/color"
@@ -21,7 +22,6 @@ import (
 type Options struct {
 	SchemaLocation string
 	ServerSide     bool
-	Verbose        bool
 	MaxConcurrency int
 }
 
@@ -63,7 +63,6 @@ func (r *ValidationResult) Error() string {
 type Validation struct {
 	hubCli      client.Hub
 	writer      io.Writer
-	verbose     bool
 	maxWorkers  int
 	validatorFn func() manifest.FileSystemValidator
 }
@@ -101,7 +100,6 @@ func New(writer io.Writer, opts Options) (*Validation, error) {
 		},
 		hubCli:     hubCli,
 		writer:     writer,
-		verbose:    opts.Verbose,
 		maxWorkers: opts.MaxConcurrency,
 	}, nil
 }
@@ -170,7 +168,7 @@ func (v *Validation) printPartialResult(res ValidationResult) {
 	}
 
 	// Print successes only in verbose mode
-	if !v.verbose {
+	if !cli.VerboseMode.IsEnabled() {
 		return
 	}
 	fmt.Fprintf(v.writer, "- %s %q\n", color.GreenString("✓"), res.Path)

--- a/internal/cli/verbose.go
+++ b/internal/cli/verbose.go
@@ -73,7 +73,7 @@ func (o *VerboseModeFlag) Set(in string) error {
 	// try int ID
 	id, err := strconv.Atoi(in)
 	if err != nil {
-		return err
+		return ErrInvalidFormatType
 	}
 	*o = VerboseModeFlag(id)
 	if !o.IsValid() {

--- a/internal/cli/verbose.go
+++ b/internal/cli/verbose.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// VerboseMode defines if CLI should use verbose mode
+var VerboseMode = VerboseModeDisabled
+
+// VerboseModeFlag is a type for capturing supported verbose mode formats.
+// Implements pflag.Value interface.
+type VerboseModeFlag int
+
+const (
+	// VerboseModeDisabled represents disabled verbose mode
+	VerboseModeDisabled VerboseModeFlag = 0
+	// VerboseModeSimple represents simple verbose mode (human friendly)
+	VerboseModeSimple VerboseModeFlag = 1
+	// VerboseModeTracing represents tracing verbose mode (output may be overwhelming)
+	// In this mode http calls (request, response body, headers etc.) are logged
+	VerboseModeTracing VerboseModeFlag = 2
+)
+
+// VerboseModeHumanMapping holds mapping between IDs and human-readable modes.
+var VerboseModeHumanMapping = map[VerboseModeFlag]string{
+	VerboseModeDisabled: "disable",
+	VerboseModeSimple:   "simple",
+	VerboseModeTracing:  "tracing",
+}
+
+// ErrInvalidFormatType is returned when an unsupported verbose mode is used.
+var ErrInvalidFormatType = fmt.Errorf("unknown verbose mode")
+
+// RegisterVerboseModeFlag registers VerboseMode flag.
+func RegisterVerboseModeFlag(flags *pflag.FlagSet) {
+	flags.VarP(&VerboseMode, "verbose", "v", fmt.Sprintf("Prints more verbose output. Allowed values: %s", VerboseMode.AllowedOptions()))
+	flags.Lookup("verbose").NoOptDefVal = VerboseModeHumanMapping[VerboseModeSimple]
+}
+
+// IsValid returns true if VerboseModeFlag is valid.
+func (o VerboseModeFlag) IsValid() bool {
+	switch o {
+	case VerboseModeDisabled, VerboseModeSimple, VerboseModeTracing:
+		return true
+	}
+	return false
+}
+
+// AllowedOptions returns list of allowed verbose mode options.
+func (o VerboseModeFlag) AllowedOptions() string {
+	return fmt.Sprintf("%s, %s, %s", VerboseModeDisabled, VerboseModeSimple, VerboseModeTracing)
+}
+
+// String returns the string representation of the Format. Required by pflag.Value interface.
+func (o VerboseModeFlag) String() string {
+	return fmt.Sprintf("%d - %s", o, VerboseModeHumanMapping[o])
+}
+
+// Set format type to a given input. Required by pflag.Value interface.
+func (o *VerboseModeFlag) Set(in string) error {
+	// try human
+	for key, humanVal := range VerboseModeHumanMapping {
+		if !strings.EqualFold(in, humanVal) {
+			continue
+		}
+		*o = key
+		return nil
+	}
+	// try int ID
+	id, err := strconv.Atoi(in)
+	if err != nil {
+		return err
+	}
+	*o = VerboseModeFlag(id)
+	if !o.IsValid() {
+		return ErrInvalidFormatType
+	}
+	return nil
+}
+
+// Type returns data type. Required by pflag.Value interface.
+func (o *VerboseModeFlag) Type() string {
+	return "int/string"
+}
+
+// IsEnabled returns true if any verbose mode is enabled.
+func (o VerboseModeFlag) IsEnabled() bool {
+	return o != VerboseModeDisabled
+}
+
+// IsTracing returns true if tracing verbose mode is enabled.
+func (o VerboseModeFlag) IsTracing() bool {
+	return o == VerboseModeTracing
+}

--- a/internal/cli/verbose_test.go
+++ b/internal/cli/verbose_test.go
@@ -1,0 +1,68 @@
+package cli_test
+
+import (
+	"testing"
+
+	"capact.io/capact/internal/cli"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerboseModeFlag(t *testing.T) {
+	tests := map[string]struct {
+		givenRawOption string
+		expectedMode   cli.VerboseModeFlag
+	}{
+		"Should parse simple verbose just by -v": {
+			givenRawOption: "-v",
+			expectedMode:   cli.VerboseModeSimple,
+		},
+		"Should parse simple verbose by id": {
+			givenRawOption: "-v=1",
+			expectedMode:   cli.VerboseModeSimple,
+		},
+		"Should parse tracing verbose by id": {
+			givenRawOption: "-v=2",
+			expectedMode:   cli.VerboseModeTracing,
+		},
+		"Should parse simple verbose by human name": {
+			givenRawOption: "-v=simple",
+			expectedMode:   cli.VerboseModeSimple,
+		},
+		"Should parse tracing verbose by human name": {
+			givenRawOption: "-v=tracing",
+			expectedMode:   cli.VerboseModeTracing,
+		},
+		"Should parse disable verbose by human name": {
+			givenRawOption: "-v=disable",
+			expectedMode:   cli.VerboseModeDisabled,
+		},
+		"Should parse disable if flag not provided": {
+			givenRawOption: "",
+			expectedMode:   cli.VerboseModeDisabled,
+		},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			old := cli.VerboseMode
+			defer func() { cli.VerboseMode = old }()
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			cli.RegisterVerboseModeFlag(flags)
+
+			var args []string
+			if tc.givenRawOption != "" {
+				args = append(args, tc.givenRawOption)
+			}
+
+			// when
+			err := flags.Parse(args)
+			require.NoError(t, err)
+
+			// then
+			assert.Equal(t, tc.expectedMode, cli.VerboseMode)
+		})
+	}
+}

--- a/pkg/engine/client/client.go
+++ b/pkg/engine/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"capact.io/capact/internal/k8s-engine/graphql/namespace"
 	enginegraphql "capact.io/capact/pkg/engine/api/graphql"
@@ -18,12 +17,9 @@ type Client struct {
 }
 
 // New returns a new Client instance.
-func New(endpoint string, httpClient *http.Client) *Client {
-	clientOpt := graphql.WithHTTPClient(httpClient)
-	client := graphql.NewClient(endpoint, clientOpt)
-
+func New(gqlClient *graphql.Client) *Client {
 	return &Client{
-		client: client,
+		client: gqlClient,
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package e2e
@@ -5,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"github.com/machinebox/graphql"
 	"testing"
 	"time"
 
@@ -99,7 +101,8 @@ func getEngineGraphQLClient() *engineclient.Client {
 		httputil.WithTLSInsecureSkipVerify(true),
 		httputil.WithBasicAuth(cfg.Gateway.Username, cfg.Gateway.Password),
 	)
-	return engineclient.New(cfg.Gateway.Endpoint, httpClient)
+	gqlClient := graphql.NewClient(cfg.Gateway.Endpoint, graphql.WithHTTPClient(httpClient))
+	return engineclient.New(gqlClient)
 }
 
 func log(format string, args ...interface{}) {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add global verbose flag to CLI, 
- Add verbose mode for GraphQL client,
- Add spent time info to each finished step (if verbose mode enabled),
- Add unit-test coverage for flag.

It is a small change, see first commit: https://github.com/mszostok/capact/commit/456f774ebf76dd3cad740a40e0d2e52a29a21500

**rest is just updated docs (autogenerated)**

**Screenshot:** _(click to fullscreen)_

<p align="center">
  <img alt="logo" src="https://user-images.githubusercontent.com/17568639/131035097-da1ef8f0-ce78-40a4-962f-e8650f600f0f.png" width="720px"/>
</p>


**Recording:** https://asciinema.org/a/432543
### REASON:
- sometimes we need to debug why CLI failed. Last time we had such issue: 
  ```
  ❯ capact action create \
    cap.interface.database.postgresql.install \
    --name rds \
    --parameters-from-file ./hidden/manifest-values/rds/params.yaml
  
  Error: 1 validation error detected:
  - Parameters "input-parameters":
      * Unknown parameter. Cannot validate it against JSONSchema.
  
  
  ❯ cat ./hidden/manifest-values/rds/params.yaml
  superuser:
    username: foo
    password: bar
  ```
  
  and it was wired that it failed, but with enabled GraphQL client logs it was easy to find out the root cause
  ```bash
  {"data":{"interface":{"rev":{"spec":{"input":{"parameters":[{"jsonSchema":null,"name":"input-parameters"}],"typeInstances":[]}}}}}}
  ```
  as you can see in body we didn't have `typeRef`

  but I had to manually add a logger to the client and build our Capact binary. Much easier it will be to tell someone to just add `-v` flag and share the response.

- last time I was debugging our installation time, and I was not able to tell how long it took, and when was started. It's nice to know if sth was stuck and also know approximately the time for each step (which you can get from previous runs). 

### IDEA:

Currently, we had verbose only for two commands (validation, install). We used the local variable assigned to a given `Options`. It's good, but it complicates a lot as we need to pass it down to each layer.

I decided to add a `VerboseMode` variable for `cli` pkg. Thanks to that, `cli` packages can use it in directly, as it is populated on `root` command.

The rule is that it can be used directly only under `cli` pkg. If you call external functions from e.g. `pkg/` you should pass this value and don't refer from e.g. `pkg` to `cli.VerboseMode` as it's tightly coupled with CLI and `flags` system.


## Related issue(s)

- https://github.com/capactio/capact/issues/353