### PR TITLE
Add fixed k3d version used for docker images

### DIFF
--- a/cmd/cli/cmd/environment/create/k3d.go
+++ b/cmd/cli/cmd/environment/create/k3d.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/capact"
 	"capact.io/capact/internal/cli/environment/create"
 	"capact.io/capact/internal/cli/printer"
@@ -27,6 +28,11 @@ func NewK3d() *cobra.Command {
 	k3d.Short = "Provision local k3d cluster"
 	// Needs to be `PersistentPreRunE` as the `PreRunE` is used by k3d to configure viper config.
 	k3d.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// 0. Configure logger for tracing
+		if cli.VerboseMode.IsTracing() {
+			logrus.SetLevel(logrus.TraceLevel)
+		}
+
 		spinnerFmt := printer.NewLogrusSpinnerFormatter(fmt.Sprintf("Creating cluster %s...", opts.Name))
 		logrus.SetFormatter(spinnerFmt)
 

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -4,20 +4,20 @@ import (
 	"log"
 	"strings"
 
+	"capact.io/capact/cmd/cli/cmd/action"
 	"capact.io/capact/cmd/cli/cmd/alpha"
+	configcmd "capact.io/capact/cmd/cli/cmd/config"
 	"capact.io/capact/cmd/cli/cmd/environment"
+	"capact.io/capact/cmd/cli/cmd/hub"
 	"capact.io/capact/cmd/cli/cmd/manifest"
 	"capact.io/capact/cmd/cli/cmd/policy"
-
-	"capact.io/capact/cmd/cli/cmd/action"
-	configcmd "capact.io/capact/cmd/cli/cmd/config"
-	"capact.io/capact/cmd/cli/cmd/hub"
 	"capact.io/capact/cmd/cli/cmd/typeinstance"
 	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/config"
 	"capact.io/capact/internal/cli/heredoc"
 
 	"github.com/common-nighthawk/go-figure"
+	k3dver "github.com/rancher/k3d/v4/version"
 	"github.com/spf13/cobra"
 )
 
@@ -101,6 +101,11 @@ func NewRoot() *cobra.Command {
 }
 
 func initConfig() {
+	// Needs to be in sync with version in `go.mod`
+	// By default is empty which results in selecting the `latest` tag
+	// for Docker images used by k3d, e.g., rancher/k3d-proxy or rancher/k3d-tools etc.
+	k3dver.Version = "v4.4.8"
+
 	err := config.Init(configPath)
 	exitOnError(err)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

As a part of https://github.com/capactio/capact/issues/492 I discovered that the `capact env create k3d` doesn't work. 

- It worked properly with the v4 — at the time when `capact env create k3d` was introduced, it was also the latest release.
- It worked on my machine, as I had the old version of the `k3d-proxy:latest` and it was using it instead of pulling a new one.

The problematic part, was that the `k3d` go lib in version v4 was creating a docker container from the  `k3d-proxy:latest` image instead of `k3d-proxy:v4.4.8`. The `latest` tag was selected as the `github.com/rancher/k3d/v4/version.Version` was not set.

In the `k3d-proxy:latest` image they change the way how the config is loaded, from the `env` to `file` backend  (since v5 version, which is the latest one right now). This resulted in error:
```
Node 'k3d-k3d-ci-capact-serverlb' is restarting for more than a minute now. Possibly it will recover soon (e.g. when it's waiting to join). Consider using a creation timeout to avoid waiting forever in a Restart Loop. [started 22:04 UTC]
```
and from `serverlb` container logs:
```bash
C[2021-11-17T11:29:12+0000] creating initial nginx config (try 1/3)
T2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: INFO Backend set to file
O2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: INFO Starting confd
p2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: INFO Backend source(s) set to /etc/confd/values.yaml
t2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: DEBUG Loading template resources from confdir /etc/confd
n2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: DEBUG Found template: /etc/confd/conf.d/nginx.toml
}2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: DEBUG Loading template resource from /etc/confd/conf.d/nginx.toml
\2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: DEBUG Retrieving keys from store
U2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: DEBUG Key prefix set to /
x2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: ERROR stat /etc/confd/values.yaml: no such file or directory
x2021-11-17T11:29:12Z k3d-k3d-ci-capact-serverlb confd[10]: FATAL stat /etc/confd/values.yaml: no such file or directory
```

Changes proposed in this pull request:

- Add fixed k3d version used for docker images
- Set the trace for logrus when `-v=trace` is used


## Related issue(s)

- https://github.com/capactio/capact/issues/492
- Fix https://github.com/capactio/capact/issues/567