### PR TITLE
Allow to use '.' in jinja keys

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -18,7 +18,7 @@ on:
       - "!**.md"
       - ".goreleaser.latest.yml"
     branches:
-      - "main"
+      - "jinja2dots"
 
 jobs:
   cancel-previous-workflows:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -18,7 +18,7 @@ on:
       - "!**.md"
       - ".goreleaser.latest.yml"
     branches:
-      - "jinja2dots"
+      - "main"
 
 jobs:
   cancel-previous-workflows:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -65,6 +65,39 @@ jobs:
         run: |
           make test-generated
 
+  python-tests:
+    name: Lint and test python code
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hack/images/jinja2/jinja2-cli
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          flake8 .
+        continue-on-error: true
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest . --count --exit-zero --max-line-length=127 --statistics
+
   documentation-sanity:
     name: Check documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -91,12 +91,12 @@ jobs:
       - name: Lint with flake8
         run: |
           pip install flake8
-          flake8 .
+          flake8 . --count --exit-zero --max-line-length=127 --statistics
         continue-on-error: true
       - name: Test with pytest
         run: |
           pip install pytest
-          pytest . --count --exit-zero --max-line-length=127 --statistics
+          pytest .
 
   documentation-sanity:
     name: Check documentation

--- a/hack/images/jinja2/README.md
+++ b/hack/images/jinja2/README.md
@@ -16,6 +16,8 @@
 * for variables use now `<@ variable @>` instead of `{{ variable }}`,
 * for blocks use now `<% block %>` instead of `{% block %}`,
 * variables can have a prefix, so the conflicting names can be rendered correctly.
+* keys with dots are allowed but need to be accessed using braces `<@ input["key.dot"] @>`
+* if there are items and attributes with the same name, items are preferred
 
 Jinja cli is a copy of https://github.com/mattrobenolt/jinja2-cli (commit de5e8bf5132c80a8bbf37d788f4fff4af631753a)
 Docker part is a copy of https://github.com/dinuta/jinja2docker (commit 9a44ceecd83cbe195d2d2c47e969dbb5cb5dbaa2)

--- a/hack/images/jinja2/jinja2-cli/jinja2cli/capact.py
+++ b/hack/images/jinja2/jinja2-cli/jinja2cli/capact.py
@@ -34,6 +34,9 @@ class Undefined(Undefined):
     def __getattr__(self, attr):
         return Undefined(name=".".join([self._undefined_name, attr]))
 
+    def __getitem__(self, attr):
+        return Undefined(name=f'{self._undefined_name}["{attr}"]')
+
 
 # Dict is a special type of dict which always returns an item before checking an attribute
 class Dict(dict):
@@ -58,7 +61,7 @@ class Dict(dict):
 
     def __getattribute__(self, name):
         try:
-            return Dict(self[name])
+            return self[name]
         except Exception as e:
             return super().__getattribute__(name)
 

--- a/hack/images/jinja2/jinja2-cli/jinja2cli/capact.py
+++ b/hack/images/jinja2/jinja2-cli/jinja2cli/capact.py
@@ -2,7 +2,7 @@ import string
 import random
 import base64
 
-from jinja2.runtime import Undefined, missing
+from jinja2.runtime import Undefined
 
 _punctuation = r"""!#$%&()*+,-.:;<=>?@[]^_{|}~"""
 
@@ -40,7 +40,7 @@ class Undefined(Undefined):
 
 # Dict is a special type of dict which always returns an item before checking an attribute
 class Dict(dict):
-    ## __init__ converts all nested dictionaries {} to the Dict
+    # __init__ converts all nested dictionaries {} to the Dict
     def __init__(self, *args, **kwargs):
         if len(kwargs) > 0:
             raise Exception("Dict does not support kwargs")
@@ -61,8 +61,8 @@ class Dict(dict):
 
     def __getattribute__(self, name):
         try:
-            return self[name]
-        except Exception as e:
+            return Dict(self[name])
+        except Exception:
             return super().__getattribute__(name)
 
 

--- a/hack/images/jinja2/jinja2-cli/jinja2cli/cli.py
+++ b/hack/images/jinja2/jinja2-cli/jinja2cli/cli.py
@@ -9,11 +9,12 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
-import os
-import sys
-from optparse import Option, OptionParser
+import os  # noqa: E402
+import sys  # noqa: E402
+from optparse import Option, OptionParser  # noqa: E402
 
-import jinja2cli.capact as capact
+
+import jinja2cli.capact as capact  # noqa: E402
 
 sys.path.insert(0, os.getcwd())
 
@@ -23,8 +24,8 @@ if PY3:
     text_type = str
     bytes_type = bytes
 else:
-    text_type = unicode  # NOQA
-    bytes_type = str  # NOQA
+    text_type = unicode  # noqa: F821
+    bytes_type = str
 
 
 def force_text(data):
@@ -252,7 +253,7 @@ def render(template_path, data, extensions, filters=None, strict=False):
     return env.get_template(os.path.basename(template_path)).render(capact.Dict(data))
 
 
-def cli(opts, args, config):
+def cli(opts, args, config):  # noqa: C901
     template_path, *data_files = args
     format = opts.format
     parsed_data = {}

--- a/hack/images/jinja2/jinja2-cli/tests/test_jinja2cli.py
+++ b/hack/images/jinja2/jinja2-cli/tests/test_jinja2cli.py
@@ -69,6 +69,12 @@ render_testcases = [
         data={},
         result='<@ input["foo.bar"] @>',
     ),
+    TestCase(
+        name="use default value",
+        template='<@ input["foo.bar"] | default("hello") @>',
+        data={},
+        result="hello",
+    ),
 ]
 
 

--- a/internal/cli/alpha/manifestgen/helm.go
+++ b/internal/cli/alpha/manifestgen/helm.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/alecthomas/jsonschema"
@@ -206,7 +205,6 @@ func buildValueKeyPathForJinja(keys []string) string {
 	for _, key := range keys[1:] {
 		if strings.ContainsRune(key, '.') {
 			newAcc := acc + fmt.Sprintf(`["%s"]`, key)
-			fmt.Fprintf(os.Stderr, "WARNING: Helm chart values key contains a dot, so we fallback to square brackets in \"%s\". You have to manually check, if %s is not undefined using \"<%% if %s -%%>...<%%- endif %%>\"!\n", newAcc, acc, acc)
 			acc = newAcc
 		} else {
 			acc += fmt.Sprintf(".%s", key)


### PR DESCRIPTION
## Description

* solves problem nr 2 from https://github.com/capactio/capact/pull/447
* add unittests
* complete features list
* enable running python tests on CI

## Related issue(s)

#417 #467