### PR TITLE
Support for validate the whole hub manifest

### DIFF
--- a/cmd/cli/cmd/manifest/validate.go
+++ b/cmd/cli/cmd/manifest/validate.go
@@ -24,10 +24,10 @@ func NewValidate() *cobra.Command {
 			<cli> manifest validate ocf-spec/0.0.1/examples/interface-group.yaml
 
 			# Validate multiple files inside test_manifests directory with additional server-side checks
-			<cli> manifest validate --server-side pkg/cli/test_manifests/*.yaml
+			<cli> manifest validate --server-side pkg/cli/test_manifests/
 
 			# Validate all Hub manifests with additional server-side checks
-			<cli> manifest validate --server-side ./manifests/**/*.yaml
+			<cli> manifest validate --server-side ./manifests/ --recursive
 			
 			# Validate interface-group.yaml file with custom OCF specification location 
 			<cli> manifest validate -s my/ocf/spec/directory ocf-spec/0.0.1/examples/interface-group.yaml`, cli.Name),
@@ -37,13 +37,13 @@ func NewValidate() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
 			return validation.Run(cmd.Context(), args)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.SchemaLocation, "schemas", "s", "", "Path to the local directory with OCF JSONSchemas. If not provided, built-in JSONSchemas are used.")
+	flags.BoolVarP(&opts.RecursiveSearch, "recursive", "r", false, "Search files under each directory, recursively.")
 	flags.BoolVar(&opts.ServerSide, "server-side", false, "Executes additional manifests checks against Capact Hub.")
 	flags.IntVar(&opts.MaxConcurrency, "concurrency", defaultMaxConcurrency, "Maximum number of concurrent workers.")
 

--- a/cmd/cli/docs/capact_manifest_validate.md
+++ b/cmd/cli/docs/capact_manifest_validate.md
@@ -17,10 +17,10 @@ capact manifest validate [flags]
 capact manifest validate ocf-spec/0.0.1/examples/interface-group.yaml
 
 # Validate multiple files inside test_manifests directory with additional server-side checks
-capact manifest validate --server-side pkg/cli/test_manifests/*.yaml
+capact manifest validate --server-side pkg/cli/test_manifests/
 
 # Validate all Hub manifests with additional server-side checks
-capact manifest validate --server-side ./manifests/**/*.yaml
+capact manifest validate --server-side ./manifests/ --recursive
 
 # Validate interface-group.yaml file with custom OCF specification location 
 capact manifest validate -s my/ocf/spec/directory ocf-spec/0.0.1/examples/interface-group.yaml
@@ -31,6 +31,7 @@ capact manifest validate -s my/ocf/spec/directory ocf-spec/0.0.1/examples/interf
 ```
       --concurrency int   Maximum number of concurrent workers. (default 5)
   -h, --help              help for validate
+  -r, --recursive         Search files under each directory, recursively.
   -s, --schemas string    Path to the local directory with OCF JSONSchemas. If not provided, built-in JSONSchemas are used.
       --server-side       Executes additional manifests checks against Capact Hub.
 ```

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -195,13 +195,16 @@ func (v *Validation) getFilesToParse(paths []string) ([]string, error) {
 	var files []string
 
 	for _, path := range paths {
-		if !isDir(path) {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !fileInfo.IsDir() {
 			files = append(files, path)
 			continue
 		}
 
 		var fileList []string
-		var err error
 		if v.recursiveSearch {
 			fileList, err = getListOfFilesRecursive(path, isCorrectExtension)
 		} else {
@@ -246,7 +249,11 @@ func getListOfFilesFromSingleDir(path string, filterFn filterFun) ([]string, err
 
 	for _, name := range fileNames {
 		fullPath := filepath.Join(path, name)
-		if isDir(fullPath) || !filterFn(fullPath) {
+		fileInfo, err := os.Stat(fullPath)
+		if err != nil {
+			return nil, err
+		}
+		if fileInfo.IsDir() || !filterFn(fullPath) {
 			continue
 		}
 		files = append(files, fullPath)
@@ -265,11 +272,6 @@ func removeDuplicatePaths(paths []string) []string {
 		result = append(result, path)
 	}
 	return result
-}
-
-func isDir(in string) bool {
-	f, err := os.Stat(in)
-	return err == nil && f.IsDir()
 }
 
 func isCorrectExtension(path string) bool {

--- a/internal/cli/validate/validate_test.go
+++ b/internal/cli/validate/validate_test.go
@@ -3,8 +3,6 @@ package validate_test
 import (
 	"context"
 	"io/ioutil"
-	"path"
-	"strings"
 	"testing"
 
 	"capact.io/capact/internal/cli/validate"
@@ -18,22 +16,9 @@ func TestValidation_Run_SmokeTest(t *testing.T) {
 	require.NoError(t, err)
 
 	pathToExamples := "../../../ocf-spec/0.0.1/examples"
-	files, err := ioutil.ReadDir(pathToExamples)
-	require.NoError(t, err)
-
-	var filePaths []string
-	for _, file := range files {
-		if file.IsDir() || !strings.HasSuffix(file.Name(), ".yaml") {
-			continue
-		}
-
-		filePaths = append(filePaths, path.Join(pathToExamples, file.Name()))
-	}
-
-	require.True(t, len(filePaths) > 0)
 
 	// when
-	err = validation.Run(context.Background(), filePaths)
+	err = validation.Run(context.Background(), []string{pathToExamples})
 
 	// then
 	assert.NoError(t, err)
@@ -45,8 +30,6 @@ func TestValidation_NoFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	filePaths := []string{"/this/file/doesnt/exist", "/same/here"}
-
-	require.True(t, len(filePaths) > 0)
 
 	// when
 	err = validation.Run(context.Background(), filePaths)

--- a/internal/cli/validate/validate_test.go
+++ b/internal/cli/validate/validate_test.go
@@ -1,6 +1,7 @@
 package validate_test
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"testing"
@@ -37,4 +38,36 @@ func TestValidation_NoFiles(t *testing.T) {
 	// then
 	assert.Error(t, err)
 	assert.EqualError(t, err, "detected 2 validation errors")
+}
+
+func TestValidation_NoRecursive(t *testing.T) {
+	// given
+	var buff = &bytes.Buffer{}
+	validation, err := validate.New(buff, validate.Options{MaxConcurrency: 5, RecursiveSearch: false})
+	require.NoError(t, err)
+
+	pathToExamples := "../../../ocf-spec/0.0.1"
+
+	// when
+	err = validation.Run(context.Background(), []string{pathToExamples})
+
+	// then
+	assert.NoError(t, err)
+	assert.Contains(t, buff.String(), "Validated 0 files in total")
+}
+
+func TestValidation_Recursive(t *testing.T) {
+	// given
+	var buff = &bytes.Buffer{}
+	validation, err := validate.New(buff, validate.Options{MaxConcurrency: 5, RecursiveSearch: true})
+	require.NoError(t, err)
+
+	pathToExamples := "../../../ocf-spec/0.0.1/"
+
+	// when
+	err = validation.Run(context.Background(), []string{pathToExamples})
+
+	// then
+	assert.NoError(t, err)
+	assert.Contains(t, buff.String(), "Validated 7 files in total")
 }

--- a/internal/cli/validate/validate_test.go
+++ b/internal/cli/validate/validate_test.go
@@ -37,7 +37,7 @@ func TestValidation_NoFiles(t *testing.T) {
 
 	// then
 	assert.Error(t, err)
-	assert.EqualError(t, err, "detected 2 validation errors")
+	assert.Contains(t, err.Error(), "no such file or directory")
 }
 
 func TestValidation_NoRecursive(t *testing.T) {


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- add a possibility to validate all files from a directory
- add a possibility to validate all files from a directory and subdirectories (recursive)

## Testing

1. Checkout this branch and build CLI:
```
gh pr checkout 574
```
```
make build-tool-cli
```
2. Clone `hub-manifests` repo:
```
gh repo clone capactio/hub-manifests
```
3. Execute manifest validate:
```
capact manifest validate {HUB_MANIFEST_REPO_PATH}/manifests/ -r 
```

All files from catalog `manifests` and subdirectories should be validated.
Execute the same command but without `-r` should validate 0 files. (as there is no file in that directory)


## Related issue(s)
Resolves #346

