### PR TITLE
Add Interface inlined JSONSchema validator

### DIFF
--- a/pkg/sdk/validation/manifest/fsvalidator.go
+++ b/pkg/sdk/validation/manifest/fsvalidator.go
@@ -29,6 +29,9 @@ func NewDefaultFilesystemValidator(fs http.FileSystem, ocfSchemaRootPath string,
 			types.TypeManifestKind: {
 				NewTypeValidator(),
 			},
+			types.InterfaceManifestKind: {
+				NewInterfaceValidator(),
+			},
 		},
 	}
 

--- a/pkg/sdk/validation/manifest/fsvalidator_test.go
+++ b/pkg/sdk/validation/manifest/fsvalidator_test.go
@@ -74,7 +74,7 @@ func TestFilesystemValidator_ValidateFile(t *testing.T) {
 				manifestRef("cap.type.productivity.mattermost.config"):        true,
 			}, nil),
 		},
-		"Invalid JSONSchema in Interface": {
+		"Invalid JSON Schema in Interface": {
 			manifestPath: "testdata/invalid-interface_json-schema.yaml",
 			expectedValidationErrorMsgs: []string{
 				"InterfaceValidator: properties.config.type: Must validate at least one schema (anyOf)",

--- a/pkg/sdk/validation/manifest/fsvalidator_test.go
+++ b/pkg/sdk/validation/manifest/fsvalidator_test.go
@@ -74,6 +74,13 @@ func TestFilesystemValidator_ValidateFile(t *testing.T) {
 				manifestRef("cap.type.productivity.mattermost.config"):        true,
 			}, nil),
 		},
+		"Invalid JSONSchema in Interface": {
+			manifestPath: "testdata/invalid-interface_json-schema.yaml",
+			expectedValidationErrorMsgs: []string{
+				"InterfaceValidator: properties.config.type: Must validate at least one schema (anyOf)",
+				`InterfaceValidator: properties.config.type: properties.config.type must be one of the following: "array", "boolean", "integer", "null", "number", "object", "string"`,
+			},
+		},
 		"Invalid JSON Schema in Type": {
 			manifestPath: "testdata/invalid-type_json-schema.yaml",
 			expectedValidationErrorMsgs: []string{

--- a/pkg/sdk/validation/manifest/helpers.go
+++ b/pkg/sdk/validation/manifest/helpers.go
@@ -1,0 +1,36 @@
+package manifest
+
+import (
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// jsonSchemaCollection defines JSONSchema collection index by the name
+type jsonSchemaCollection map[string]string
+
+// validateJSONSchema07Definition validate a given JSONSchema collection.
+// Fast return on internal error, otherwise returns aggregated ValidationResult for all schemas.
+func validateJSONSchema07Definition(schemas jsonSchemaCollection) (ValidationResult, error) {
+	result := ValidationResult{}
+
+	schemaLoader := gojsonschema.NewReferenceLoader("http://json-schema.org/draft-07/schema")
+	schemaDraft07, err := gojsonschema.NewSchema(schemaLoader)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+
+	for name, schema := range schemas {
+		manifestLoader := gojsonschema.NewStringLoader(schema)
+
+		jsonSchemaValidationResult, err := schemaDraft07.Validate(manifestLoader)
+		if err != nil {
+			return newValidationResult(errors.Wrap(err, name)), nil
+		}
+
+		for _, err := range jsonSchemaValidationResult.Errors() {
+			result.Errors = append(result.Errors, errors.New(err.String()))
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/sdk/validation/manifest/helpers.go
+++ b/pkg/sdk/validation/manifest/helpers.go
@@ -5,7 +5,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// jsonSchemaCollection defines JSONSchema collection index by the name
+// jsonSchemaCollection defines JSONSchema collection index by the name.
 type jsonSchemaCollection map[string]string
 
 // validateJSONSchema07Definition validate a given JSONSchema collection.

--- a/pkg/sdk/validation/manifest/json_interface.go
+++ b/pkg/sdk/validation/manifest/json_interface.go
@@ -1,0 +1,49 @@
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+
+	"github.com/pkg/errors"
+)
+
+// InterfaceValidator is a validator for Interface manifest, which executes static validation.
+type InterfaceValidator struct{}
+
+// NewInterfaceValidator creates new ImplementationValidator.
+func NewInterfaceValidator() *InterfaceValidator {
+	return &InterfaceValidator{}
+}
+
+// Do is a method which triggers the validation.
+func (v *InterfaceValidator) Do(_ context.Context, _ types.ManifestMetadata, jsonBytes []byte) (ValidationResult, error) {
+	var entity types.Interface
+	err := json.Unmarshal(jsonBytes, &entity)
+	if err != nil {
+		return ValidationResult{}, errors.Wrap(err, "while unmarshalling JSON into Interface type")
+	}
+
+	if entity.Spec.Input.Parameters == nil {
+		return ValidationResult{}, nil
+	}
+
+	toValidate := jsonSchemaCollection{}
+	for name, param := range entity.Spec.Input.Parameters.ParametersParameterMap {
+		if param.JSONSchema == nil {
+			continue
+		}
+
+		key := fmt.Sprintf("spec.input.parameters.%s.jsonSchema.value", name)
+		toValidate[key] = param.JSONSchema.Value
+	}
+
+	return validateJSONSchema07Definition(toValidate)
+}
+
+// Name returns the validator name.
+func (v *InterfaceValidator) Name() string {
+	return "InterfaceValidator"
+}

--- a/pkg/sdk/validation/manifest/json_type.go
+++ b/pkg/sdk/validation/manifest/json_type.go
@@ -3,11 +3,10 @@ package manifest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+
 	"github.com/pkg/errors"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 // TypeValidator is a validator for Type manifest.
@@ -26,21 +25,9 @@ func (v *TypeValidator) Do(_ context.Context, _ types.ManifestMetadata, jsonByte
 		return ValidationResult{}, errors.Wrap(err, "while unmarshalling JSON into Type type")
 	}
 
-	jsonSchemaStr := typeEntity.Spec.JSONSchema.Value
-	schemaLoader := gojsonschema.NewReferenceLoader("http://json-schema.org/draft-07/schema")
-	manifestLoader := gojsonschema.NewStringLoader(jsonSchemaStr)
-
-	jsonSchemaValidationResult, err := gojsonschema.Validate(schemaLoader, manifestLoader)
-	if err != nil {
-		return newValidationResult(errors.Wrap(err, "spec.jsonSchema.value")), nil
-	}
-
-	result := ValidationResult{}
-	for _, err := range jsonSchemaValidationResult.Errors() {
-		result.Errors = append(result.Errors, fmt.Errorf("%v", err.String()))
-	}
-
-	return result, nil
+	return validateJSONSchema07Definition(jsonSchemaCollection{
+		"spec.jsonSchema.value": typeEntity.Spec.JSONSchema.Value,
+	})
 }
 
 // Name returns the validator name.

--- a/pkg/sdk/validation/manifest/testdata/invalid-interface_json-schema.yaml
+++ b/pkg/sdk/validation/manifest/testdata/invalid-interface_json-schema.yaml
@@ -18,10 +18,6 @@ spec:
   input:
     parameters:
       input-parameters:
-        typeRef:
-          path: cap.type.productivity.mattermost.install-input
-          revision: 0.1.0
-      additional-parameters:
         jsonSchema:
           #
           # Invalid type of config property
@@ -37,12 +33,13 @@ spec:
               "properties": {
                 "config": {
                   "$id": "#/properties/config",
-                  "type": "object",
+                  "type": "mixin",
                   "title": "Contains Kubernetes kubeconfig"
                 }
               },
               "additionalProperties": false
             }
+
 
   output:
     typeInstances:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add Interface inlined JSONSchema validator

## Testing

Implemented logic is covered with unit-test. To test it locally, run:

1. Checkout this branch and build CLI:

    ```bash
    gh pr checkout -R capactio/capact 550
    ```

    ```bash
    make build-tool-cli
    ```

1. Clone `hub-manifests` repo:

   ```bash
   gh repo clone capactio/hub-manifests
   ```

1. Execute manifest validate (without `server-side`):

    ```bash
    capact manifest validate {HUB_MANIFEST_REPO_PATH}/manifests/**/*.yaml
    ```

1. Introduce error in Interface JSONSchema:

   Change in `/manifests/interface/capactio/capact/validation/action/update.yaml` property **type** to e.g. `hakuna-matata` instead of `string`.

1. Execute validate once again:

    ```bash
    capact manifest validate {HUB_MANIFEST_REPO_PATH}/manifests/**/*.yaml
    Validating files in 5 concurrent jobs...
    - ✗ "./manifests/interface/capactio/capact/validation/action/update.yaml":
        * InterfaceValidator: properties.testString.type: Must validate at least one schema (anyOf)
        * InterfaceValidator: properties.testString.type: properties.testString.type must be one of the following: "array", "boolean", "integer", "null", "number", "object", "string"
    
    
    Validated 162 files in total.
    Error: detected 2 validation errors
    ```

## Related issue(s)

- https://github.com/capactio/capact/issues/487
