### PR TITLE
Support multiple input parameters

### DIFF
--- a/internal/cli/action/converter.go
+++ b/internal/cli/action/converter.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"encoding/json"
+
 	gqlengine "capact.io/capact/pkg/engine/api/graphql"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 )
@@ -14,10 +16,11 @@ func convertTypeInstancesRefsToGQL(refs []types.InputTypeInstanceRef) []*gqlengi
 	return out
 }
 
-func convertParametersToGQL(parameters string) *gqlengine.JSON {
-	if parameters == "" {
+func convertParametersToGQL(parameters json.RawMessage) *gqlengine.JSON {
+	if parameters == nil {
 		return nil
 	}
-	out := gqlengine.JSON(parameters)
+
+	out := gqlengine.JSON(string(parameters))
 	return &out
 }

--- a/internal/cli/upgrade/upgrade.go
+++ b/internal/cli/upgrade/upgrade.go
@@ -28,6 +28,8 @@ const (
 	capactTypeRefPath          = "cap.type.capactio.capact.config"
 	helmReleaseTypeRefPath     = "cap.type.helm.chart.release"
 
+	actionParametersKey = "input-parameters"
+
 	randomSuffixLength = 5
 	pollInterval       = time.Second
 )
@@ -375,7 +377,7 @@ func mapToInputTypeInstances(capactCfg gqllocalapi.TypeInstance) ([]*gqlengine.I
 
 func mapToInputParameters(params capact.InputParameters) (gqlengine.JSON, error) {
 	parameters := map[string]interface{}{
-		"input-parameters": params,
+		actionParametersKey: params,
 	}
 
 	marshalled, err := json.Marshal(parameters)

--- a/internal/cli/upgrade/upgrade.go
+++ b/internal/cli/upgrade/upgrade.go
@@ -374,7 +374,11 @@ func mapToInputTypeInstances(capactCfg gqllocalapi.TypeInstance) ([]*gqlengine.I
 }
 
 func mapToInputParameters(params capact.InputParameters) (gqlengine.JSON, error) {
-	marshalled, err := json.Marshal(params)
+	parameters := map[string]interface{}{
+		"input-parameters": params,
+	}
+
+	marshalled, err := json.Marshal(parameters)
 	if err != nil {
 		return "", err
 	}

--- a/internal/k8s-engine/controller/action_controller_test.go
+++ b/internal/k8s-engine/controller/action_controller_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	graphqldomain "capact.io/capact/internal/k8s-engine/graphql/domain/action"
 	corev1alpha1 "capact.io/capact/pkg/engine/k8s/api/v1alpha1"
 )
 
@@ -76,7 +75,7 @@ var _ = Describe("Action Controller", func() {
 					Namespace: key.Namespace,
 				},
 				StringData: map[string]string{
-					graphqldomain.ParametersSecretDataKey: `{ "message": { "pico": "bello"}}`,
+					"input-parameters": `{ "message": { "pico": "bello"}}`,
 				},
 			}
 

--- a/internal/k8s-engine/controller/action_service.go
+++ b/internal/k8s-engine/controller/action_service.go
@@ -413,14 +413,18 @@ func (a *ActionService) RenderAction(ctx context.Context, action *v1alpha1.Actio
 		return nil, errors.Wrap(err, "while marshaling action to json")
 	}
 
-	parametersBytes, err := json.Marshal(parametersCollection)
-	if err != nil {
-		return nil, errors.Wrap(err, "while marshaling user input to json")
+	status := &v1alpha1.RenderingStatus{}
+
+	if parametersCollection != nil {
+		parametersBytes, err := json.Marshal(parametersCollection)
+		if err != nil {
+			return nil, errors.Wrap(err, "while marshaling user input to json")
+		}
+
+		status.SetInputParameters(parametersBytes)
 	}
 
-	status := &v1alpha1.RenderingStatus{}
 	status.SetAction(actionBytes)
-	status.SetInputParameters(parametersBytes)
 	status.SetTypeInstancesToLock(renderOutput.TypeInstancesToLock)
 	status.SetActionPolicy(actionPolicyData)
 

--- a/internal/k8s-engine/graphql/domain/action/converter.go
+++ b/internal/k8s-engine/graphql/domain/action/converter.go
@@ -2,13 +2,14 @@ package action
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
+	"strings"
 
 	"capact.io/capact/internal/k8s-engine/graphql/model"
 	"capact.io/capact/pkg/engine/api/graphql"
 	"capact.io/capact/pkg/engine/k8s/api/v1alpha1"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
-	"capact.io/capact/pkg/sdk/renderer/argo"
 	"github.com/pkg/errors"
 	authv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
@@ -17,6 +18,8 @@ import (
 )
 
 const (
+	// ParameterDataKeyPrefix prefixes every user input parameter key in the Secret data
+	ParameterDataKeyPrefix = "parameter-"
 	// ActionPolicySecretDataKey defines key name for Action Policy.
 	ActionPolicySecretDataKey = "action-policy.json"
 	// LatestRevision defines keyword to indicate latest revision.
@@ -24,6 +27,22 @@ const (
 
 	secretKind = "Secret"
 )
+
+// GetParameterDataKey returns the parameter data key in the Secret resource
+func GetParameterDataKey(parameterName string) string {
+	return fmt.Sprintf("%s%s", ParameterDataKeyPrefix, parameterName)
+}
+
+// IsParameterDataKey returns two values given a Secret data key:
+// First value - bool indicating, if the key represents an user input parameter
+// Second value - name of the user input parameter
+func IsParameterDataKey(key string) (bool, string) {
+	if !strings.HasPrefix(key, ParameterDataKeyPrefix) {
+		return false, ""
+	}
+
+	return true, strings.TrimPrefix(key, ParameterDataKeyPrefix)
+}
 
 // Converter provides functionality to convert GraphQL DTO to models.
 type Converter struct{}
@@ -191,12 +210,12 @@ func (c *Converter) inputParamsFromGraphQL(in *graphql.ActionInputData, name str
 	}
 
 	var (
-		data types.ParametersCollection = types.ParametersCollection{}
+		data = make(map[string]string)
 		err  error
 	)
 
 	if in.Parameters != nil {
-		data, err = argo.ToParametersCollection(json.RawMessage(*in.Parameters))
+		data, err = toParametersData(json.RawMessage(*in.Parameters))
 		if err != nil {
 			return nil, errors.Wrap(err, "while getting parameters collection")
 		}
@@ -221,6 +240,32 @@ func (c *Converter) inputParamsFromGraphQL(in *graphql.ActionInputData, name str
 		},
 		StringData: data,
 	}, nil
+}
+
+func toParametersData(parameters json.RawMessage) (map[string]string, error) {
+	if parameters == nil {
+		return nil, nil
+	}
+
+	parametersMap := make(map[string]interface{})
+	if err := json.Unmarshal(parameters, &parametersMap); err != nil {
+		return make(map[string]string), err
+	}
+
+	result := make(map[string]string)
+
+	for name := range parametersMap {
+		value := parametersMap[name]
+		valueData, err := json.Marshal(&value)
+		if err != nil {
+			return types.ParametersCollection{}, errors.Wrapf(err, "while marshaling %s parameter to JSON", name)
+		}
+
+		key := GetParameterDataKey(name)
+		result[key] = string(valueData)
+	}
+
+	return result, nil
 }
 
 func (c *Converter) actionInputToGraphQL(in *v1alpha1.ResolvedActionInput) (*graphql.ActionInput, error) {

--- a/internal/k8s-engine/graphql/domain/action/fixtures_test.go
+++ b/internal/k8s-engine/graphql/domain/action/fixtures_test.go
@@ -454,7 +454,7 @@ func fixModelInputSecret(name string, paramsEnabled, policyEnabled bool) *corev1
 	}
 
 	if paramsEnabled {
-		sec.StringData["input-parameters"] = `{"param":"one"}`
+		sec.StringData["parameter-input-parameters"] = `{"param":"one"}`
 	}
 	if policyEnabled {
 		sec.StringData["action-policy.json"] = `{"rules":[{"interface":{"path":"cap.interface.dummy","revision":null},"oneOf":[{"implementationConstraints":{"requires":null,"attributes":null,"path":"cap.implementation.dummy"},"inject":{"requiredTypeInstances":[{"id":"policy-ti-id","description":"Sample description"}],"additionalParameters":[{"name":"additional-parameters","value":{"snapshot":true}}],"additionalTypeInstances":[{"name":"additional-ti","id":"additional-ti-id"}]}}]}]}`

--- a/internal/k8s-engine/graphql/domain/action/fixtures_test.go
+++ b/internal/k8s-engine/graphql/domain/action/fixtures_test.go
@@ -372,7 +372,7 @@ func fixGQLInputActionPolicy() *graphql.PolicyInput {
 }
 
 func fixGQLInputParameters() *graphql.JSON {
-	params := graphql.JSON(`{"param":"one"}`)
+	params := graphql.JSON(`{"input-parameters":{"param":"one"}}`)
 	return &params
 }
 
@@ -454,7 +454,7 @@ func fixModelInputSecret(name string, paramsEnabled, policyEnabled bool) *corev1
 	}
 
 	if paramsEnabled {
-		sec.StringData["parameters.json"] = `{"param":"one"}`
+		sec.StringData["input-parameters"] = `{"param":"one"}`
 	}
 	if policyEnabled {
 		sec.StringData["action-policy.json"] = `{"rules":[{"interface":{"path":"cap.interface.dummy","revision":null},"oneOf":[{"implementationConstraints":{"requires":null,"attributes":null,"path":"cap.implementation.dummy"},"inject":{"requiredTypeInstances":[{"id":"policy-ti-id","description":"Sample description"}],"additionalParameters":[{"name":"additional-parameters","value":{"snapshot":true}}],"additionalTypeInstances":[{"name":"additional-ti","id":"additional-ti-id"}]}}]}]}`

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"capact.io/capact/internal/ctxutil"
+	"capact.io/capact/internal/k8s-engine/graphql/domain/action"
 
 	"capact.io/capact/internal/ptr"
 	hubpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
@@ -805,7 +806,7 @@ func (r *dedicatedRenderer) addUserInputFromSecret(rootWorkflow *Workflow, param
 						SecretName: r.inputParametersSecretRef.Name,
 						Items: []apiv1.KeyToPath{
 							{
-								Key:  parameterName,
+								Key:  action.GetParameterDataKey(parameterName),
 								Path: parameterName,
 							},
 						},

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"capact.io/capact/internal/ctxutil"
 
@@ -461,7 +462,16 @@ func (r *dedicatedRenderer) AddUserInputSecretRefIfProvided(rootWorkflow *Workfl
 		return err
 	}
 
-	for paramName := range inputParametersMap {
+	// To ensure fixed order of steps in rendered workflow,
+	// we have to iterate over the paramNames in a deterministic order.
+	// In other case tests would fail sometimes.
+	paramNames := make([]string, 0, len(inputParametersMap))
+	for name := range inputParametersMap {
+		paramNames = append(paramNames, name)
+	}
+	sort.Strings(paramNames)
+
+	for _, paramName := range paramNames {
 		r.addUserInputFromSecret(rootWorkflow, paramName)
 	}
 

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -27,7 +27,7 @@ type dedicatedRenderer struct {
 
 	// set with options
 	inputParametersSecretRef *UserInputSecretRef
-	inputParametersRaw       string
+	inputParametersRaw       json.RawMessage
 	inputTypeInstances       []types.InputTypeInstanceRef
 	ownerID                  *string
 

--- a/pkg/sdk/renderer/argo/helpers.go
+++ b/pkg/sdk/renderer/argo/helpers.go
@@ -163,14 +163,14 @@ func addPrefix(prefix, s string) string {
 	return fmt.Sprintf("%s-%s", prefix, s)
 }
 
-// ToInputParams maps a single parameters into an array which has this one parameter with
+// ToParametersCollection maps a single parameters into an array which has this one parameter with
 // a hardcoded name.
 // Accepts only string, for all other types returns nil response.
 // Empty interface is used only to simplify usage.
 //
 // It's a known bug that we accept only one input parameter for render process
 // but we allow to specify multiple in Hub manifests definition
-func ToInputParams(parameters json.RawMessage) (types.ParametersCollection, error) {
+func ToParametersCollection(parameters json.RawMessage) (types.ParametersCollection, error) {
 	if parameters == nil {
 		return nil, nil
 	}
@@ -186,7 +186,7 @@ func ToInputParams(parameters json.RawMessage) (types.ParametersCollection, erro
 		value := parametersMap[name]
 		valueData, err := json.Marshal(&value)
 		if err != nil {
-			return types.ParametersCollection{}, err
+			return types.ParametersCollection{}, errors.Wrapf(err, "while marshaling %s parameter to JSON", name)
 		}
 
 		result[name] = string(valueData)

--- a/pkg/sdk/renderer/argo/options.go
+++ b/pkg/sdk/renderer/argo/options.go
@@ -1,8 +1,6 @@
 package argo
 
 import (
-	"encoding/json"
-
 	"capact.io/capact/pkg/engine/k8s/policy"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 )
@@ -18,10 +16,10 @@ func WithTypeInstances(typeInstances []types.InputTypeInstanceRef) RendererOptio
 }
 
 // WithSecretUserInput returns a RendererOption, which adds user input to the workflow.
-func WithSecretUserInput(ref *UserInputSecretRef, inputRaw json.RawMessage) RendererOption {
+func WithSecretUserInput(ref *UserInputSecretRef, parameters types.ParametersCollection) RendererOption {
 	return func(r *dedicatedRenderer) {
 		r.inputParametersSecretRef = ref
-		r.inputParametersRaw = inputRaw
+		r.inputParametersCollection = parameters
 	}
 }
 

--- a/pkg/sdk/renderer/argo/options.go
+++ b/pkg/sdk/renderer/argo/options.go
@@ -1,6 +1,8 @@
 package argo
 
 import (
+	"encoding/json"
+
 	"capact.io/capact/pkg/engine/k8s/policy"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 )
@@ -16,10 +18,10 @@ func WithTypeInstances(typeInstances []types.InputTypeInstanceRef) RendererOptio
 }
 
 // WithSecretUserInput returns a RendererOption, which adds user input to the workflow.
-func WithSecretUserInput(ref *UserInputSecretRef, inputRaw []byte) RendererOption {
+func WithSecretUserInput(ref *UserInputSecretRef, inputRaw json.RawMessage) RendererOption {
 	return func(r *dedicatedRenderer) {
 		r.inputParametersSecretRef = ref
-		r.inputParametersRaw = string(inputRaw)
+		r.inputParametersRaw = inputRaw
 	}
 }
 

--- a/pkg/sdk/renderer/argo/renderer.go
+++ b/pkg/sdk/renderer/argo/renderer.go
@@ -119,7 +119,9 @@ func (r *Renderer) Render(ctx context.Context, input *RenderInput) (*RenderOutpu
 	rootWorkflow, entrypointStep := dedicatedRenderer.WrapEntrypointWithRootStep(rootWorkflow)
 
 	// 4. Add user input
-	dedicatedRenderer.AddUserInputSecretRefIfProvided(rootWorkflow)
+	if err := dedicatedRenderer.AddUserInputSecretRefIfProvided(rootWorkflow); err != nil {
+		return nil, errors.Wrap(err, "while adding user input parameters to workflow")
+	}
 
 	// 5. List data based on policy and inject them if provided
 	// 5.1 Required TypeInstances

--- a/pkg/sdk/renderer/argo/renderer.go
+++ b/pkg/sdk/renderer/argo/renderer.go
@@ -148,11 +148,16 @@ func (r *Renderer) Render(ctx context.Context, input *RenderInput) (*RenderOutpu
 	}
 	dedicatedRenderer.InjectAdditionalInput(entrypointStep, additionalParameters)
 
+	parameters, err := ToInputParams(dedicatedRenderer.inputParametersRaw)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting parameters collection")
+	}
+
 	// 6. Validate workflow input against Interface:
 	// Implementation-specific input is already validated on PolicyEnforcedClient level
 	validateInput := renderer.InterfaceInput{
 		Interface:     iface,
-		Parameters:    ToInputParams(dedicatedRenderer.inputParametersRaw),
+		Parameters:    parameters,
 		TypeInstances: dedicatedRenderer.inputTypeInstances,
 	}
 	err = r.wfValidator.ValidateInterfaceInput(ctx, validateInput)

--- a/pkg/sdk/renderer/argo/renderer.go
+++ b/pkg/sdk/renderer/argo/renderer.go
@@ -150,13 +150,12 @@ func (r *Renderer) Render(ctx context.Context, input *RenderInput) (*RenderOutpu
 	}
 	dedicatedRenderer.InjectAdditionalInput(entrypointStep, additionalParameters)
 
-	// 6. Validate given input:
+	// 6. Validate workflow input against Interface:
 	parameters, err := ToParametersCollection(dedicatedRenderer.inputParametersRaw)
 	if err != nil {
 		return nil, errors.Wrap(err, "while getting parameters collection")
 	}
 
-	// 6. Validate workflow input against Interface:
 	// Implementation-specific input is already validated on PolicyEnforcedClient level
 	validateInput := renderer.InterfaceInput{
 		Interface:     iface,

--- a/pkg/sdk/renderer/argo/renderer.go
+++ b/pkg/sdk/renderer/argo/renderer.go
@@ -151,15 +151,10 @@ func (r *Renderer) Render(ctx context.Context, input *RenderInput) (*RenderOutpu
 	dedicatedRenderer.InjectAdditionalInput(entrypointStep, additionalParameters)
 
 	// 6. Validate workflow input against Interface:
-	parameters, err := ToParametersCollection(dedicatedRenderer.inputParametersRaw)
-	if err != nil {
-		return nil, errors.Wrap(err, "while getting parameters collection")
-	}
-
 	// Implementation-specific input is already validated on PolicyEnforcedClient level
 	validateInput := renderer.InterfaceInput{
 		Interface:     iface,
-		Parameters:    parameters,
+		Parameters:    dedicatedRenderer.inputParametersCollection,
 		TypeInstances: dedicatedRenderer.inputTypeInstances,
 	}
 	err = r.wfValidator.ValidateInterfaceInput(ctx, validateInput)

--- a/pkg/sdk/renderer/argo/renderer.go
+++ b/pkg/sdk/renderer/argo/renderer.go
@@ -150,7 +150,8 @@ func (r *Renderer) Render(ctx context.Context, input *RenderInput) (*RenderOutpu
 	}
 	dedicatedRenderer.InjectAdditionalInput(entrypointStep, additionalParameters)
 
-	parameters, err := ToInputParams(dedicatedRenderer.inputParametersRaw)
+	// 6. Validate given input:
+	parameters, err := ToParametersCollection(dedicatedRenderer.inputParametersRaw)
 	if err != nil {
 		return nil, errors.Wrap(err, "while getting parameters collection")
 	}

--- a/pkg/sdk/renderer/argo/renderer_test.go
+++ b/pkg/sdk/renderer/argo/renderer_test.go
@@ -130,6 +130,16 @@ func TestRenderHappyPath(t *testing.T) {
 			},
 			typeInstancesToLock: []string{"6fc7dd6b-d150-4af3-a1aa-a868962b7d68"},
 		},
+		{
+			name: "Workflow with two input parameters",
+			ref: types.InterfaceRef{
+				Path: "cap.interface.multiparam.two",
+			},
+			userParameterCollection: types.ParametersCollection{
+				"input-parameters":  `{"key":true}`,
+				"second-parameters": `{"key":false}`,
+			},
+		},
 	}
 	for _, test := range tests {
 		tt := test

--- a/pkg/sdk/renderer/argo/renderer_test.go
+++ b/pkg/sdk/renderer/argo/renderer_test.go
@@ -68,21 +68,21 @@ func TestRenderHappyPath(t *testing.T) {
 			ref: types.InterfaceRef{
 				Path: "cap.interface.database.postgresql.install",
 			},
-			rawUserInput: []byte(`{"superuser":{"password":"bar"}}`),
+			rawUserInput: []byte(`{"input-parameters":{"superuser":{"password":"bar"}}}`),
 		},
 		{
 			name: "Workflow with apps stack installation with user input",
 			ref: types.InterfaceRef{
 				Path: "cap.interface.app-stack.stack.install",
 			},
-			rawUserInput: []byte(`{"key": true}`),
+			rawUserInput: []byte(`{"input-parameters":{"key": true}}`),
 		},
 		{
 			name: "Mattermost workflow with user input",
 			ref: types.InterfaceRef{
 				Path: "cap.interface.productivity.mattermost.install",
 			},
-			rawUserInput: []byte(`{"host": "mattermost.local"}`),
+			rawUserInput: []byte(`{"input-parameters":{"host": "mattermost.local"}}`),
 		},
 		{
 			name: "PostgreSQL change password",
@@ -99,7 +99,7 @@ func TestRenderHappyPath(t *testing.T) {
 					ID:   "f2421415-b8a4-464b-be12-b617794411c5",
 				},
 			},
-			rawUserInput:        []byte(`{"password": "foo"}`),
+			rawUserInput:        []byte(`{"input-parameters":{"password": "foo"}}`),
 			typeInstancesToLock: []string{"6fc7dd6b-d150-4af3-a1aa-a868962b7d68"},
 		},
 		{
@@ -117,7 +117,7 @@ func TestRenderHappyPath(t *testing.T) {
 					ID:   "f2421415-b8a4-464b-be12-b617794411c5",
 				},
 			},
-			rawUserInput:        []byte(`{"key": true}`),
+			rawUserInput:        []byte(`{"input-parameters":{"key": true}}`),
 			typeInstancesToLock: []string{"6fc7dd6b-d150-4af3-a1aa-a868962b7d68"},
 		},
 	}
@@ -184,7 +184,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 			ref: types.InterfaceRef{
 				Path: "cap.interface.productivity.mattermost.install",
 			},
-			rawUserInput: []byte(`{"host": "mattermost.local"}`),
+			rawUserInput: []byte(`{"input-parameters":{"host": "mattermost.local"}}`),
 			policy:       fixGCPGlobalPolicy(),
 		},
 		{
@@ -192,7 +192,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 			ref: types.InterfaceRef{
 				Path: "cap.interface.productivity.mattermost.install",
 			},
-			rawUserInput: []byte(`{"host": "mattermost.local"}`),
+			rawUserInput: []byte(`{"input-parameters":{"host": "mattermost.local"}}`),
 			policy:       fixExistingDBPolicy(),
 		},
 		{
@@ -201,7 +201,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.database.postgresql.install",
 			},
 			policy:       fixGCPGlobalPolicy(),
-			rawUserInput: []byte(`{"superuser":{"password":"bar"}}`),
+			rawUserInput: []byte(`{"input-parameters":{"superuser":{"password":"bar"}}}`),
 		},
 		{
 			name: "RDS installation with AWS SA and additional parameters injected",
@@ -209,7 +209,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.database.postgresql.install",
 			},
 			policy:       fixAWSRDSPolicy(),
-			rawUserInput: []byte(`{"superuser":{"password":"bar"}}`),
+			rawUserInput: []byte(`{"input-parameters":{"superuser":{"password":"bar"}}}`),
 		},
 		{
 			name: "Mattermost with CloudSQL using Terraform",
@@ -217,7 +217,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.productivity.mattermost.install",
 			},
 			policy:       fixTerraformPolicy(),
-			rawUserInput: []byte(`{"host": "mattermost.local"}`),
+			rawUserInput: []byte(`{"input-parameters":{"host": "mattermost.local"}}`),
 		},
 		{
 			name: "Mattermost with AWS RDS install",
@@ -225,7 +225,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.productivity.mattermost.install",
 			},
 			policy:       fixAWSGlobalPolicy(),
-			rawUserInput: []byte(`{"host": "mattermost.local"}`),
+			rawUserInput: []byte(`{"input-parameters":{"host": "mattermost.local"}}`),
 		},
 		{
 			name: "Unmet policy constraints - fallback to Bitnami Implementation",
@@ -233,7 +233,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.database.postgresql.install",
 			},
 			policy:       fixGlobalPolicyForFallback(),
-			rawUserInput: []byte(`{"superuser":{"password":"bar"}}`),
+			rawUserInput: []byte(`{"input-parameters":{"superuser":{"password":"bar"}}}`),
 		},
 		{
 			name: "Workflow policy injects additional input - reference by ManifestRef",
@@ -241,7 +241,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.app-stack.app1.install",
 			},
 			policy:       fixAWSGlobalPolicy(),
-			rawUserInput: []byte(`{"key": "string"}`),
+			rawUserInput: []byte(`{"input-parameters":{"key": "string"}}`),
 		},
 		{
 			name: "Workflow policy injects additional input - reference by alias",
@@ -249,7 +249,7 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 				Path: "cap.interface.app-stack.app2.install",
 			},
 			policy:       fixAWSGlobalPolicy(),
-			rawUserInput: []byte(`{"key": "string"}`),
+			rawUserInput: []byte(`{"input-parameters":{"key": "string"}}`),
 		},
 	}
 	for testIdx, test := range tests {

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
@@ -1089,11 +1089,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: mattermost-install
@@ -1176,23 +1176,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
@@ -1197,7 +1197,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Mattermost_workflow_with_user_input.golden.yaml
@@ -1176,12 +1176,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1193,13 +1192,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
@@ -251,7 +251,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
@@ -230,12 +230,11 @@ args:
           template: upload-update-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -247,13 +246,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Nested_PostgreSQL_change_password.golden.yaml
@@ -202,11 +202,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
             - from: '{{workflow.outputs.artifacts.firstRole}}'
               name: firstRole
@@ -230,23 +230,24 @@ args:
           template: upload-update-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
@@ -232,7 +232,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
@@ -211,12 +211,11 @@ args:
           template: upload-update-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -228,13 +227,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_change_password.golden.yaml
@@ -183,11 +183,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
             - from: '{{workflow.outputs.artifacts.role}}'
               name: role
@@ -211,23 +211,24 @@ args:
           template: upload-update-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
@@ -163,11 +163,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: postgres-install
@@ -202,23 +202,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
@@ -223,7 +223,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/PostgreSQL_workflow_with_user_input_and_without_TypeInstances.golden.yaml
@@ -202,12 +202,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -219,13 +218,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
@@ -1175,7 +1175,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
@@ -1154,12 +1154,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1171,13 +1170,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_apps_stack_installation_with_user_input.golden.yaml
@@ -1049,11 +1049,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: stack-install
@@ -1154,23 +1154,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_two_input_parameters.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_two_input_parameters.golden.yaml
@@ -1,0 +1,121 @@
+args:
+  workflow:
+    arguments: {}
+    entrypoint: capact-root
+    templates:
+    - inputs:
+        artifacts:
+        - name: input-parameters
+        - name: second-parameters
+          optional: true
+      metadata: {}
+      name: main
+      outputs: {}
+    - inputs: {}
+      metadata: {}
+      name: capact-root
+      outputs: {}
+      steps:
+      - - arguments: {}
+          name: inject-runner-context-step
+          template: inject-runner-context
+      - - arguments: {}
+          name: populate-second-parameters-step
+          template: populate-second-parameters
+      - - arguments: {}
+          name: populate-input-parameters-step
+          template: populate-input-parameters
+      - - arguments:
+            artifacts:
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
+              name: input-parameters
+            - from: '{{steps.populate-second-parameters-step.outputs.artifacts.second-parameters}}'
+              name: second-parameters
+          name: start-entrypoint
+          template: main
+    - container:
+        args:
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
+        command:
+        - sh
+        - -c
+        image: ghcr.io/capactio/infra/jq:1.6
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /input
+          name: user-secret-volume
+      inputs: {}
+      metadata: {}
+      name: populate-input-parameters
+      outputs:
+        artifacts:
+        - name: input-parameters
+          path: /output
+      volumes:
+      - name: user-secret-volume
+        secret:
+          items:
+          - key: parameters.json
+            path: parameters.json
+          optional: false
+          secretName: user-input
+    - container:
+        args:
+        - cat "/input/parameters.json" | jq -r '."second-parameters"' | tee "/output"
+          && sleep 1
+        command:
+        - sh
+        - -c
+        image: ghcr.io/capactio/infra/jq:1.6
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /input
+          name: user-secret-volume
+      inputs: {}
+      metadata: {}
+      name: populate-second-parameters
+      outputs:
+        artifacts:
+        - name: second-parameters
+          path: /output
+      volumes:
+      - name: user-secret-volume
+        secret:
+          items:
+          - key: parameters.json
+            path: parameters.json
+          optional: false
+          secretName: user-input
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /input
+          name: runner-context
+          readOnly: true
+      inputs: {}
+      metadata: {}
+      name: inject-runner-context
+      outputs:
+        artifacts:
+        - globalName: runner-context
+          name: runner-context
+          path: /input/context.yaml
+      volumes:
+      - name: runner-context
+        secret:
+          items:
+          - key: key
+            path: context.yaml
+          optional: false
+          secretName: secret
+runnerInterface: cap.interface.runner.argo.run

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_two_input_parameters.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPath/Workflow_with_two_input_parameters.golden.yaml
@@ -35,12 +35,11 @@ args:
           template: main
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -52,23 +51,22 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: parameter-input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."second-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -80,13 +78,13 @@ args:
       outputs:
         artifacts:
         - name: second-parameters
-          path: /output
+          path: /input/second-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: parameter-second-parameters
+            path: second-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -216,12 +216,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -233,13 +232,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -237,7 +237,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -177,11 +177,11 @@ args:
           name: inject-input-type-instances-2-0-step
           template: inject-input-type-instances-2-0
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: postgres-install
@@ -216,23 +216,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -1506,12 +1506,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1523,13 +1522,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -1397,11 +1397,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: mattermost-install
@@ -1506,23 +1506,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -1527,7 +1527,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -1207,12 +1207,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1224,13 +1223,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -1228,7 +1228,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -1120,11 +1120,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: mattermost-install
@@ -1207,23 +1207,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
@@ -1181,11 +1181,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: mattermost-install
@@ -1279,23 +1279,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
@@ -1279,12 +1279,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1296,13 +1295,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
@@ -1300,7 +1300,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
@@ -959,11 +959,11 @@ args:
           name: inject-input-type-instances-1-0-step
           template: inject-input-type-instances-1-0
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
             - from: '{{workflow.outputs.artifacts.postgresql}}'
               name: postgresql
@@ -1028,23 +1028,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
@@ -1028,12 +1028,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -1045,13 +1044,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
@@ -1049,7 +1049,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
@@ -454,11 +454,11 @@ args:
           name: inject-input-type-instances-3-0-step
           template: inject-input-type-instances-3-0
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
             - name: additional-parameters
               raw:
@@ -519,23 +519,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
@@ -540,7 +540,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
@@ -519,12 +519,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -536,13 +535,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
@@ -163,11 +163,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: postgres-install
@@ -202,23 +202,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
@@ -223,7 +223,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Unmet_policy_constraints_-_fallback_to_Bitnami_Implementation.golden.yaml
@@ -202,12 +202,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -219,13 +218,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -954,7 +954,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -839,11 +839,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: app1-install
@@ -933,23 +933,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -933,12 +933,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -950,13 +949,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -839,11 +839,11 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: populate-user-input-step
-          template: populate-user-input
+          name: populate-input-parameters-step
+          template: populate-input-parameters
       - - arguments:
             artifacts:
-            - from: '{{steps.populate-user-input-step.outputs.artifacts.input-parameters}}'
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
               name: input-parameters
           name: start-entrypoint
           template: main
@@ -933,23 +933,24 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - sleep 1
+        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
+          && sleep 1
         command:
         - sh
         - -c
-        image: alpine:3.7
+        image: ghcr.io/capactio/infra/jq:1.6
         name: ""
         resources: {}
         volumeMounts:
-        - mountPath: /output
+        - mountPath: /input
           name: user-secret-volume
       inputs: {}
       metadata: {}
-      name: populate-user-input
+      name: populate-input-parameters
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output/parameters.json
+          path: /output
       volumes:
       - name: user-secret-volume
         secret:

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -954,7 +954,7 @@ args:
       - name: user-secret-volume
         secret:
           items:
-          - key: input-parameters
+          - key: parameter-input-parameters
             path: input-parameters
           optional: false
           secretName: user-input

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -933,12 +933,11 @@ args:
           template: upload-output-type-instances
     - container:
         args:
-        - cat "/input/parameters.json" | jq -r '."input-parameters"' | tee "/output"
-          && sleep 1
+        - sleep 1
         command:
         - sh
         - -c
-        image: ghcr.io/capactio/infra/jq:1.6
+        image: alpine:3.7
         name: ""
         resources: {}
         volumeMounts:
@@ -950,13 +949,13 @@ args:
       outputs:
         artifacts:
         - name: input-parameters
-          path: /output
+          path: /input/input-parameters
       volumes:
       - name: user-secret-volume
         secret:
           items:
-          - key: parameters.json
-            path: parameters.json
+          - key: input-parameters
+            path: input-parameters
           optional: false
           secretName: user-input
     - container:

--- a/pkg/sdk/renderer/argo/testdata/hub/implementation/multiparam/two.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/implementation/multiparam/two.yaml
@@ -1,0 +1,52 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: cap.implementation.multiparam
+  name: two
+  license:
+    name: "Apache 2.0"
+  displayName: ""
+  description: ""
+  documentationURL: ""
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  appVersion: "1.x.x"
+
+  implements:
+    - path: cap.interface.multiparam.two
+      revision: 0.1.0
+
+  requires:
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.core.type.platform.kubernetes
+            revision: 0.1.0
+          valueConstraints:
+      prefix: cap.core.type.platform
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: main
+        templates:
+          - name: main
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: second-parameters
+                  optional: true
+            steps: []

--- a/pkg/sdk/renderer/argo/testdata/hub/interface/multiparam/two.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/interface/multiparam/two.yaml
@@ -19,30 +19,28 @@ spec:
   input:
     parameters:
       - name: input-parameters
-        jsonSchema:
-          value: |-
-            {
-              "$schema": "http://json-schema.org/draft-07/schema",
-              "type": "object",
-              "properties": {
-                "key": {
-                  "type":"string"
-                }
-              },
-              "required": ["key"]
-            }
+        jsonSchema: |-
+          {
+            "$schema": "http://json-schema.org/draft-07/schema",
+            "type": "object",
+            "properties": {
+              "key": {
+                "type":"boolean"
+              }
+            },
+            "required": ["key"]
+          }
 
       - name: second-parameters
-        jsonSchema:
-          value: |-
-            {
-              "$schema": "http://json-schema.org/draft-07/schema",
-              "type": "object",
-              "properties": {
-                "key": {
-                  "type":"string" 
-                }
+        jsonSchema: |-
+          {
+            "$schema": "http://json-schema.org/draft-07/schema",
+            "type": "object",
+            "properties": {
+              "key": {
+                "type":"boolean" 
               }
             }
+          }
   output:
     typeInstances: []

--- a/pkg/sdk/renderer/argo/testdata/hub/interface/multiparam/two.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/interface/multiparam/two.yaml
@@ -1,0 +1,48 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Interface
+metadata:
+  prefix: cap.interface.multiparam
+  name: two
+  path: cap.interface.multiparam.two
+  displayName: ""
+  description: ""
+  documentationURL: ""
+  supportURL: ""
+  iconURL: ""
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  input:
+    parameters:
+      - name: input-parameters
+        jsonSchema:
+          value: |-
+            {
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type":"string"
+                }
+              },
+              "required": ["key"]
+            }
+
+      - name: second-parameters
+        jsonSchema:
+          value: |-
+            {
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type":"string" 
+                }
+              }
+            }
+  output:
+    typeInstances: []

