### PR TITLE
Ensure map initialized before accessing it, create secret only if needed

### DIFF
--- a/internal/k8s-engine/graphql/domain/action/converter.go
+++ b/internal/k8s-engine/graphql/domain/action/converter.go
@@ -230,6 +230,10 @@ func (c *Converter) inputParamsFromGraphQL(in *graphql.ActionInputData, name str
 		data[ActionPolicySecretDataKey] = string(policyData)
 	}
 
+	if len(data) == 0 { // e.g. after unmarshaling we discovered that empty params were submitted
+		return nil, nil
+	}
+
 	return &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       secretKind,

--- a/internal/k8s-engine/graphql/domain/action/converter_test.go
+++ b/internal/k8s-engine/graphql/domain/action/converter_test.go
@@ -54,6 +54,9 @@ func TestConverter_FromGraphQLInput_HappyPath(t *testing.T) {
 			expectedModelPolicy: fixModelInputPolicy(name),
 			expectedModelSecret: fixModelInputSecret(name, false, true),
 		},
+		"Should ignore empty parameters and don't create secret": {
+			givenGQLParams: fixEmptyGQLInputParameters(),
+		},
 	}
 	for tn, tc := range tests {
 		t.Run(tn, func(t *testing.T) {

--- a/internal/k8s-engine/graphql/domain/action/fixtures_test.go
+++ b/internal/k8s-engine/graphql/domain/action/fixtures_test.go
@@ -344,6 +344,11 @@ func fixGQLInputParameters() *graphql.JSON {
 	return &params
 }
 
+func fixEmptyGQLInputParameters() *graphql.JSON {
+	params := graphql.JSON(`{}`)
+	return &params
+}
+
 func fixGQLInputTypeInstances() []*graphql.InputTypeInstanceData {
 	return []*graphql.InputTypeInstanceData{
 		{

--- a/internal/k8s-engine/graphql/domain/action/service.go
+++ b/internal/k8s-engine/graphql/domain/action/service.go
@@ -337,13 +337,9 @@ func (s *Service) createInputParamsSecretIfShould(ctx context.Context, item mode
 	owner := item.Action
 	secret := item.InputParamsSecret
 	secret.SetResourceVersion("") // ResourceVersion can be not empty when using the Service directly
+
 	secret.SetOwnerReferences([]v1.OwnerReference{
-		{
-			APIVersion: v1alpha1.GroupVersion.Identifier(),
-			Kind:       v1alpha1.ActionKind,
-			Name:       owner.Name,
-			UID:        owner.UID,
-		},
+		*metav1.NewControllerRef(&owner, v1alpha1.GroupVersion.WithKind(v1alpha1.ActionKind)),
 	})
 
 	log.Info("Creating Secret with input params")


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Ensure that map is initialized before accessing it
- Create Secret by gql service only if needed
- Ensure that Secrets is owned by Action

### Testing

Check bug description https://github.com/capactio/capact/issues/593

## Related issue(s)

Fix https://github.com/capactio/capact/issues/593