### PR TITLE
Bump Neo4j to 4.2.13 and apoc to 4.2.09

### DIFF
--- a/deploy/kubernetes/charts/neo4j/values.yaml
+++ b/deploy/kubernetes/charts/neo4j/values.yaml
@@ -9,7 +9,7 @@ neo4j:
         cpu: 400m
         memory: 2048Mi
   image: ghcr.io/capactio/neo4j
-  imageTag: 4.2.8-apoc
+  imageTag: 4.2.13-apoc
   neo4jPassword: okon
   readinessProbe:
     initialDelaySeconds: 10

--- a/hack/images/neo4j/Dockerfile
+++ b/hack/images/neo4j/Dockerfile
@@ -1,7 +1,7 @@
-FROM neo4j:4.2.8
+FROM neo4j:4.2.13
 
 ARG DESTINATION=/apoc.jar
-ARG PLUGIN_JAR_URL=https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/4.2.0.5/apoc-4.2.0.5-all.jar
+ARG PLUGIN_JAR_URL=https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/4.2.0.9/apoc-4.2.0.9-all.jar
 
 RUN wget -q --timeout 300 --tries 30 --output-document="${DESTINATION}" "${PLUGIN_JAR_URL}"
 

--- a/hack/images/neo4j/README.md
+++ b/hack/images/neo4j/README.md
@@ -2,12 +2,13 @@
 
 This folder contains Dockerfile which wraps official [Neo4j Docker image](https://hub.docker.com/_/neo4j/) and adds `apoc` plugin. As a result, when Neo4j container is started, plugin is not downloaded from the internet which allows air-gaped usage.
 
-The [`neo4jlabs-plugins.json`](./neo4jlabs-plugins.json) and [`docker-entrypoint.sh`](./docker-entrypoint.sh) were copied from [this](https://github.com/neo4j/docker-neo4j/pull/302) PR and adjusted for `apoc` plugin. We had to copy them as the 4.4 version was not yet release, but we want to re-use the option to load plugins from disk instead of downloading them from the internet each time.
+The [`neo4jlabs-plugins.json`](./neo4jlabs-plugins.json) and [`docker-entrypoint.sh`](./docker-entrypoint.sh) were copied from [this](https://github.com/neo4j/docker-neo4j/pull/302) PR and adjusted for `apoc` plugin. We had to copy them until we can upgrade to the 4.4 version (see [#584](https://github.com/capactio/capact/pull/584) to track progress), as we want to re-use the option to load plugins from disk instead of downloading them from the internet each time.
 
 To update our Neo4j image, run:
 ```bash
-docker build -t ghcr.io/capactio/neo4j:4.2.8-apoc .
-docker push ghcr.io/capactio/neo4j:4.2.8-apoc
+NEO4J_VERSION="4.2.13"
+docker build -t "ghcr.io/capactio/neo4j:${NEO4J_VERSION}-apoc" .
+docker push "ghcr.io/capactio/neo4j:${NEO4J_VERSION}-apoc"
 ```
 
 > **NOTE:** You need to be logged to ghcr.io.


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Bump Neo4j to 4.2.13 and apoc to 4.2.09

## Reason

https://neo4j.com/security/log4j/

Apoc plugin is not affected: https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/2393

## Related issue(s)

See also PR https://github.com/capactio/capact/pull/584

