### PR TITLE
Retry creating ClusterIssuer during Capact installation

### DIFF
--- a/internal/cli/capact/cert_manager.go
+++ b/internal/cli/capact/cert_manager.go
@@ -27,12 +27,12 @@ func ApplyClusterIssuer(ctx context.Context, config *rest.Config, new *certv1.Cl
 	err = retryCreatingClusterIssuer(ctx, cli, new)
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return err
+			return errors.Wrapf(err, "while creating the ClusterIssuer %q", new.Name)
 		}
 
 		err = retryUpdatingClusterIssuer(ctx, cli, new)
 		if err != nil {
-			return errors.Wrapf(err, "while updating the ClusterIssuer %s", new.Name)
+			return errors.Wrapf(err, "while updating the ClusterIssuer %q", new.Name)
 		}
 	}
 
@@ -56,7 +56,7 @@ func retryUpdatingClusterIssuer(ctx context.Context, cli certmanager.ClusterIssu
 	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
 		old, err := cli.Get(ctx, new.Name, metav1.GetOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "while getting the ClusterIssuer %s", old.Name)
+			return errors.Wrapf(err, "while getting the ClusterIssuer %q", old.Name)
 		}
 
 		old.Spec = new.Spec

--- a/internal/cli/capact/retry.go
+++ b/internal/cli/capact/retry.go
@@ -2,19 +2,21 @@ package capact
 
 import (
 	"github.com/avast/retry-go"
-	"github.com/pkg/errors"
 )
 
-// retryForFn retries failed function 4 times. The exponential retries are used: ~102ms ~302ms ~700ms 1.5s
-func retryForFn(fn retry.RetryableFunc) error {
-	err := retry.Do(
-		fn,
-		retry.Attempts(5),
-		retry.DelayType(retry.BackOffDelay),
-	)
-	if err != nil {
-		return errors.Wrap(err, "while waiting")
-	}
+// retryAttemptsCount defined number of retries of failed function.
+const retryAttemptsCount = 10
 
-	return nil
+// retryForFn retries failed function. The exponential retries are used: ~102ms ~302ms ~700ms 1.5s and so on.
+func retryForFn(fn retry.RetryableFunc, customOpts ...retry.Option) error {
+	opts := []retry.Option{
+		retry.Attempts(retryAttemptsCount),
+		retry.DelayType(retry.BackOffDelay),
+	}
+	opts = append(opts, customOpts...)
+
+	return retry.Do(
+		fn,
+		opts...,
+	)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Retry creating ClusterIssuer during Capact installation
- Increase number of waiting attempts

Issue discovered as a part of #584, and split to a separate PR as #584 is currently blocked. It happens randomly during Capact installation:

```
Error: while creating letsencrypt ClusterIssuer: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.capact-system.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority
```

Both on local machine and CI (example run: https://github.com/capactio/capact/runs/4534631664?check_suite_focus=true)

## Testing

I tested both installation (`DISABLE_MONITORING_INSTALLATION=true make dev-cluster`) and upgrade (`DISABLE_MONITORING_INSTALLATION=true make dev-cluster-upgrade`).