### PR TITLE
helm-runner to take kubeconfig as argument

### DIFF
--- a/cmd/helm-runner/README.md
+++ b/cmd/helm-runner/README.md
@@ -73,6 +73,7 @@ The following environment variables can be set:
 | RUNNER_REPOSITORY_CACHE_PATH         | no       | `/tmp/helm`              | Set the path to the repository cache directory                                 |
 | RUNNER_OUTPUT_HELM_RELEASE_FILE_PATH | no       | `/tmp/helm-release.yaml` | Defines path under which the Helm release artifacts is saved                   |
 | RUNNER_OUTPUT_ADDITIONAL_FILE_PATH   | no       | `/tmp/additional.yaml`   | Defines path under which the additional output is saved                        |
+| RUNNER_KUBECONFIG                    | no       |                          | Path to kubeconfig file used by Runner, if not set the value of KUBECONFIG will be used |
 | KUBECONFIG                           | no       | `~/.kube/config`         | Path to kubeconfig file                                                        |
 
 

--- a/cmd/helm-runner/main.go
+++ b/cmd/helm-runner/main.go
@@ -6,23 +6,60 @@ import (
 	"capact.io/capact/pkg/runner"
 	"capact.io/capact/pkg/runner/helm"
 	statusreporter "capact.io/capact/pkg/runner/status-reporter"
+	"k8s.io/client-go/rest"
 
 	"github.com/vrischmann/envconfig"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
+// Config holds the input parameters for the Helm runner binary.
+type Config struct {
+	// Kubeconfig to be used by the runner
+	KubeConfig          string `envconfig:"optional"`
+	Command             helm.CommandType
+	HelmReleasePath     string `envconfig:"optional"`
+	HelmDriver          string `envconfig:"default=secrets"`
+	RepositoryCachePath string `envconfig:"default=/tmp/helm"`
+	Output              struct {
+		HelmReleaseFilePath string `envconfig:"default=/tmp/helm-release.yaml"`
+		// Extracting resource metadata from Kubernetes as outputs
+		AdditionalFilePath string `envconfig:"default=/tmp/additional.yaml"`
+	}
+}
+
 func main() {
-	var cfg helm.Config
+	var cfg Config
 	err := envconfig.InitWithPrefix(&cfg, "RUNNER")
 	exitOnError(err, "while loading configuration")
 
 	stop := signals.SetupSignalHandler()
+	var k8sCfg *rest.Config
+	if cfg.KubeConfig != "" {
+		k8sCfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: cfg.KubeConfig},
+			&clientcmd.ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Server: "",
+				},
+				CurrentContext: "",
+			}).ClientConfig()
+	} else {
+		k8sCfg, err = config.GetConfig()
+	}
 
-	k8sCfg, err := config.GetConfig()
 	exitOnError(err, "while creating k8s config")
 
-	helmRunner := helm.NewRunner(k8sCfg, cfg)
+	helmConfig := helm.Config{
+		Command:             cfg.Command,
+		HelmReleasePath:     cfg.HelmReleasePath,
+		HelmDriver:          cfg.HelmDriver,
+		RepositoryCachePath: cfg.RepositoryCachePath,
+		Output:              cfg.Output,
+	}
+	helmRunner := helm.NewRunner(k8sCfg, helmConfig)
 
 	statusReporter := statusreporter.NewNoop()
 


### PR DESCRIPTION
## Helm-runner to take kubeconfig as argument

Changes proposed in this pull request:

- Extend the helm runner cli to take kubeconfig as argument

## Related issue(s)

https://github.com/capactio/capact/issues/533