### PR TITLE
Fix `hack/eks/install.sh` and add server auth mod for Argo

### DIFF
--- a/deploy/kubernetes/charts/argo/values.yaml
+++ b/deploy/kubernetes/charts/argo/values.yaml
@@ -15,6 +15,10 @@ argo-workflows:
     image:
       # Overrides the image tag whose default is the chart appVersion.
       tag: "v3.2.2"
+    extraArgs:
+      # https://argoproj.github.io/argo-workflows/argo-server-auth-mode/
+      # when server is exposed we don't need to provide token
+      - --auth-mode=server
 
   useDefaultArtifactRepo: true
   artifactRepository:

--- a/hack/eks/install.sh
+++ b/hack/eks/install.sh
@@ -77,7 +77,7 @@ capact::aws::install::capact() {
   shout "Deploying Capact..."
   capact install --environment eks \
     --version "${CAPACT_VERSION}" \
-    --capact-overrides "global.domainName=${CAPACT_DOMAIN_NAME}" \
+    --capact-overrides "global.domainName=${CAPACT_DOMAIN_NAME},gateway.ingress.annotations.class=capact" \
     --cert-manager-overrides "${CUSTOM_CERT_MANAGER_OVERRIDES}"
 
   shout "Capact deployed successfully!"

--- a/hack/eks/install.sh
+++ b/hack/eks/install.sh
@@ -127,12 +127,12 @@ capact::aws::register_dnses() {
     exit 1
   fi
 
-  local -r internal_lb_hosted_zone="$(aws elb describe-load-balancers \
+  local -r internal_lb_hosted_zone="$(aws elb describe-load-balancers --region "${CAPACT_REGION}" \
     | jq -r ".LoadBalancerDescriptions[] \
       | select(.DNSName == \"${internal_lb_fqdn}\") \
       | .CanonicalHostedZoneNameID")"
 
-  local -r external_lb_hosted_zone="$(aws elb describe-load-balancers \
+  local -r external_lb_hosted_zone="$(aws elb describe-load-balancers --region "${CAPACT_REGION}" \
     | jq -r ".LoadBalancerDescriptions[] \
       | select(.DNSName == \"${external_lb_fqdn}\") \
       | .CanonicalHostedZoneNameID")"

--- a/hack/eks/public-ingress-controller/install.sh
+++ b/hack/eks/public-ingress-controller/install.sh
@@ -14,7 +14,7 @@ readonly CURRENT_DIR
 readonly REPO_ROOT_DIR
 readonly K8S_DEPLOY_DIR="${REPO_ROOT_DIR}/deploy/kubernetes"
 
-helm upgrade public-ingress-nginx "${K8S_DEPLOY_DIR}/charts/ingress-nginx" \
+helm upgrade public-ingress-nginx "${K8S_DEPLOY_DIR}/charts/ingress-controller" \
     --install \
     --namespace="capact-system" \
     --values "${CURRENT_DIR}/values.yml" \

--- a/hack/eks/terraform/templates/bastion_userdata.sh.tpl
+++ b/hack/eks/terraform/templates/bastion_userdata.sh.tpl
@@ -44,7 +44,7 @@ helm version
 echo "source <(helm completion bash)" >> /home/${capact_user}/.bashrc
 
 # download argo
-curl -sLO "https://github.com/argoproj/argo/releases/download/v2.12.11/argo-linux-amd64.gz"
+curl -sLO "https://github.com/argoproj/argo/releases/download/v3.2.3/argo-linux-amd64.gz"
 gunzip argo-linux-amd64.gz
 chmod +x argo-linux-amd64
 mv ./argo-linux-amd64 /usr/local/bin/argo

--- a/hack/eks/terraform/variables.tf
+++ b/hack/eks/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "domain_name" {
 }
 
 variable "capact_cli_version" {
-  default     = "v0.3.0"
+  default     = "v0.5.0"
   description = "Version of the Capact CLI binary, installed on the bastion host"
 }
 

--- a/hack/eks/terraform/variables.tf
+++ b/hack/eks/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "vpc_single_nat_gateway" {
 }
 
 variable "eks_cluster_version" {
-  default     = "1.18"
+  default     = "1.20"
   description = "Version of the EKS cluster"
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix ingress controller Helm chart path
- Gateway Ingress was manged by public ingress controller, where the entry in Route 53 is hard-coded to the internal ELB. The reason was the lack of `gateway.ingress.annotations.class=capact` override during install.
- Add missing region to aws CLI
- Bump EKS version to be compatible with Capact. Currently, you will get such error:
    ```bash
     ✗ Installing capact Helm chart
    Error: All attempts fail:
    #1: while installing Helm chart [capact]: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
    #2: while installing Helm chart [capact]: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
    #3: while installing Helm chart [capact]: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
    ```
- The Argo server used to start with auth mode of "server" by default, but since v3.0 it defaults to the "client". As a result, you need to always pass the token (first generate it via SA). I changed it back to `server` as we don't expose Argo publically. 

