### PR TITLE
Bump argo image version to v3.2.2

### DIFF
--- a/deploy/kubernetes/charts/argo/values.yaml
+++ b/deploy/kubernetes/charts/argo/values.yaml
@@ -4,6 +4,17 @@ argo-workflows:
     pullPolicy: IfNotPresent
   controller:
     containerRuntimeExecutor: pns
+    image:
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "v3.2.2"
+  executor:
+    image:
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "v3.2.2"
+  server:
+    image:
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: "v3.2.2"
 
   useDefaultArtifactRepo: true
   artifactRepository:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Bump argo image version to v3.2.2 due to https://github.com/argoproj/argo-workflows/issues/6194


We also had an old problem, if you will not set the new version in `values.yaml` file the upgrade will use the old version. Issue was already described here: [Only the old values.yaml is used instead of merging them with new ones](https://github.com/capactio/capact/issues/360)

