### PR TITLE
Fix running slack notification when previous jobs fail

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -280,10 +280,9 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-latest
     needs: [ update-cluster, integration-tests ]
-    if: always()
+    if: failure()
     steps:
       - name: Slack Notification
-        if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_USERNAME: Capact CI Notifier


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix running slack notification when previous jobs fail

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
