### PR TITLE
Send Slack notifications only on failures

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -279,11 +279,11 @@ jobs:
   slackNotification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [ update-cluster ]
+    needs: [ update-cluster, integration-tests ]
     if: always()
     steps:
       - name: Slack Notification
-        if: ${{ always() && needs.update-cluster.result != 'success' }}
+        if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_USERNAME: Capact CI Notifier


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Send Slack notifications only on failures
  This will ignore canceled, skipped and success results.

Possible results: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
