### PR TITLE
Add local registry support for k3d environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,11 +62,6 @@ COPY --from=builder /bin/$COMPONENT /app.test
 RUN apk add --no-cache 'git=>2.30' && \
     go install github.com/onsi/ginkgo/ginkgo@latest
 
-LABEL source=git@github.com:capactio/capact.git
-LABEL app=$COMPONENT
-
-CMD ["/go/bin/ginkgo", "-v", "-nodes=1", "/app.test" ]
-
 FROM scratch as e2e
 
 COPY --from=builder /bin/$COMPONENT /app.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ LABEL app=$COMPONENT
 
 CMD ["/app"]
 
-FROM builder as e2e-builder
+FROM builder as e2e
 
 # Copy common CA certificates from Builder image (installed by default with ca-certificates package)
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -62,10 +62,8 @@ COPY --from=builder /bin/$COMPONENT /app.test
 RUN apk add --no-cache 'git=>2.30' && \
     go install github.com/onsi/ginkgo/ginkgo@latest
 
-FROM scratch as e2e
-
-COPY --from=builder /bin/$COMPONENT /app.test
-COPY --from=e2e-builder /go/bin/ginkgo /go/bin/ginkgo
+LABEL source=git@github.com:capactio/capact.git
+LABEL app=$COMPONENT
 
 CMD ["/go/bin/ginkgo", "-v", "-nodes=1", "/app.test" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ LABEL app=$COMPONENT
 
 CMD ["/app"]
 
-FROM builder as e2e
+FROM builder as e2e-builder
 
 # Copy common CA certificates from Builder image (installed by default with ca-certificates package)
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -64,6 +64,13 @@ RUN apk add --no-cache 'git=>2.30' && \
 
 LABEL source=git@github.com:capactio/capact.git
 LABEL app=$COMPONENT
+
+CMD ["/go/bin/ginkgo", "-v", "-nodes=1", "/app.test" ]
+
+FROM scratch as e2e
+
+COPY --from=builder /bin/$COMPONENT /app.test
+COPY --from=e2e-builder /go/bin/ginkgo /go/bin/ginkgo
 
 CMD ["/go/bin/ginkgo", "-v", "-nodes=1", "/app.test" ]
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ export GOPROXY = https://proxy.golang.org
 # enable the BuildKit builder in the Docker CLI.
 export DOCKER_BUILDKIT = 1
 
-export DOCKER_REPOSITORY ?= ghcr.io/capactio
-export DOCKER_TAG ?= latest
+DOCKER_REPOSITORY ?= ghcr.io/capactio
+DOCKER_TAG ?= latest
 
 all: generate build-all-images test-unit test-lint ## Default: generate all, build all, test all and lint
 .PHONY: all

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -25,32 +25,34 @@ func NewK3d() *cobra.Command {
 	k3d.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		spinnerFmt := printer.NewLogrusSpinnerFormatter(fmt.Sprintf("Creating cluster %s...", opts.Name))
 		logrus.SetFormatter(spinnerFmt)
-		return create.K3dSetDefaultConfig(cmd.Flags(), opts)
+
+		if err := create.K3dSetDefaultConfig(cmd.Flags(), opts); err != nil {
+			return err
+		}
+		if !opts.RegistryEnabled {
+			return nil
+		}
+		return create.LocalRegistry(cmd.Context(), os.Stdout)
 	}
 	k3d.RunE = func(cmd *cobra.Command, _ []string) (err error) {
-		if opts.RegistryEnabled {
-			if _, err := create.LocalRegistry(cmd.Context(), cmd.OutOrStdout()); err != nil {
-				return err
-			}
-		}
-
-		k3d.Run(cmd, []string{opts.Name}) // Run k3d create cmd
-
-		if opts.RegistryEnabled {
-			if err := create.RegistryConnWithNetwork(cmd.Context(), create.K3dDockerNetwork); err != nil {
-				return err
-			}
-		}
+		// Run k3d create cmd
+		k3d.Run(cmd, []string{opts.Name})
 
 		if opts.Wait == time.Duration(0) {
 			return nil
 		}
-		ctx, cancel := getTimeoutContext(cmd.Context(), opts.Wait)
+		ctx, cancel := context.WithTimeout(cmd.Context(), opts.Wait)
 		defer cancel()
 		return create.WaitForK3dReadyNodes(ctx, os.Stdout, opts.Name)
 	}
+	k3d.PostRunE = func(cmd *cobra.Command, args []string) error {
+		if !opts.RegistryEnabled {
+			return nil
+		}
+		return create.RegistryConnWithNetwork(cmd.Context(), create.K3dDockerNetwork)
+	}
 
-	create.K3dRemoveWaitAndTimeoutFlags(k3d) // remove it so we use own `--wait` flag
+	create.K3dRemoveWaitAndTimeoutFlags(k3d) // remove it, so we use own `--wait` flag
 
 	// add `name` flag to have the same UX as we have for `kind` in the minimal scenario:
 	//   $ capact env create kind --name capact-dev --wait 10m
@@ -60,11 +62,4 @@ func NewK3d() *cobra.Command {
 	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Creates local registry and configures environment to use it")
 
 	return k3d
-}
-
-func getTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	if timeout.Seconds() == 0 {
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, timeout)
 }

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -28,8 +28,19 @@ func NewK3d() *cobra.Command {
 		return create.K3dSetDefaultConfig(cmd.Flags(), opts)
 	}
 	k3d.RunE = func(cmd *cobra.Command, _ []string) (err error) {
-		// Run k3d create cmd
-		k3d.Run(cmd, []string{opts.Name})
+		if opts.RegistryEnabled {
+			if _, err := create.LocalRegistry(cmd.Context(), cmd.OutOrStdout()); err != nil {
+				return err
+			}
+		}
+
+		k3d.Run(cmd, []string{opts.Name}) // Run k3d create cmd
+
+		if opts.RegistryEnabled {
+			if err := create.RegistryConnWithNetwork(cmd.Context(), create.K3dDockerNetwork); err != nil {
+				return err
+			}
+		}
 
 		if opts.Wait == time.Duration(0) {
 			return nil
@@ -46,7 +57,7 @@ func NewK3d() *cobra.Command {
 	//   $ capact env create k3d  --name capact-dev --wait 10m
 	k3d.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	k3d.Flags().DurationVar(&opts.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready")
-	k3d.Flags().BoolVar(&opts.RegistryEnabled, "registry", false, "Creates local registry and configures environment to use it")
+	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Creates local registry and configures environment to use it")
 
 	return k3d
 }

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -72,7 +72,7 @@ func NewK3d() *cobra.Command {
 	//   $ capact env create k3d  --name capact-dev --wait 10m
 	k3d.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	k3d.Flags().DurationVar(&opts.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready")
-	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Creates local registry and configures environment to use it")
+	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Creates local registry and configures k3d environment to use it")
 
 	return k3d
 }

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -59,10 +59,7 @@ func NewK3d() *cobra.Command {
 			return err
 		}
 
-		if err := capact.AddRegistryToHostsFile(status); err != nil {
-			return err
-		}
-		return nil
+		return capact.AddRegistryToHostsFile(status)
 	}
 
 	create.K3dRemoveWaitAndTimeoutFlags(k3d) // remove it, so we use own `--wait` flag
@@ -72,7 +69,7 @@ func NewK3d() *cobra.Command {
 	//   $ capact env create k3d  --name capact-dev --wait 10m
 	k3d.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	k3d.Flags().DurationVar(&opts.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready")
-	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Create local Docker registry and configures k3d environment to use it")
+	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Create local Docker registry and configure k3d environment to use it")
 
 	return k3d
 }

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -72,7 +72,7 @@ func NewK3d() *cobra.Command {
 	//   $ capact env create k3d  --name capact-dev --wait 10m
 	k3d.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	k3d.Flags().DurationVar(&opts.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready")
-	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Creates local registry and configures k3d environment to use it")
+	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Create local Docker registry and configures k3d environment to use it")
 
 	return k3d
 }

--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -69,7 +69,7 @@ func NewK3d() *cobra.Command {
 	//   $ capact env create k3d  --name capact-dev --wait 10m
 	k3d.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	k3d.Flags().DurationVar(&opts.Wait, "wait", time.Duration(0), "Wait for control plane node to be ready")
-	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Create local Docker registry and configure k3d environment to use it")
+	k3d.Flags().BoolVar(&opts.RegistryEnabled, "enable-registry", false, "Create Capact local Docker registry and configure k3d environment to use it")
 
 	return k3d
 }

--- a/cmd/cli/cmd/environment/delete/k3d.go
+++ b/cmd/cli/cmd/environment/delete/k3d.go
@@ -1,10 +1,11 @@
 package delete
 
 import (
+	"fmt"
+
 	"capact.io/capact/internal/cli/environment/create"
 	"capact.io/capact/internal/cli/environment/delete"
 	"capact.io/capact/internal/cli/printer"
-	"fmt"
 	"github.com/rancher/k3d/v4/cmd/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/cli/cmd/environment/delete/k3d.go
+++ b/cmd/cli/cmd/environment/delete/k3d.go
@@ -1,11 +1,10 @@
 package delete
 
 import (
-	"fmt"
-
 	"capact.io/capact/internal/cli/environment/create"
 	"capact.io/capact/internal/cli/environment/delete"
 	"capact.io/capact/internal/cli/printer"
+	"fmt"
 	"github.com/rancher/k3d/v4/cmd/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,25 +12,28 @@ import (
 
 // NewK3d returns a cobra.Command for creating k3d environment.
 func NewK3d() *cobra.Command {
-	var name string
+	var opts delete.K3dOptions
+
 	cmd := &cobra.Command{
 		Use:   "k3d",
 		Short: "Delete local k3d cluster",
 		Args:  cobra.NoArgs,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			spinnerFmt := printer.NewLogrusSpinnerFormatter(fmt.Sprintf("Deleting cluster %q...", name))
+			spinnerFmt := printer.NewLogrusSpinnerFormatter(fmt.Sprintf("Deleting cluster %q...", opts.Name))
 			logrus.SetFormatter(spinnerFmt)
 		},
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			return delete.K3d(cmd.Context(), name)
+			return delete.K3d(cmd.Context(), opts)
 		},
 	}
 
 	// add `name` flag to have the same UX as we have for `kind` in the minimal scenario:
 	//   $ capact env delete kind --name capact-dev
 	//   $ capact env delete k3d  --name capact-dev
-	cmd.Flags().StringVar(&name, "name", create.DefaultClusterName, "Cluster name")
+	cmd.Flags().StringVar(&opts.Name, "name", create.DefaultClusterName, "Cluster name")
 	_ = cmd.RegisterFlagCompletionFunc("name", util.ValidArgsAvailableClusters)
+
+	cmd.Flags().BoolVar(&opts.RemoveRegistry, "remove-registry", true, "Remove registry")
 
 	return cmd
 }

--- a/cmd/cli/cmd/install.go
+++ b/cmd/cli/cmd/install.go
@@ -35,6 +35,10 @@ func NewInstall() *cobra.Command {
 			# Install Capact from local git repository. Needs to be run from the main directory
 			<cli> install --version @local`, cli.Name),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
 			k8sCfg, err := config.GetConfig()
 			if err != nil {
 				return errors.Wrap(err, "while creating k8s config")

--- a/cmd/cli/cmd/install.go
+++ b/cmd/cli/cmd/install.go
@@ -61,7 +61,7 @@ func NewInstall() *cobra.Command {
 	flags.BoolVar(&opts.UpdateHostsFile, "update-hosts-file", true, "Updates /etc/hosts with entry for Capact GraphQL Gateway.")
 	flags.BoolVar(&opts.UpdateTrustedCerts, "update-trusted-certs", true, "Add Capact GraphQL Gateway certificate.")
 	flags.StringVar(&opts.Parameters.Override.HelmRepoURL, "helm-repo-url", capact.HelmRepoStable, fmt.Sprintf("Capact Helm chart repository URL. Use %s tag to select repository which holds the latest Helm chart versions.", capact.LatestVersionTag))
-	flags.StringVar(&opts.Registry, "registry", "", "If specified, Capact images are pushed to a given registry.")
+	flags.BoolVar(&opts.RegistryEnabled, "enable-registry", false, "If specified, Capact images are pushed to registry.")
 	flags.StringSliceVar(&opts.Parameters.Override.CapactStringOverrides, "capact-overrides", []string{}, "Overrides for Capact component.")
 	flags.StringSliceVar(&opts.Parameters.Override.IngressStringOverrides, "ingress-controller-overrides", []string{}, "Overrides for Ingress controller component.")
 	flags.StringSliceVar(&opts.Parameters.Override.CertManagerStringOverrides, "cert-manager-overrides", []string{}, "Overrides for Cert Manager component.")

--- a/cmd/cli/cmd/install.go
+++ b/cmd/cli/cmd/install.go
@@ -57,6 +57,7 @@ func NewInstall() *cobra.Command {
 	flags.BoolVar(&opts.UpdateHostsFile, "update-hosts-file", true, "Updates /etc/hosts with entry for Capact GraphQL Gateway.")
 	flags.BoolVar(&opts.UpdateTrustedCerts, "update-trusted-certs", true, "Add Capact GraphQL Gateway certificate.")
 	flags.StringVar(&opts.Parameters.Override.HelmRepoURL, "helm-repo-url", capact.HelmRepoStable, fmt.Sprintf("Capact Helm chart repository URL. Use %s tag to select repository which holds the latest Helm chart versions.", capact.LatestVersionTag))
+	flags.StringVar(&opts.Registry, "registry", "", "If specified, Capact images are pushed to a given registry.")
 	flags.StringSliceVar(&opts.Parameters.Override.CapactStringOverrides, "capact-overrides", []string{}, "Overrides for Capact component.")
 	flags.StringSliceVar(&opts.Parameters.Override.IngressStringOverrides, "ingress-controller-overrides", []string{}, "Overrides for Ingress controller component.")
 	flags.StringSliceVar(&opts.Parameters.Override.CertManagerStringOverrides, "cert-manager-overrides", []string{}, "Overrides for Cert Manager component.")

--- a/cmd/cli/cmd/install.go
+++ b/cmd/cli/cmd/install.go
@@ -61,7 +61,7 @@ func NewInstall() *cobra.Command {
 	flags.BoolVar(&opts.UpdateHostsFile, "update-hosts-file", true, "Updates /etc/hosts with entry for Capact GraphQL Gateway.")
 	flags.BoolVar(&opts.UpdateTrustedCerts, "update-trusted-certs", true, "Add Capact GraphQL Gateway certificate.")
 	flags.StringVar(&opts.Parameters.Override.HelmRepoURL, "helm-repo-url", capact.HelmRepoStable, fmt.Sprintf("Capact Helm chart repository URL. Use %s tag to select repository which holds the latest Helm chart versions.", capact.LatestVersionTag))
-	flags.BoolVar(&opts.RegistryEnabled, "enable-registry", false, "If specified, Capact images are pushed to registry.")
+	flags.BoolVar(&opts.LocalRegistryEnabled, "enable-registry", false, "If specified, Capact images are pushed to Capact local Docker registry.")
 	flags.StringSliceVar(&opts.Parameters.Override.CapactStringOverrides, "capact-overrides", []string{}, "Overrides for Capact component.")
 	flags.StringSliceVar(&opts.Parameters.Override.IngressStringOverrides, "ingress-controller-overrides", []string{}, "Overrides for Ingress controller component.")
 	flags.StringSliceVar(&opts.Parameters.Override.CertManagerStringOverrides, "cert-manager-overrides", []string{}, "Overrides for Cert Manager component.")

--- a/cmd/cli/docs/capact_environment_create_k3d.md
+++ b/cmd/cli/docs/capact_environment_create_k3d.md
@@ -27,7 +27,7 @@ capact environment create k3d [flags]
       --agents-memory string                                           Memory limit imposed on the agents nodes [From docker]
       --api-port [HOST:]HOSTPORT                                       Specify the Kubernetes API server port exposed on the LoadBalancer (Format: [HOST:]HOSTPORT)
                                                                         - Example: `k3d cluster create --servers 3 --api-port 0.0.0.0:6550`
-      --enable-registry                                                Create local Docker registry and configures k3d environment to use it
+      --enable-registry                                                Create Capact local Docker registry and configure k3d environment to use it
   -e, --env KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]                   Add environment variables to nodes (Format: KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]
                                                                         - Example: `k3d cluster create --agents 2 -e "HTTP_PROXY=my.proxy.com@server[0]" -e "SOME_KEY=SOME_VAL@server[0]"`
       --gpus string                                                    GPU devices to add to the cluster node containers ('all' to pass all GPUs) [From docker]

--- a/cmd/cli/docs/capact_environment_create_k3d.md
+++ b/cmd/cli/docs/capact_environment_create_k3d.md
@@ -27,6 +27,7 @@ capact environment create k3d [flags]
       --agents-memory string                                           Memory limit imposed on the agents nodes [From docker]
       --api-port [HOST:]HOSTPORT                                       Specify the Kubernetes API server port exposed on the LoadBalancer (Format: [HOST:]HOSTPORT)
                                                                         - Example: `k3d cluster create --servers 3 --api-port 0.0.0.0:6550`
+      --enable-registry                                                Create local Docker registry and configures k3d environment to use it
   -e, --env KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]                   Add environment variables to nodes (Format: KEY[=VALUE][@NODEFILTER[;NODEFILTER...]]
                                                                         - Example: `k3d cluster create --agents 2 -e "HTTP_PROXY=my.proxy.com@server[0]" -e "SOME_KEY=SOME_VAL@server[0]"`
       --gpus string                                                    GPU devices to add to the cluster node containers ('all' to pass all GPUs) [From docker]

--- a/cmd/cli/docs/capact_environment_delete_k3d.md
+++ b/cmd/cli/docs/capact_environment_delete_k3d.md
@@ -13,8 +13,9 @@ capact environment delete k3d [flags]
 ### Options
 
 ```
-  -h, --help          help for k3d
-      --name string   Cluster name (default "dev-capact")
+  -h, --help              help for k3d
+      --name string       Cluster name (default "dev-capact")
+      --remove-registry   Remove registry (default true)
 ```
 
 ### Options inherited from parent commands

--- a/cmd/cli/docs/capact_install.md
+++ b/cmd/cli/docs/capact_install.md
@@ -33,6 +33,7 @@ capact install --version @local
       --build-image strings                    Local images names that should be build when using @local version. Takes comma-separated list. (default [argo-actions,argo-runner,e2e-test,gateway,hub-js,k8s-engine,populator])
       --capact-overrides strings               Overrides for Capact component.
       --cert-manager-overrides strings         Overrides for Cert Manager component.
+      --enable-registry                        If specified, Capact images are pushed to registry.
       --environment string                     Capact environment. (default "kind")
       --helm-repo-url string                   Capact Helm chart repository URL. Use @latest tag to select repository which holds the latest Helm chart versions. (default "https://storage.googleapis.com/capactio-stable-charts")
   -h, --help                                   help for install

--- a/cmd/cli/docs/capact_install.md
+++ b/cmd/cli/docs/capact_install.md
@@ -33,7 +33,7 @@ capact install --version @local
       --build-image strings                    Local images names that should be build when using @local version. Takes comma-separated list. (default [argo-actions,argo-runner,e2e-test,gateway,hub-js,k8s-engine,populator])
       --capact-overrides strings               Overrides for Capact component.
       --cert-manager-overrides strings         Overrides for Cert Manager component.
-      --enable-registry                        If specified, Capact images are pushed to registry.
+      --enable-registry                        If specified, Capact images are pushed to Capact local Docker registry.
       --environment string                     Capact environment. (default "kind")
       --helm-repo-url string                   Capact Helm chart repository URL. Use @latest tag to select repository which holds the latest Helm chart versions. (default "https://storage.googleapis.com/capactio-stable-charts")
   -h, --help                                   help for install

--- a/deploy/kubernetes/charts/neo4j/values.yaml
+++ b/deploy/kubernetes/charts/neo4j/values.yaml
@@ -8,5 +8,22 @@ neo4j:
       limits:
         cpu: 400m
         memory: 2048Mi
-  imageTag: 4.2.8
+  image: mszostok/neo4j
+  imageTag: 4.2.8-apoc
   neo4jPassword: okon
+  readinessProbe:
+    initialDelaySeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 3
+    periodSeconds: 10
+    tcpSocket:
+      port: 7687
+
+  livenessProbe:
+    initialDelaySeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 3
+    periodSeconds: 10
+    tcpSocket:
+      port: 7687
+

--- a/deploy/kubernetes/charts/neo4j/values.yaml
+++ b/deploy/kubernetes/charts/neo4j/values.yaml
@@ -8,22 +8,5 @@ neo4j:
       limits:
         cpu: 400m
         memory: 2048Mi
-  image: mszostok/neo4j
-  imageTag: 4.2.8-apoc
+  imageTag: 4.2.8
   neo4jPassword: okon
-  readinessProbe:
-    initialDelaySeconds: 10
-    failureThreshold: 30
-    timeoutSeconds: 3
-    periodSeconds: 10
-    tcpSocket:
-      port: 7687
-
-  livenessProbe:
-    initialDelaySeconds: 10
-    failureThreshold: 30
-    timeoutSeconds: 3
-    periodSeconds: 10
-    tcpSocket:
-      port: 7687
-

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/common-nighthawk/go-figure v0.0.0-20200609044655-c4b36f998cf2
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.8+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/evanphx/json-patch/v5 v5.5.0 // indirect
 	github.com/fatih/color v1.12.0
 	github.com/fatih/structs v1.1.0

--- a/hack/dev-cluster-create.sh
+++ b/hack/dev-cluster-create.sh
@@ -32,7 +32,6 @@ main() {
     capact::create_cluster
 
     export DOCKER_TAG=dev
-    export DOCKER_REPOSITORY="local"
     export PRINT_INSECURE_NOTES="true"
     shout "Installing Capact on development local cluster..."
     capact::install

--- a/hack/dev-cluster-update.sh
+++ b/hack/dev-cluster-update.sh
@@ -23,7 +23,6 @@ main() {
     shout "Updating development local cluster..."
 
     export DOCKER_TAG=dev-$RANDOM
-    export DOCKER_REPOSITORY="local"
     export BUILD_IMAGES="true"
     export REPO_DIR=$REPO_ROOT_DIR
     export CLUSTER_TYPE=${CLUSTER_TYPE:-"kind"}

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -186,13 +186,15 @@ capact::delete_cluster() {
 # Installs Capact charts. If they are already installed, it upgrades them.
 #
 # Required envs:
-#  - DOCKER_REPOSITORY
 #  - DOCKER_TAG
 #  - REPO_DIR
 #  - CAPACT_NAMESPACE
-#  - CAPACT_VERSION
 #  - CLUSTER_TYPE
 #  - CLUSTER_NAME
+# Optional envs:
+#  - CAPACT_VERSION
+#  - DOCKER_REPOSITORY
+#  - PRINT_INSECURE_NOTES
 #  - ENABLE_POPULATOR - if set to true then database populator will be enabled and it will populate database with manifests
 #  - USE_TEST_SETUP - if set to true, then a test policy is configured
 #  - INCREASE_RESOURCE_LIMITS - if set to true, then the components will use higher resource requests and limits
@@ -218,7 +220,6 @@ capact::install() {
     export CAPACT_OVERRIDES=${CAPACT_OVERRIDES:=""}
     export CAPACT_INSTALL_ADDITIONAL_OPTS=""
 
-    CAPACT_OVERRIDES+=",global.containerRegistry.path=${DOCKER_REPOSITORY}"
     CAPACT_OVERRIDES+=",global.containerRegistry.overrideTag=${DOCKER_TAG}"
     CAPACT_OVERRIDES+=",hub-public.populator.enabled=${ENABLE_POPULATOR}"
     CAPACT_OVERRIDES+=",engine.testSetup.enabled=${USE_TEST_SETUP}"
@@ -242,6 +243,10 @@ capact::install() {
 
     if [ -n "${HUB_MANIFESTS_SOURCE_REPO_URL:-}" ]; then
       CAPACT_OVERRIDES+=",hub-public.populator.manifestsLocation.repository=${HUB_MANIFESTS_SOURCE_REPO_URL}"
+    fi
+
+    if [ -n "${DOCKER_REPOSITORY:-}" ]; then
+      CAPACT_OVERRIDES+=",global.containerRegistry.path=${DOCKER_REPOSITORY}"
     fi
 
     if [[ "${BUILD_IMAGES:-"true"}" == "false" ]]; then

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -163,10 +163,14 @@ capact::create_cluster() {
     if [[ "${MULTINODE_CLUSTER:-"false"}" == "true" ]]; then
       CLUSTER_CONFIG_FLAG=--cluster-config="${REPO_DIR}/hack/cluster-config/kind/config-multinode.yaml"
     fi
+    if [[ "${ENABLE_K3D_REGISTRY:-"true"}" == "true" && "${CLUSTER_TYPE}" == "k3d" ]]; then
+      K3D_REGISTRY="--enable-registry"
+    fi
     # shellcheck disable=SC2086
     capact::cli env create ${CLUSTER_TYPE} --verbose \
       --name="${CLUSTER_NAME}" \
       ${CLUSTER_CONFIG_FLAG:-} \
+      ${K3D_REGISTRY:-} \
       --wait=5m
 }
 
@@ -246,6 +250,10 @@ capact::install() {
 
     if [ -n "${CAPACT_HELM_REPO_URL:-}" ]; then
       CAPACT_INSTALL_ADDITIONAL_OPTS="${CAPACT_INSTALL_ADDITIONAL_OPTS} --helm-repo-url=${CAPACT_HELM_REPO_URL}"
+    fi
+
+    if [[ "${ENABLE_K3D_REGISTRY:-"true"}" == "true" && "${CLUSTER_TYPE}" == "k3d" ]]; then
+      CAPACT_INSTALL_ADDITIONAL_OPTS="${CAPACT_INSTALL_ADDITIONAL_OPTS} --enable-registry"
     fi
 
     # shellcheck disable=SC2086

--- a/hack/lib/utilities.sh
+++ b/hack/lib/utilities.sh
@@ -163,7 +163,7 @@ capact::create_cluster() {
     if [[ "${MULTINODE_CLUSTER:-"false"}" == "true" ]]; then
       CLUSTER_CONFIG_FLAG=--cluster-config="${REPO_DIR}/hack/cluster-config/kind/config-multinode.yaml"
     fi
-    if [[ "${ENABLE_K3D_REGISTRY:-"true"}" == "true" && "${CLUSTER_TYPE}" == "k3d" ]]; then
+    if [[ "${DISABLE_K3D_REGISTRY:-"false"}" == "false" && "${CLUSTER_TYPE}" == "k3d" ]]; then
       K3D_REGISTRY="--enable-registry"
     fi
     # shellcheck disable=SC2086
@@ -252,7 +252,7 @@ capact::install() {
       CAPACT_INSTALL_ADDITIONAL_OPTS="${CAPACT_INSTALL_ADDITIONAL_OPTS} --helm-repo-url=${CAPACT_HELM_REPO_URL}"
     fi
 
-    if [[ "${ENABLE_K3D_REGISTRY:-"true"}" == "true" && "${CLUSTER_TYPE}" == "k3d" ]]; then
+    if [[ "${DISABLE_K3D_REGISTRY:-"false"}" == "false" && "${CLUSTER_TYPE}" == "k3d" ]]; then
       CAPACT_INSTALL_ADDITIONAL_OPTS="${CAPACT_INSTALL_ADDITIONAL_OPTS} --enable-registry"
     fi
 

--- a/internal/cli/capact/build.go
+++ b/internal/cli/capact/build.go
@@ -2,13 +2,14 @@ package capact
 
 import (
 	"bytes"
-	"capact.io/capact/internal/cli/printer"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"os/exec"
 	"sort"
+
+	"capact.io/capact/internal/cli/printer"
+	"github.com/pkg/errors"
 
 	"k8s.io/utils/strings/slices"
 )
@@ -120,15 +121,15 @@ func BuildImages(ctx context.Context, w *printer.Status, repository, version str
 			return nil, errors.Wrapf(err, "while building image %s", image)
 		}
 		created = append(created, imageTag)
-
 	}
 	return created, nil
 }
 
 // PushImages pushes passed images to a given registry
-func PushImages(ctx context.Context, w *printer.Status, names []string, reg string) error {
+func PushImages(ctx context.Context, w *printer.Status, names []string) error {
 	var buff bytes.Buffer
 	for _, image := range names {
+		// #nosec G204
 		cmd := exec.CommandContext(ctx, "docker",
 			"push",
 			image)

--- a/internal/cli/capact/build.go
+++ b/internal/cli/capact/build.go
@@ -139,7 +139,7 @@ func PushImages(ctx context.Context, status *printer.Status, names []string) err
 }
 
 func runCMD(cmd *exec.Cmd, status *printer.Status, stageFmt string, args ...interface{}) error {
-	if cli.VerboseMode.IsEnabled() {
+	if cli.VerboseMode.IsTracing() {
 		cmd.Stdout = status.Writer()
 		cmd.Stderr = status.Writer()
 		return cmd.Run()

--- a/internal/cli/capact/build.go
+++ b/internal/cli/capact/build.go
@@ -9,10 +9,9 @@ import (
 	"sort"
 
 	"capact.io/capact/internal/cli"
-
 	"capact.io/capact/internal/cli/printer"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
 	"k8s.io/utils/strings/slices"
 )
 

--- a/internal/cli/capact/capact.go
+++ b/internal/cli/capact/capact.go
@@ -1,6 +1,7 @@
 package capact
 
 import (
+	"github.com/pkg/errors"
 	"time"
 )
 
@@ -62,4 +63,11 @@ type Options struct {
 	UpdateHostsFile    bool
 	UpdateTrustedCerts bool
 	Registry           string
+}
+
+func (o *Options) Validate() error {
+	if o.Registry != "" && o.Environment != K3dEnv {
+		return errors.New("registry can be used only with K3d environment")
+	}
+	return nil
 }

--- a/internal/cli/capact/capact.go
+++ b/internal/cli/capact/capact.go
@@ -1,8 +1,9 @@
 package capact
 
 import (
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -62,11 +63,12 @@ type Options struct {
 	Parameters         InputParameters
 	UpdateHostsFile    bool
 	UpdateTrustedCerts bool
-	Registry           string
+	RegistryEnabled    bool
 }
 
+// Validate validates capact install options.
 func (o *Options) Validate() error {
-	if o.Registry != "" && o.Environment != K3dEnv {
+	if o.RegistryEnabled && o.Environment != K3dEnv {
 		return errors.New("registry can be used only with K3d environment")
 	}
 	return nil

--- a/internal/cli/capact/capact.go
+++ b/internal/cli/capact/capact.go
@@ -61,4 +61,5 @@ type Options struct {
 	Parameters         InputParameters
 	UpdateHostsFile    bool
 	UpdateTrustedCerts bool
+	Registry           string
 }

--- a/internal/cli/capact/components.go
+++ b/internal/cli/capact/components.go
@@ -157,9 +157,15 @@ func (c *ComponentData) runUpgrade(upgradeCli *action.Upgrade, values map[string
 		return nil, errors.Wrap(err, "while loading Helm chart")
 	}
 
-	r, err := upgradeCli.Run(c.Name(), chartData, values)
+	//  Sometimes we run into in issue with webhooks, e.g.
+	//  Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://ingress-nginx-controller-admission.capact-system.svc:443/networking/v1beta1/ingresses?timeout=10s": dial tcp 10.43.95.159:443: connect: connection refused
+	var r *release.Release
+	err = retry.Do(func() error {
+		r, err = upgradeCli.Run(c.Name(), chartData, values)
+		return errors.Wrapf(err, "while upgrading Helm chart [%s]", c.Name())
+	}, retry.Attempts(3))
 	if err != nil {
-		return nil, errors.Wrapf(err, "while upgrading Helm chart [%s]", c.Name())
+		return nil, err
 	}
 	return r, nil
 }
@@ -187,9 +193,15 @@ func (c *ComponentData) runInstall(installCli *action.Install, values map[string
 		return nil, errors.Wrap(err, "while loading Helm chart")
 	}
 
-	r, err := installCli.Run(chartData, values)
+	//  Sometimes we run into in issue with webhooks, e.g.
+	//  Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://ingress-nginx-controller-admission.capact-system.svc:443/networking/v1beta1/ingresses?timeout=10s": dial tcp 10.43.95.159:443: connect: connection refused
+	var r *release.Release
+	err = retry.Do(func() error {
+		r, err = installCli.Run(chartData, values)
+		return errors.Wrapf(err, "while installing Helm chart [%s]", installCli.ReleaseName)
+	}, retry.Attempts(3))
 	if err != nil {
-		return nil, errors.Wrapf(err, "while installing Helm chart [%s]", installCli.ReleaseName)
+		return nil, err
 	}
 
 	return r, nil

--- a/internal/cli/capact/images.go
+++ b/internal/cli/capact/images.go
@@ -3,13 +3,16 @@ package capact
 import (
 	"context"
 
+	"capact.io/capact/internal/cli/printer"
+
 	"github.com/pkg/errors"
 )
 
 // LoadImages loads Docker images into proper environment
-func LoadImages(ctx context.Context, images []string, opts Options) error {
+func LoadImages(ctx context.Context, status *printer.Status, images []string, opts Options) error {
 	switch opts.Environment {
 	case KindEnv:
+		status.Step("Loading Docker images into kind cluster")
 		for _, img := range images {
 			if err := LoadKindImage(opts.Name, img); err != nil {
 				return errors.Wrap(err, "while loading images into kind environment")

--- a/internal/cli/capact/k3d.go
+++ b/internal/cli/capact/k3d.go
@@ -19,9 +19,5 @@ func LoadK3dImages(ctx context.Context, clusterName string, images []string) err
 		return err
 	}
 
-	err = tools.ImageImportIntoClusterMulti(ctx, runtimes.SelectedRuntime, images, cluster, k3dtypes.ImageImportOpts{})
-	if err != nil {
-		return err
-	}
-	return nil
+	return tools.ImageImportIntoClusterMulti(ctx, runtimes.SelectedRuntime, images, cluster, k3dtypes.ImageImportOpts{})
 }

--- a/internal/cli/capact/os.go
+++ b/internal/cli/capact/os.go
@@ -9,13 +9,25 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"capact.io/capact/internal/cli/environment/create"
 )
 
-// AddGatewayToHostsFile adds a new entry to the /etc/hosts file for Capact Gateway
-func AddGatewayToHostsFile() error {
-	hosts := "/etc/hosts"
-	entry := fmt.Sprintf("\n127.0.0.1 gateway.%s.local", Name)
+const hosts = "/etc/hosts"
 
+// AddGatewayToHostsFile adds a new entry to the /etc/hosts file for Capact Gateway.
+func AddGatewayToHostsFile() error {
+	entry := fmt.Sprintf("\n127.0.0.1 gateway.%s.local", Name)
+	return updateHostFile(entry)
+}
+
+// AddRegistryToHostsFile adds a new entry to the /etc/hosts file for Capact local Docker registry.
+func AddRegistryToHostsFile() error {
+	entry := fmt.Sprintf("\n127.0.0.1 %s", create.ContainerRegistry)
+	return updateHostFile(entry)
+}
+
+func updateHostFile(entry string) error {
 	data, err := ioutil.ReadFile(hosts)
 	if err != nil {
 		return err

--- a/internal/cli/capact/os.go
+++ b/internal/cli/capact/os.go
@@ -46,7 +46,7 @@ func updateHostFile(entry string) error {
 	return cmd.Run()
 }
 
-// TrustSelfSigned adds Capact generatd certificate to the trusted certificates
+// TrustSelfSigned adds Capact generated certificate to the trusted certificates
 func TrustSelfSigned() error {
 	tmpFileName := "/tmp/capact-cert"
 
@@ -64,7 +64,7 @@ func TrustSelfSigned() error {
 		return trustSelfSignedLinux(tmpFileName)
 	default:
 		// TODO
-		// Prepeare a message with not supported OS
+		// Prepare a message with not supported OS
 		// Depending where we will store the cert the message needs to be adjusted
 	}
 	return nil

--- a/internal/cli/environment/create/defaults.go
+++ b/internal/cli/environment/create/defaults.go
@@ -3,6 +3,4 @@ package create
 const (
 	// DefaultClusterName defines default name for a cluster.
 	DefaultClusterName = "dev-capact"
-	// DefaultDockerNetwork defines default Docker network name for a cluster.
-	DefaultDockerNetwork = "capact"
 )

--- a/internal/cli/environment/create/k3d.go
+++ b/internal/cli/environment/create/k3d.go
@@ -1,9 +1,14 @@
 package create
 
 import (
+	"capact.io/capact/internal/cli/config"
 	"context"
 	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"io"
+	"os"
+	"text/template"
 	"time"
 
 	"capact.io/capact/internal/cli/printer"
@@ -14,6 +19,13 @@ import (
 	k3dtypes "github.com/rancher/k3d/v4/pkg/types"
 	"golang.org/x/sync/errgroup"
 )
+
+// K3dOptions holds configuration for creating k3d cluster.
+type K3dOptions struct {
+	Name            string
+	Wait            time.Duration
+	RegistryEnabled bool
+}
 
 // WaitForK3dReadyNodes waits until nodes are in Ready state based on the role message log.
 func WaitForK3dReadyNodes(ctx context.Context, w io.Writer, clusterName string) (err error) {
@@ -49,4 +61,54 @@ func WaitForK3dReadyNodes(ctx context.Context, w io.Writer, clusterName string) 
 	}
 
 	return nil
+}
+
+// K3dSetDefaultConfig sets default values for k3d flags
+// We cannot use v1alpha2.SimpleConfig struct as tags are messed up and we are not able to marshal it properly.
+func K3dSetDefaultConfig(flags *pflag.FlagSet, opts K3dOptions) error {
+	configFlag := flags.Lookup("config")
+	if configFlag.Changed { // do not change user settings
+		return nil
+	}
+
+	fName, err := config.GetDefaultConfigPath("k3d-config.yaml")
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("cfg").Parse(k3dDefaultConfigTmpl)
+	if err != nil {
+		return err
+	}
+
+	data := map[string]string{
+		"name":        DefaultClusterName,
+		"image":       k3dDefaultNodeImage,
+		"networkName": K3dDockerNetwork,
+	}
+	if opts.RegistryEnabled {
+		data["registry"] = ContainerRegistryName
+	}
+
+	f, err := os.OpenFile(fName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err := tmpl.Execute(f, data); err != nil {
+		return err
+	}
+
+	return configFlag.Value.Set(fName)
+}
+
+// K3dRemoveWaitAndTimeoutFlags removes the wait and timeout flags
+func K3dRemoveWaitAndTimeoutFlags(k3d *cobra.Command) {
+	flags := k3d.Flags()
+	k3d.ResetFlags()
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Name == "wait" || flag.Name == "timeout" { // we set this by ourselves
+			return
+		}
+		if flag.Name == "volume" {
+			flag.Shorthand = "" // to avoid 'unable to redefine 'v' shorthand in "k3d" flagset: it's already used for "volume" flag'
+		}
+		k3d.Flags().AddFlag(flag)
+	})
 }

--- a/internal/cli/environment/create/k3d.go
+++ b/internal/cli/environment/create/k3d.go
@@ -1,15 +1,17 @@
 package create
 
 import (
-	"capact.io/capact/internal/cli/config"
 	"context"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"io"
 	"os"
+	"path/filepath"
 	"text/template"
 	"time"
+
+	"capact.io/capact/internal/cli/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"capact.io/capact/internal/cli/printer"
 
@@ -25,6 +27,7 @@ type K3dOptions struct {
 	Name            string
 	Wait            time.Duration
 	RegistryEnabled bool
+	Registry        string
 }
 
 // WaitForK3dReadyNodes waits until nodes are in Ready state based on the role message log.
@@ -87,10 +90,13 @@ func K3dSetDefaultConfig(flags *pflag.FlagSet, opts K3dOptions) error {
 		"networkName": K3dDockerNetwork,
 	}
 	if opts.RegistryEnabled {
-		data["registry"] = ContainerRegistryName
+		data["registry"] = ContainerRegistry
 	}
 
-	f, err := os.OpenFile(fName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(filepath.Clean(fName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
 	if err := tmpl.Execute(f, data); err != nil {
 		return err
 	}

--- a/internal/cli/environment/create/k3d.go
+++ b/internal/cli/environment/create/k3d.go
@@ -10,10 +10,9 @@ import (
 	"time"
 
 	"capact.io/capact/internal/cli/config"
+	"capact.io/capact/internal/cli/printer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"capact.io/capact/internal/cli/printer"
 
 	"github.com/pkg/errors"
 	"github.com/rancher/k3d/v4/pkg/client"

--- a/internal/cli/environment/create/k3d.go
+++ b/internal/cli/environment/create/k3d.go
@@ -3,7 +3,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -26,12 +25,10 @@ type K3dOptions struct {
 	Name            string
 	Wait            time.Duration
 	RegistryEnabled bool
-	Registry        string
 }
 
 // WaitForK3dReadyNodes waits until nodes are in Ready state based on the role message log.
-func WaitForK3dReadyNodes(ctx context.Context, w io.Writer, clusterName string) (err error) {
-	status := printer.NewStatus(w, "")
+func WaitForK3dReadyNodes(ctx context.Context, status *printer.Status, clusterName string) (err error) {
 	defer func() {
 		status.End(err == nil)
 	}()

--- a/internal/cli/environment/create/k3d_defaults.go
+++ b/internal/cli/environment/create/k3d_defaults.go
@@ -18,8 +18,9 @@ const (
 
 // K3dOptions holds configuration for creating k3d cluster.
 type K3dOptions struct {
-	Name string
-	Wait time.Duration
+	Name            string
+	Wait            time.Duration
+	RegistryEnabled bool
 }
 
 // K3dDefaultConfig returns default set of values for k3d.
@@ -44,10 +45,28 @@ options:
         extraServerArgs:
             - --no-deploy=traefik
             - --node-label=ingress-ready=true
+registries:
+  config: |
+    mirrors:
+      capact-registry.localhost:5000:
+        endpoint:
+          - http://capact-registry.localhost:5000
+      docker.io:
+        endpoint:
+          - http://capact-registry.localhost:5000
+      gcr.io:
+        endpoint:
+          - http://capact-registry.localhost:5000
+      eu.gcr.io:
+        endpoint:
+          - http://capact-registry.localhost:5000
+      configs: {}
+      auths: {}
+
 `, DefaultClusterName, K3dDefaultNodeImage, DefaultDockerNetwork)
 
 // K3dSetDefaultConfig sets default values for k3d flags
-func K3dSetDefaultConfig(flags *pflag.FlagSet) error {
+func K3dSetDefaultConfig(flags *pflag.FlagSet, opts K3dOptions) error {
 	configFlag := flags.Lookup("config")
 	if configFlag.Changed { // do not change user settings
 		return nil

--- a/internal/cli/environment/create/k3d_defaults.go
+++ b/internal/cli/environment/create/k3d_defaults.go
@@ -1,101 +1,15 @@
 package create
 
 import (
-	"fmt"
-	"os"
-	"time"
-
-	"capact.io/capact/internal/cli/config"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
+	_ "embed"
 )
+
+//go:embed tmpl/k3d-config.tmpl.yaml
+var k3dDefaultConfigTmpl string
 
 const (
-	// K3dDefaultNodeImage defines default Kubernetes image for a new k3d cluster.
-	K3dDefaultNodeImage = "docker.io/rancher/k3s:v1.20.7-k3s1"
-	// K3dDockerNetwork defines default Docker network name for a cluster.
+	// k3dDefaultNodeImage defines default Kubernetes image for a new k3d cluster.
+	k3dDefaultNodeImage = "docker.io/rancher/k3s:v1.20.7-k3s1"
+	// K3dDockerNetwork defines default Docker network name k3d cluster.
 	K3dDockerNetwork = "capact"
 )
-
-// K3dOptions holds configuration for creating k3d cluster.
-type K3dOptions struct {
-	Name            string
-	Wait            time.Duration
-	RegistryEnabled bool
-}
-
-// K3dDefaultConfig returns default set of values for k3d.
-// We cannot use v1alpha2.SimpleConfig struct as tags are messed up and we are not able to marshal it properly.
-var K3dDefaultConfig = fmt.Sprintf(`
-kind: Simple
-apiVersion: k3d.io/v1alpha2
-name: %s
-servers: 1
-agents: 0
-image: %s
-network: %s
-ports:
-    - port: 80:80
-      nodeFilters:
-        - loadbalancer
-    - port: 443:443
-      nodeFilters:
-        - loadbalancer
-options:
-    k3s:
-        extraServerArgs:
-            - --no-deploy=traefik
-            - --node-label=ingress-ready=true
-registries:
-  config: |
-    mirrors:
-      capact-registry.localhost:5000:
-        endpoint:
-          - http://capact-registry.localhost:5000
-      docker.io:
-        endpoint:
-          - http://capact-registry.localhost:5000
-      gcr.io:
-        endpoint:
-          - http://capact-registry.localhost:5000
-      eu.gcr.io:
-        endpoint:
-          - http://capact-registry.localhost:5000
-      configs: {}
-      auths: {}
-
-`, DefaultClusterName, K3dDefaultNodeImage, K3dDockerNetwork)
-
-// K3dSetDefaultConfig sets default values for k3d flags
-func K3dSetDefaultConfig(flags *pflag.FlagSet, opts K3dOptions) error {
-	configFlag := flags.Lookup("config")
-	if configFlag.Changed { // do not change user settings
-		return nil
-	}
-
-	file, err := config.GetDefaultConfigPath("k3d-config.yaml")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(file, []byte(K3dDefaultConfig), 0600); err != nil {
-		return err
-	}
-
-	return configFlag.Value.Set(file)
-}
-
-// K3dRemoveWaitAndTimeoutFlags removes the wait and timeout flags
-func K3dRemoveWaitAndTimeoutFlags(k3d *cobra.Command) {
-	flags := k3d.Flags()
-	k3d.ResetFlags()
-	flags.VisitAll(func(flag *pflag.Flag) {
-		if flag.Name == "wait" || flag.Name == "timeout" { // we set this by ourselves
-			return
-		}
-		if flag.Name == "volume" {
-			flag.Shorthand = "" // to avoid 'unable to redefine 'v' shorthand in "k3d" flagset: it's already used for "volume" flag'
-		}
-		k3d.Flags().AddFlag(flag)
-	})
-}

--- a/internal/cli/environment/create/k3d_defaults.go
+++ b/internal/cli/environment/create/k3d_defaults.go
@@ -14,6 +14,8 @@ import (
 const (
 	// K3dDefaultNodeImage defines default Kubernetes image for a new k3d cluster.
 	K3dDefaultNodeImage = "docker.io/rancher/k3s:v1.20.7-k3s1"
+	// K3dDockerNetwork defines default Docker network name for a cluster.
+	K3dDockerNetwork = "capact"
 )
 
 // K3dOptions holds configuration for creating k3d cluster.
@@ -63,7 +65,7 @@ registries:
       configs: {}
       auths: {}
 
-`, DefaultClusterName, K3dDefaultNodeImage, DefaultDockerNetwork)
+`, DefaultClusterName, K3dDefaultNodeImage, K3dDockerNetwork)
 
 // K3dSetDefaultConfig sets default values for k3d flags
 func K3dSetDefaultConfig(flags *pflag.FlagSet, opts K3dOptions) error {

--- a/internal/cli/environment/create/local_registry.go
+++ b/internal/cli/environment/create/local_registry.go
@@ -1,5 +1,78 @@
 package create
 
-func CreateLocalRegistry() {
-	docker container run -d --name registry.localhost -v local_registry:/var/lib/registry --restart always -p 5000:5000 registry:2
+import (
+	"capact.io/capact/internal/cli/printer"
+	"context"
+	"github.com/docker/docker/api/types"
+	"io"
+	"os"
+
+	"capact.io/capact/internal/cli/config"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+)
+
+const containerRegistryName = "capact-registry.localhost"
+
+func LocalRegistry(ctx context.Context, w io.Writer) (id string, err error) {
+	status := printer.NewStatus(w, "")
+	defer func() {
+		status.End(err == nil)
+	}()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return "", err
+	}
+
+	// Get local_registry local path
+	localRegistryFolder, err := config.GetDefaultConfigPath("local_registry")
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(localRegistryFolder, os.ModePerm); err != nil { // ensure folder exists
+		return "", err
+	}
+	status.Step("Creating local registry under %s...", localRegistryFolder)
+	// Equal to:
+	// docker container run -d \
+	//  -p 5000:5000 \
+	//  --restart=always \
+	//  --name capact-registry.localhost \
+	//  --network capact \
+	//  -v $HOME/.config/capact/local_registry:/var/lib/registry \
+	//  registry:2
+	cnt := &container.Config{Image: "registry:2"}
+	host := &container.HostConfig{
+		PortBindings: nat.PortMap{
+			"5000/tcp": {{HostIP: "", HostPort: "5000"}},
+		},
+		RestartPolicy: container.RestartPolicy{Name: "always"},
+		Mounts: []mount.Mount{{
+			Type:   mount.TypeBind,
+			Source: localRegistryFolder,
+			Target: "/var/lib/registry",
+		}},
+	}
+
+	createdCnt, err := cli.ContainerCreate(ctx, cnt, host, nil, nil, "capact-registry.localhost")
+	if err != nil {
+		return "", err
+	}
+	if err := cli.ContainerStart(ctx, createdCnt.ID, types.ContainerStartOptions{}); err != nil {
+		return "", err
+	}
+	return createdCnt.ID, nil
+}
+
+func RegistryConnWithNetwork(ctx context.Context, networkID string) error {
+	//docker network connect networkID capact-registry.localhost
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+
+	return cli.NetworkConnect(ctx, networkID, containerRegistryName, nil)
 }

--- a/internal/cli/environment/create/local_registry.go
+++ b/internal/cli/environment/create/local_registry.go
@@ -1,11 +1,12 @@
 package create
 
 import (
-	"capact.io/capact/internal/cli/printer"
 	"context"
-	"github.com/docker/docker/api/types"
 	"io"
 	"os"
+
+	"capact.io/capact/internal/cli/printer"
+	"github.com/docker/docker/api/types"
 
 	"capact.io/capact/internal/cli/config"
 	"github.com/docker/docker/api/types/container"
@@ -14,8 +15,16 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-const ContainerRegistryName = "capact-registry.localhost"
+const (
+	// ContainerRegistryName defines name for the container registry. It's also used as DNS for registry.
+	ContainerRegistryName = "capact-registry.localhost"
+	// ContainerRegistryPort defines port for the container registry.
+	ContainerRegistryPort = "5000"
+	// ContainerRegistry defines container DNS with port.
+	ContainerRegistry = ContainerRegistryName + ":" + ContainerRegistryPort
+)
 
+// LocalRegistry create a local Docker registry used to pushed locally build images.
 func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 	status := printer.NewStatus(w, "")
 	defer func() {
@@ -42,7 +51,7 @@ func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 	cnt := &container.Config{Image: "registry:2"}
 	host := &container.HostConfig{
 		PortBindings: nat.PortMap{
-			"5000/tcp": {{HostIP: "", HostPort: "5000"}},
+			"5000/tcp": {{HostIP: "", HostPort: ContainerRegistryPort}},
 		},
 		RestartPolicy: container.RestartPolicy{Name: "always"},
 		Mounts: []mount.Mount{{
@@ -63,8 +72,9 @@ func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 	return nil
 }
 
+// RegistryConnWithNetwork connects container registry with a given network.
 func RegistryConnWithNetwork(ctx context.Context, networkID string) error {
-	//docker network connect networkID capact-registry.localhost
+	//docker network connect ${networkID} capact-registry.localhost
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err

--- a/internal/cli/environment/create/local_registry.go
+++ b/internal/cli/environment/create/local_registry.go
@@ -1,0 +1,5 @@
+package create
+
+func CreateLocalRegistry() {
+	docker container run -d --name registry.localhost -v local_registry:/var/lib/registry --restart always -p 5000:5000 registry:2
+}

--- a/internal/cli/environment/create/local_registry.go
+++ b/internal/cli/environment/create/local_registry.go
@@ -2,36 +2,41 @@ package create
 
 import (
 	"context"
-	"io"
+	"io/ioutil"
 	"os"
 
-	"capact.io/capact/internal/cli/printer"
-	"github.com/docker/docker/api/types"
-
+	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/config"
+	"capact.io/capact/internal/cli/printer"
+
+	"github.com/docker/cli/cli/streams"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
 )
 
 const (
+	// ContainerRegistryImage defines local Docker registry image.
+	ContainerRegistryImage = "registry:2"
 	// ContainerRegistryName defines name for the container registry. It's also used as DNS for registry.
 	ContainerRegistryName = "capact-registry.localhost"
 	// ContainerRegistryPort defines port for the container registry.
+	// TODO: allow setting different port by user
 	ContainerRegistryPort = "5000"
 	// ContainerRegistry defines container DNS with port.
 	ContainerRegistry = ContainerRegistryName + ":" + ContainerRegistryPort
 )
 
 // LocalRegistry create a local Docker registry used to pushed locally build images.
-func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
-	status := printer.NewStatus(w, "")
+func LocalRegistry(ctx context.Context, status *printer.Status) (err error) {
 	defer func() {
 		status.End(err == nil)
 	}()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	dockerCli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
@@ -41,14 +46,25 @@ func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 	if err != nil {
 		return err
 	}
+
+	status.Step("Storing local registry data under %s", localRegistryFolder)
 	if err := os.MkdirAll(localRegistryFolder, os.ModePerm); err != nil { // ensure folder exists
 		return err
 	}
 
-	status.Step("Creating local registry under %s", localRegistryFolder)
+	if err := ensureRegistryImage(ctx, dockerCli, status); err != nil {
+		return err
+	}
+
+	status.Step("Creating local registry %s", ContainerRegistry)
 	// Equal to:
 	// docker container run -d -p 5000:5000  --restart=always  --name capact-registry.localhost  --network capact -v $HOME/.config/capact/local_registry:/var/lib/registry registry:2
-	cnt := &container.Config{Image: "registry:2"}
+	if err != nil {
+		return err
+	}
+	cnt := &container.Config{
+		Image: ContainerRegistryImage,
+	}
 	host := &container.HostConfig{
 		PortBindings: nat.PortMap{
 			"5000/tcp": {{HostIP: "", HostPort: ContainerRegistryPort}},
@@ -61,21 +77,73 @@ func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 		}},
 	}
 
-	createdCnt, err := cli.ContainerCreate(ctx, cnt, host, nil, nil, ContainerRegistryName)
+	createdCnt, err := dockerCli.ContainerCreate(ctx, cnt, host, nil, nil, ContainerRegistryName)
 	if err != nil {
 		return err
 	}
 
-	return cli.ContainerStart(ctx, createdCnt.ID, types.ContainerStartOptions{})
+	return dockerCli.ContainerStart(ctx, createdCnt.ID, types.ContainerStartOptions{})
 }
 
 // RegistryConnWithNetwork connects container registry with a given network.
 func RegistryConnWithNetwork(ctx context.Context, networkID string) error {
 	//docker network connect ${networkID} capact-registry.localhost
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	dockerCli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
 
-	return cli.NetworkConnect(ctx, networkID, ContainerRegistryName, nil)
+	return dockerCli.NetworkConnect(ctx, networkID, ContainerRegistryName, nil)
+}
+
+func ensureRegistryImage(ctx context.Context, dockerCli *client.Client, status *printer.Status) error {
+	found, err := foundRegistryImageLocally(ctx, dockerCli)
+	if err != nil {
+		return err
+	}
+	if found {
+		return nil
+	}
+
+	return pullRegistryImage(ctx, dockerCli, status)
+}
+
+func isDockerNotFoundErr(err error) bool {
+	type notFound interface {
+		NotFound()
+	}
+	_, ok := err.(notFound)
+	return ok
+}
+
+func foundRegistryImageLocally(ctx context.Context, dockerCli *client.Client) (bool, error) {
+	_, _, err := dockerCli.ImageInspectWithRaw(ctx, ContainerRegistryImage)
+	switch {
+	case err == nil: // found
+		return true, nil
+	case isDockerNotFoundErr(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func pullRegistryImage(ctx context.Context, dockerCli *client.Client, status *printer.Status) error {
+	out := streams.NewOut(os.Stdout)
+	if !cli.VerboseMode.IsTracing() {
+		status.Step("Pulling %q image", ContainerRegistryImage)
+		out = streams.NewOut(ioutil.Discard)
+	}
+
+	reader, err := dockerCli.ImagePull(ctx, ContainerRegistryImage, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	err = jsonmessage.DisplayJSONMessagesToStream(reader, out, nil)
+	if err != nil {
+		return err
+	}
+
+	return reader.Close()
 }

--- a/internal/cli/environment/create/local_registry.go
+++ b/internal/cli/environment/create/local_registry.go
@@ -66,10 +66,7 @@ func LocalRegistry(ctx context.Context, w io.Writer) (err error) {
 		return err
 	}
 
-	if err := cli.ContainerStart(ctx, createdCnt.ID, types.ContainerStartOptions{}); err != nil {
-		return err
-	}
-	return nil
+	return cli.ContainerStart(ctx, createdCnt.ID, types.ContainerStartOptions{})
 }
 
 // RegistryConnWithNetwork connects container registry with a given network.

--- a/internal/cli/environment/create/tmpl/k3d-config.tmpl.yaml
+++ b/internal/cli/environment/create/tmpl/k3d-config.tmpl.yaml
@@ -1,0 +1,39 @@
+kind: Simple
+apiVersion: k3d.io/v1alpha2
+name: {{ .name }}
+servers: 1
+agents: 0
+image: {{ .image }}
+network: {{ .networkName }}
+ports:
+  - port: 80:80
+    nodeFilters:
+      - loadbalancer
+  - port: 443:443
+    nodeFilters:
+      - loadbalancer
+options:
+  k3s:
+    extraServerArgs:
+      - --no-deploy=traefik
+      - --node-label=ingress-ready=true
+{{if .registry }}
+registries:
+  config: |
+    mirrors:
+      {{ .registry }}:
+        endpoint:
+          - http://{{ .registry }}
+      docker.io:
+        endpoint:
+          - http://{{ .registry }}
+      gcr.io:
+        endpoint:
+          - http://{{ .registry }}
+      eu.gcr.io:
+        endpoint:
+          - http://{{ .registry }}
+      configs: {}
+      auths: {}
+{{end}}
+

--- a/internal/cli/environment/delete/registry.go
+++ b/internal/cli/environment/delete/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/client"
 )
 
+// LocalRegistry deletes the local Docker registry if there is one.
 func LocalRegistry(ctx context.Context, status *printer.Status) (err error) {
 	status.Step("Removing Docker registry (if there is one)...")
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/internal/cli/environment/delete/registry.go
+++ b/internal/cli/environment/delete/registry.go
@@ -1,0 +1,36 @@
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"capact.io/capact/internal/cli/environment/create"
+	"capact.io/capact/internal/cli/printer"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+func LocalRegistry(ctx context.Context, status *printer.Status) (err error) {
+	status.Step("Removing Docker registry (if there is one)...")
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+
+	filter := filters.Arg("name", create.ContainerRegistryName)
+	cnts, err := cli.ContainerList(ctx, types.ContainerListOptions{Filters: filters.NewArgs(filter)})
+	if err != nil {
+		return err
+	}
+
+	switch n := len(cnts); n {
+	case 0:
+		return nil
+	case 1:
+		return cli.ContainerRemove(ctx, cnts[0].ID, types.ContainerRemoveOptions{Force: true})
+	default:
+		return fmt.Errorf("found %d containers, when exepected only one", n)
+	}
+}

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -50,7 +50,7 @@ func Install(ctx context.Context, w io.Writer, k8sCfg *rest.Config, opts capact.
 				return err
 			}
 		} else { // load into a given environment
-			if err := capact.LoadImages(ctx, created, opts); err != nil {
+			if err := capact.LoadImages(ctx, status, created, opts); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -23,7 +23,7 @@ func Install(ctx context.Context, w io.Writer, k8sCfg *rest.Config, opts capact.
 
 	err = opts.Parameters.SetCapactValuesFromOverrides()
 	if err != nil {
-		return errors.Wrap(err, "while parsing capact overrides")
+		return errors.Wrap(err, "while parsing Capact overrides")
 	}
 
 	err = opts.Parameters.ResolveVersion()
@@ -32,8 +32,8 @@ func Install(ctx context.Context, w io.Writer, k8sCfg *rest.Config, opts capact.
 	}
 
 	version := opts.Parameters.Version
-	if version == "@local" {
-		if opts.RegistryEnabled {
+	if version == capact.LocalVersionTag {
+		if opts.LocalRegistryEnabled {
 			opts.Parameters.Override.CapactValues.Global.ContainerRegistry.Path = create.ContainerRegistry
 		}
 		registryPath := opts.Parameters.Override.CapactValues.Global.ContainerRegistry.Path
@@ -45,7 +45,7 @@ func Install(ctx context.Context, w io.Writer, k8sCfg *rest.Config, opts capact.
 			return errors.Wrap(err, "while building images")
 		}
 
-		if opts.RegistryEnabled { // push to Docker registry
+		if opts.LocalRegistryEnabled { // push to Docker registry
 			if err := capact.PushImages(ctx, status, created); err != nil {
 				return err
 			}

--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"log"
 
-	"capact.io/capact/internal/cli/environment/create"
-
 	"capact.io/capact/internal/cli/capact"
+	"capact.io/capact/internal/cli/environment/create"
 	"capact.io/capact/internal/cli/printer"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 )

--- a/internal/cli/printer/status.go
+++ b/internal/cli/printer/status.go
@@ -20,10 +20,13 @@ type Spinner interface {
 
 // Status provides functionality to display steps progress in terminal.
 type Status struct {
-	stage           string
+	w io.Writer
+
 	spinner         Spinner
-	timeStarted     time.Time
 	durationSprintf func(format string, a ...interface{}) string
+
+	timeStarted time.Time
+	stage       string
 }
 
 // NewStatus returns a new Status instance.
@@ -32,7 +35,9 @@ func NewStatus(w io.Writer, header string) *Status {
 		fmt.Fprintln(w, header)
 	}
 
-	st := &Status{}
+	st := &Status{
+		w: w,
+	}
 	if cli.IsSmartTerminal(w) {
 		st.durationSprintf = color.New(color.Faint, color.Italic).Sprintf
 		st.spinner = NewDynamicSpinner(w)
@@ -80,4 +85,9 @@ func (s *Status) End(success bool) {
 	msg := fmt.Sprintf(" %s %s%s\n",
 		icon, s.stage, dur)
 	s.spinner.Stop(msg)
+}
+
+// Writer returns underlying io.Writer
+func (s *Status) Writer() io.Writer {
+	return s.w
 }


### PR DESCRIPTION
## Description

Currently, we build images on local machine, archive them, mount to kind/k3d cluster and load into cluster.
This PR adds support for local registry, so we build images on local machine and push them to local registry.
As a result, we re-use native docker support for pushing only changed layers and also re-use layers between images. Thanks to that, we reduce time spent on sharing images between localhost and k3d cluster in all scenarios (install/upgrade and when the cluster is deleted as the local registry stores data on localhost).

K3d and local registry containers are connected with the same network.


Changes proposed in this pull request:


- Reduce the e2e test image size from **420MB to 74.9MB**
- Add opt to create local registry via `capact env create k3d --enable-registry`
- Add opt to use local registry via `capact install --environment k3d --enable-registry`
- Remove registry if available via `capact env delete k3d`
- Handle verbose mode during building/pushing images. If `v=2` not specified, output is more concise and consistent.
- Move k3d config to dedicated tmpl file and use Go template to render it instead of `fmt.Sprintf`

**Kind with loading images**
![build](https://user-images.githubusercontent.com/17568639/132014528-71cb4435-25ac-4dd7-b8b7-c4d04c744774.png)

Install: 
```bash
✓ Building image local/argo-actions:dev [took 3s]
✓ Building image local/argo-runner:dev [took 1s]
✓ Building image local/e2e-test:dev [took 1s]
✓ Building image local/gateway:dev [took 1s]
✓ Building image local/hub-js:dev [took 2s]
✓ Building image local/k8s-engine:dev [took 2s]
✓ Building image local/populator:dev [took 3s]
✓ Loading Docker images into kind cluster [took 91s]
```

Upgrade: (no changes)
```bash
✓ Building image local/argo-actions:dev-5143 [took 2s]
✓ Building image local/argo-runner:dev-5143 [took 1s]
✓ Building image local/e2e-test:dev-5143 [took 1s]
✓ Building image local/gateway:dev-5143 [took 1s]
✓ Building image local/hub-js:dev-5143 [took 1s]
✓ Building image local/k8s-engine:dev-5143 [took 2s]
✓ Building image local/populator:dev-5143 [took 2s]
✓ Loading Docker images into kind cluster [took 82s]
```



**K3d with local registry**
![registry](https://user-images.githubusercontent.com/17568639/132014523-763bdf39-17ea-4d9c-9f98-5cc59d91450f.png)


Install:

```bash
Installing Capact on cluster...
 ✓ Building image capact-registry.localhost:5000/argo-actions:dev [took 6s]
 ✓ Building image capact-registry.localhost:5000/argo-runner:dev [took 4s]
 ✓ Building image capact-registry.localhost:5000/e2e-test:dev [took 17s]
 ✓ Building image capact-registry.localhost:5000/gateway:dev [took 3s]
 ✓ Building image capact-registry.localhost:5000/hub-js:dev [took 2s]
 ✓ Building image capact-registry.localhost:5000/k8s-engine:dev [took 4s]
 ✓ Building image capact-registry.localhost:5000/populator:dev [took 6s]
 ✓ Pushing capact-registry.localhost:5000/argo-actions:dev [took 1s]
 ✓ Pushing capact-registry.localhost:5000/argo-runner:dev [took 2s]
 ✓ Pushing capact-registry.localhost:5000/e2e-test:dev [took 3s]
 ✓ Pushing capact-registry.localhost:5000/gateway:dev [took 0s]
 ✓ Pushing capact-registry.localhost:5000/hub-js:dev [took 17s]
 ✓ Pushing capact-registry.localhost:5000/k8s-engine:dev [took 2s]
 ✓ Pushing capact-registry.localhost:5000/populator:dev [took 4s]
```

Upgrade (no changes):
```bash
 ✓ Building image capact-registry.localhost:5000/argo-actions:dev-29541 [took 2s]
 ✓ Building image capact-registry.localhost:5000/argo-runner:dev-29541 [took 1s]
 ✓ Building image capact-registry.localhost:5000/e2e-test:dev-29541 [took 1s]
 ✓ Building image capact-registry.localhost:5000/gateway:dev-29541 [took 1s]
 ✓ Building image capact-registry.localhost:5000/hub-js:dev-29541 [took 1s]
 ✓ Building image capact-registry.localhost:5000/k8s-engine:dev-29541 [took 1s]
 ✓ Building image capact-registry.localhost:5000/populator:dev-29541 [took 2s]
 ✓ Pushing capact-registry.localhost:5000/argo-actions:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/argo-runner:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/e2e-test:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/gateway:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/hub-js:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/k8s-engine:dev-29541 [took 0s]
 ✓ Pushing capact-registry.localhost:5000/populator:dev-29541 [took 0s]
```

https://asciinema.org/a/432775

## Related issue(s)

- https://github.com/capactio/capact/issues/466

