### PR TITLE
Update runc Go dependency and Jinja2 templating base image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/opencontainers/runc v1.0.2 // indirect
+	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/k3d/v4 v4.4.8
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1332,8 +1332,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
-github.com/opencontainers/runc v1.0.2 h1:opHZMaswlyxz1OuGpBE53Dwe4/xF7EZTY0A2L/FpCOg=
-github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
+github.com/opencontainers/runc v1.0.3 h1:1hbqejyQWCJBvtKAfdO0b1FmaEf2z/bxnjqbARass5k=
+github.com/opencontainers/runc v1.0.3/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=

--- a/hack/images/jinja2/Dockerfile
+++ b/hack/images/jinja2/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:rc-alpine
+FROM python:3.10-alpine3.14
 
 # Create folders
 RUN mkdir /templates/ /variables/

--- a/hack/images/jinja2/Dockerfile
+++ b/hack/images/jinja2/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine3.14
+FROM python:3.10-alpine3.15
 
 # Create folders
 RUN mkdir /templates/ /variables/
@@ -10,7 +10,7 @@ ENV TEMPLATES_DIR /templates
 # Copy extra scripts: embedded render
 COPY jinja2-cli/ $SCRIPTS_DIR/jinja2-cli
 
-RUN pip3 install --no-cache-dir pip==21.1.1
+RUN pip3 install --no-cache-dir pip==21.3.1
 RUN pip3 install --no-cache-dir $SCRIPTS_DIR/jinja2-cli[yaml]
 
 ENTRYPOINT ["jinja2"]

--- a/hack/images/jinja2/jinja2-cli/jinja2cli/cli.py
+++ b/hack/images/jinja2/jinja2-cli/jinja2cli/cli.py
@@ -135,7 +135,7 @@ def _load_ini():
 def _load_yaml():
     import yaml
 
-    return yaml.load, yaml.YAMLError, MalformedYAML
+    return yaml.safe_load, yaml.YAMLError, MalformedYAML
 
 
 def _load_querystring():

--- a/hack/images/jinja2/jinja2-cli/setup.py
+++ b/hack/images/jinja2/jinja2-cli/setup.py
@@ -29,9 +29,9 @@ setup(
     license="BSD",
     install_requires=install_requires,
     extras_require={
-        "yaml": install_requires + ["pyyaml"],
-        "toml": install_requires + ["toml"],
-        "xml": install_requires + ["xmltodict"],
+        "yaml": install_requires + ["pyyaml~=6.0.0"],
+        "toml": install_requires + ["toml~=0.10.2"],
+        "xml": install_requires + ["xmltodict~=0.12.0"],
         "tests": install_requires + tests_requires,
     },
     tests_require=tests_requires,


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Update runc Go dependency (resolve https://github.com/advisories/GHSA-v95c-p5hm-xq8f)
- Update Jinja2 templating base image (resolve 12 vulnerability issues - see screenshot)

    ![Screenshot 2021-12-21 at 13 41 05](https://user-images.githubusercontent.com/7155799/146931648-6f3eb3b2-57f9-466f-b9eb-f5524ed6f4b0.png)

I will update the Jinja image in Hub manifests after this PR merge.


## Testing

1. Checkout this repo (e.g. using `gh` CLI)
1. Run:
```
cd hack/images/jinja2

docker run --rm -it -v $PWD/testdata:/data ghcr.io/capactio/pr/infra/jinja2:PR-590 /data/user.tmpl /data/data1.yaml --format=yaml -o /data/render.yaml
```