--- a/pkg/sdk/renderer/argo/types.go
+++ b/pkg/sdk/renderer/argo/types.go
@@ -57,7 +57,6 @@ type RunnerContextSecretRef struct {
 // in a Kubernetes Secret resource.
 type UserInputSecretRef struct {
 	Name string
-	Key  string
 }
 
 // RenderInput holds the input parameters to the Render method.

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -229,10 +229,14 @@ var _ = Describe("Action", func() {
 			}, cfg.PollingTimeout, cfg.PollingInterval).Should(BeNil())
 		},
 			Entry("Passing action", map[string]interface{}{
-				"testString": "success",
+				"input-parameters": map[string]interface{}{
+					"testString": "success",
+				},
 			}, enginegraphql.ActionStatusPhaseSucceeded),
 			Entry("Failing action", map[string]interface{}{
-				"testString": "failure",
+				"input-parameters": map[string]interface{}{
+					"testString": "failure",
+				},
 			}, enginegraphql.ActionStatusPhaseFailed),
 		)
 	})


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Allow providing multiple user input parameters through CLI
- Inject multiple input parameters in rendering

## Testing

AFAIK we don't have any Interface with two input parameters. I added a test for this + you can run an existing Action, eg. setup a Bitnami Helm Postgresql using the following input parameters:

```yaml
input-parameters:
  superuser:
    username: damian
    password: sup3rs3cr3t
  defaultDBName: postgres
```

Check also `capact upgrade` on a cluster from this PR and CLI compiled from this PR:
```bash
capact upgrade --action-name-prefix 'capact-upgrade-' --version @latest --helm-repo-url @latest --increase-resource-limits --wait
```


## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

Resolves https://github.com/capactio/capact/issues/468
