### PR TITLE
Enable CORS for Capact Gateway Ingress

### DIFF
--- a/deploy/kubernetes/charts/capact/charts/gateway/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/capact/charts/gateway/templates/ingress.yaml
@@ -10,9 +10,11 @@ metadata:
     kubernetes.io/tls-acme: "{{ .Values.ingress.annotations.tls_acme }}"
     cert-manager.io/cluster-issuer: "{{ .Values.ingress.annotations.issuer }}"
     acmechallengetype: "{{ .Values.ingress.annotations.acmechallengetype }}"
-    nginx.ingress.kubernetes.io/enable-cors: "{{ .Values.ingress.annotations.cors.enable }}"
+    {{- if .Values.ingress.annotations.cors.enabled }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "{{ .Values.ingress.annotations.cors.allowMethods }}"
     nginx.ingress.kubernetes.io/cors-allow-origin: "{{ .Values.ingress.annotations.cors.allowOrigins }}"
+    {{- end }}
 spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:

--- a/deploy/kubernetes/charts/capact/charts/gateway/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/capact/charts/gateway/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     kubernetes.io/tls-acme: "{{ .Values.ingress.annotations.tls_acme }}"
     cert-manager.io/cluster-issuer: "{{ .Values.ingress.annotations.issuer }}"
     acmechallengetype: "{{ .Values.ingress.annotations.acmechallengetype }}"
+    nginx.ingress.kubernetes.io/enable-cors: "{{ .Values.ingress.annotations.cors.enable }}"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "{{ .Values.ingress.annotations.cors.allowMethods }}"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "{{ .Values.ingress.annotations.cors.allowOrigins }}"
 spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:

--- a/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
@@ -62,6 +62,10 @@ ingress:
     class: "nginx"
     issuer: "letsencrypt"
     acmechallengetype: "http01"
+    cors:
+      enable: "true"
+      allowMethods: "HEAD, GET, POST, OPTIONS"
+      allowOrigins: "*"
 
   host: "gateway"
 

--- a/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
@@ -63,7 +63,7 @@ ingress:
     issuer: "letsencrypt"
     acmechallengetype: "http01"
     cors:
-      enable: "true"
+      enabled: false
       allowMethods: "HEAD, GET, POST, OPTIONS"
       allowOrigins: "*"
 

--- a/internal/cli/capact/defaults.go
+++ b/internal/cli/capact/defaults.go
@@ -58,6 +58,11 @@ cert-manager:
 	capactLocalClusterOverridesYAML = `
 global:
   domainName: "capact.local"
+gateway:
+  ingress:
+    annotations:
+      cors:
+        enabled: true
 `
 )
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Enable CORS for Capact Gateway Ingress

It enables Gateway GraphQL API to be consumed by UIs deployed anywhere by default only for local installation.

- [x] To discuss, which default values should we set: should we enable CORS by default and allow all origins? Or keep such overrides for local Capact for convenience if someone wants to develop UI for it?
