### PR TITLE
Fix releasing CLIs pipeline

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -184,12 +184,8 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Install upx 3.96
         run: |
-          # Install UPX
           wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
           tar -xf upx-3.96-amd64_linux.tar.xz
-
-          # Compress files
-          ./upx-3.96-amd64_linux/upx -V
           mv ./upx-3.96-amd64_linux/upx /usr/local/bin/upx
           upx -V
       - name: Set up GoReleaser

--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -182,8 +182,18 @@ jobs:
             ${{ runner.os }}-go-
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Install upx 3.96
+        run: |
+          # Install UPX
+          wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+          tar -xf upx-3.96-amd64_linux.tar.xz
+
+          # Compress files
+          ./upx-3.96-amd64_linux/upx -V
+          mv ./upx-3.96-amd64_linux/upx /usr/local/bin/upx
+          upx -V
       - name: Set up GoReleaser
-        run: go install github.com/goreleaser/goreleaser@v0.173.2
+        run: go install github.com/goreleaser/goreleaser@v1.1.0
       - name: Set up GCS
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Set up GoReleaser
-        run: go install github.com/goreleaser/goreleaser@v0.173.2
+        run: go install github.com/goreleaser/goreleaser@v1.1.0
       - name: Set up GCS
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -389,7 +389,7 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Set up GoReleaser
-        run: go install github.com/goreleaser/goreleaser@v0.173.2
+        run: go install github.com/goreleaser/goreleaser@v1.1.0
       - run: make build-tool-cli
       - name: Share Capact CLI for integration tests bootstrapping
         uses: actions/upload-artifact@v2

--- a/.github/workflows/recreate_cluster.yaml
+++ b/.github/workflows/recreate_cluster.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           go-version: ${{env.GO_VERSION}}
       - name: Set up GoReleaser
-        run: go install github.com/goreleaser/goreleaser@v0.173.2
+        run: go install github.com/goreleaser/goreleaser@v1.1.0
       - name: Delete old cluster
         env:
           OLD_CLUSTER_NAME: ${{ github.event.inputs.oldClusterToDelete }}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Use the UPX 3.96
- Use the GoReleaser 1.1.0 
- Update docs: https://github.com/capactio/website/pull/89

## Testing
I tested that on my fork: https://github.com/mszostok/capact/runs/4558596650?check_suite_focus=true

The problem was that the on [`ubuntu-latest` the latest UPX has 3.95 version](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)—in this version binaries compressed for macOS cannot be executed (https://github.com/upx/upx/issues/424)

## Related issue(s)

Fixes https://github.com/capactio/capact/issues/585
