### PR TITLE
Support GET requests and token auth in GitLab runner

### DIFF
--- a/pkg/runner/gitlab-api-runner/runner.go
+++ b/pkg/runner/gitlab-api-runner/runner.go
@@ -42,10 +42,11 @@ func (r *RESTRunner) Do(ctx context.Context, in runner.StartInput) (*runner.Wait
 	}
 
 	req, err := git.NewRequest(input.Args.Method, input.Args.Path, input.Args.RequestBody, nil)
-	req.WithContext(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "while creating request")
 	}
+
+	req.WithContext(ctx)
 
 	rawBody := map[string]interface{}{}
 	_, err = git.Do(req, &rawBody)
@@ -95,7 +96,7 @@ func (r *RESTRunner) readInputData(in runner.StartInput) (Input, error) {
 	var args Arguments
 	err := yaml.Unmarshal(in.Args, &args)
 	if err != nil {
-		return Input{}, errors.Wrap(err, "while unmarshaling runner arguments")
+		return Input{}, errors.Wrap(err, "while unmarshalling runner arguments")
 	}
 
 	return Input{

--- a/pkg/runner/gitlab-api-runner/runner.go
+++ b/pkg/runner/gitlab-api-runner/runner.go
@@ -43,7 +43,11 @@ func (r *RESTRunner) Do(ctx context.Context, in runner.StartInput) (*runner.Wait
 
 	req.WithContext(ctx)
 
-	rawBody := map[string]interface{}{}
+	if input.Args.QueryParameters != nil {
+		req.URL.RawQuery = input.Args.QueryParameters.Encode()
+	}
+
+	var rawBody interface{}
 	_, err = git.Do(req, &rawBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "while executing request")
@@ -122,7 +126,7 @@ func (r *RESTRunner) gitlabClientForAuth(auth Auth, opts []gitlab.ClientOptionFu
 	return nil, errors.New("no token or basic credentials provided")
 }
 
-func (r *RESTRunner) renderOutput(artifactTemplate string, data map[string]interface{}) ([]byte, error) {
+func (r *RESTRunner) renderOutput(artifactTemplate string, data interface{}) ([]byte, error) {
 	if artifactTemplate == "" {
 		return []byte{}, nil
 	}

--- a/pkg/runner/gitlab-api-runner/runner.go
+++ b/pkg/runner/gitlab-api-runner/runner.go
@@ -105,8 +105,14 @@ func (r *RESTRunner) readInputData(in runner.StartInput) (Input, error) {
 }
 
 func (r *RESTRunner) gitlabClientForAuth(auth Auth, opts []gitlab.ClientOptionFunc) (*gitlab.Client, error) {
-	// access token
 	token := auth.Token
+	basic := auth.Basic
+
+	if token != nil && basic != nil {
+		return nil, errors.New("both token and basic credentials must not be provided")
+	}
+
+	// access token
 	if token != nil {
 		return gitlab.NewClient(
 			*token,
@@ -115,10 +121,10 @@ func (r *RESTRunner) gitlabClientForAuth(auth Auth, opts []gitlab.ClientOptionFu
 	}
 
 	// basic credentials
-	if auth.Basic != nil {
+	if basic != nil {
 		return gitlab.NewBasicAuthClient(
-			auth.Basic.Username,
-			auth.Basic.Password,
+			basic.Username,
+			basic.Password,
 			opts...,
 		)
 	}

--- a/pkg/runner/gitlab-api-runner/types.go
+++ b/pkg/runner/gitlab-api-runner/types.go
@@ -1,6 +1,10 @@
 package gitlabapi
 
-import "capact.io/capact/pkg/runner"
+import (
+	"net/url"
+
+	"capact.io/capact/pkg/runner"
+)
 
 // Config holds RESTRunner related configuration.
 type Config struct {
@@ -18,12 +22,13 @@ type Input struct {
 
 // Arguments stores the input arguments for the GitLab API runner operation.
 type Arguments struct {
-	Method      string                  `json:"method"`
-	Path        string                  `json:"path"`
-	RequestBody *map[string]interface{} `json:"body"`
-	BaseURL     string                  `json:"baseURL"`
-	Auth        Auth                    `json:"auth"`
-	Output      OutputArgs              `json:"output"`
+	Method          string                  `json:"method"`
+	Path            string                  `json:"path"`
+	RequestBody     *map[string]interface{} `json:"body"`
+	QueryParameters *url.Values             `json:"queryParameters"`
+	BaseURL         string                  `json:"baseURL"`
+	Auth            Auth                    `json:"auth"`
+	Output          OutputArgs              `json:"output"`
 }
 
 // Auth holds auth data for GitLab API.

--- a/pkg/runner/gitlab-api-runner/types.go
+++ b/pkg/runner/gitlab-api-runner/types.go
@@ -27,12 +27,15 @@ type Arguments struct {
 }
 
 // Auth holds auth data for GitLab API.
-// TODO: add token support
 type Auth struct {
-	Basic struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
-	} `json:"basic"`
+	Basic *BasicAuth `json:"basic"`
+	Token *string    `json:"token"`
+}
+
+// BasicAuth holds basic auth data.
+type BasicAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // OutputArgs stores input arguments for generating the output artifacts.

--- a/pkg/runner/gitlab-api-runner/types.go
+++ b/pkg/runner/gitlab-api-runner/types.go
@@ -18,12 +18,12 @@ type Input struct {
 
 // Arguments stores the input arguments for the GitLab API runner operation.
 type Arguments struct {
-	Method      string                 `json:"method"`
-	Path        string                 `json:"path"`
-	RequestBody map[string]interface{} `json:"body"`
-	BaseURL     string                 `json:"baseURL"`
-	Auth        Auth                   `json:"auth"`
-	Output      OutputArgs             `json:"output"`
+	Method      string                  `json:"method"`
+	Path        string                  `json:"path"`
+	RequestBody *map[string]interface{} `json:"body"`
+	BaseURL     string                  `json:"baseURL"`
+	Auth        Auth                    `json:"auth"`
+	Output      OutputArgs              `json:"output"`
 }
 
 // Auth holds auth data for GitLab API.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix GitLab API Runner panic when provided body is empty
- Fix panic when created request is nil
- Support GET requests with query parameters
- Support personal token authentication in GitLab API Runner


## Testing

You can test it in isolation with the following input to the GitLab runner (see the [instruction](https://github.com/capactio/capact/blob/main/cmd/gitlab-api-runner/README.md):

```yaml
method: GET
path: "projects"
baseURL: "{baseURL}"
auth:
  token: "{token}"
body: null
queryParameters:
  simple: ["true"]
  search: ["{repo-path}"]
output:
  goTemplate: |
    id: {{ (index . 0).id }}
```