### PR TITLE
Fix detecting invalid JSONSchemas

### DIFF
--- a/pkg/sdk/validation/manifest/fsvalidator_test.go
+++ b/pkg/sdk/validation/manifest/fsvalidator_test.go
@@ -91,7 +91,7 @@ func TestFilesystemValidator_ValidateFile(t *testing.T) {
 		"Invalid Type": {
 			manifestPath: "testdata/invalid-type.yaml",
 			expectedValidationErrorMsgs: []string{
-				"TypeValidator: spec.jsonSchema.value: invalid character '}' looking for beginning of object key string",
+				`TypeValidator: spec.jsonSchema.value: invalid JSON: invalid character '}' looking for beginning of object key string`,
 				"RemoteTypeValidator: manifest revision 'cap.core.sample.attr:0.1.0' doesn't exist in Hub",
 			},
 			hubCli: fixHub(t, map[graphql.ManifestReference]bool{

--- a/pkg/sdk/validation/manifest/schema_validate_test.go
+++ b/pkg/sdk/validation/manifest/schema_validate_test.go
@@ -1,0 +1,75 @@
+package manifest
+
+import (
+	"testing"
+
+	"capact.io/capact/internal/cli/heredoc"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateJSONSchema07DefinitionSuccess(t *testing.T) {
+	// given
+	validJSONSchema := heredoc.Doc(`
+			{
+			  "$schema": "http://json-schema.org/draft-07/schema",
+			  "type": "object",
+			  "required": [ "key" ],
+			  "properties": {
+				"key": {
+				  "type": "string"
+				}
+			  }
+			}`)
+
+	// when
+	res, err := validateJSONSchema07Definition(jsonSchemaCollection{
+		"valid-schema": validJSONSchema,
+	})
+
+	// then
+	require.NoError(t, err)
+	assert.Empty(t, res.Errors)
+}
+
+func TestValidateJSONSchema07DefinitionFailures(t *testing.T) {
+	tests := map[string]struct {
+		JSONSchema string
+		errMsg     string
+	}{
+		"Invalid JSONSchema": {
+			JSONSchema: `{ "invalid" - schema]`,
+			errMsg:     `schema-name: invalid JSON: invalid character '-' after object key`,
+		},
+		"Valid JSONSchema with appended random characters": {
+			JSONSchema: heredoc.Doc(`
+				{
+				  "$schema": "http://json-schema.org/draft-07/schema",
+				  "type": "object",
+				  "properties": {
+					"key": {
+					  "type": "string"
+					}
+				  }
+				}^&*()`),
+			errMsg: `schema-name: invalid JSON: invalid character '^' after top-level value`,
+		},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			// when
+			res, err := validateJSONSchema07Definition(jsonSchemaCollection{
+				"schema-name": tc.JSONSchema,
+			})
+
+			// then
+			require.NoError(t, err)
+
+			assert.False(t, res.Valid())
+
+			require.Len(t, res.Errors, 1)
+			assert.EqualError(t, res.Errors[0], tc.errMsg)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Fix detecting invalid JSONSchemas
- Add unit test coverage

## Testing

1. Execute current CLI version against `hub-manifest`:
    ```bash
    capact manifest validate {HUB_MANIFEST_REPO_PATH}/manifests/ -r 
    ```
1. Checkout this branch and build CLI:
    ```
    gh pr checkout 581
    ```
    ```
    make build-tool-cli
    ```
2. Execute CLI built from this PR once again:
    ```
    capact manifest validate {HUB_MANIFEST_REPO_PATH}/manifests/ -r 
    ```


