### PR TITLE
Simplify manifest generation

### DIFF
--- a/cmd/cli/cmd/alpha/manifest-gen/attribute/attribute.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/attribute/attribute.go
@@ -1,0 +1,80 @@
+package attribute
+
+import (
+	"strings"
+
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"capact.io/capact/internal/cli"
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"capact.io/capact/internal/cli/heredoc"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewAttribute returns a cobra.Command to bootstrap new Attribute manifests.
+func NewAttribute() *cobra.Command {
+	var attributeCfg manifestgen.AttributeConfig
+
+	cmd := &cobra.Command{
+		Use:     "attribute [PATH]",
+		Aliases: []string{"attributes"},
+		Short:   "Generate new Attribute manifests",
+		Example: heredoc.WithCLIName(`
+			# Generate manifests for the cap.attribute.cloud.provider.aws Attribute
+			<cli> alpha manifest-gen attribute cap.attribute.cloud.provider.aws`, cli.Name),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("accepts only one argument")
+			}
+
+			path := args[0]
+			if !strings.HasPrefix(path, "cap.attribute.") || len(strings.Split(path, ".")) < 4 {
+				return errors.New(`manifest path must be in format "cap.attribute.[PREFIX].[NAME]"`)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			attributeCfg.ManifestPath = args[0]
+			attributeCfg.ManifestMetadata = common.GetDefaultMetadata()
+
+			files, err := manifestgen.GenerateAttributeTemplatingConfig(&attributeCfg)
+			if err != nil {
+				return errors.Wrap(err, "while generating attribute templating config")
+			}
+
+			outputDir, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return errors.Wrap(err, "while reading output flag")
+			}
+
+			overrideManifests, err := cmd.Flags().GetBool("overwrite")
+			if err != nil {
+				return errors.Wrap(err, "while reading overwrite flag")
+			}
+
+			if err := manifestgen.WriteManifestFiles(outputDir, files, overrideManifests); err != nil {
+				return errors.Wrap(err, "while writing manifest files")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&attributeCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Attribute manifest")
+
+	return cmd
+}
+
+// GenerateAttributeFile generates new Attribute file.
+func GenerateAttributeFile(opts common.ManifestGenOptions) (map[string]string, error) {
+	var attributeCfg manifestgen.AttributeConfig
+	attributeCfg.ManifestPath = common.CreateManifestPath(common.AttributeManifest, opts.ManifestPath)
+	attributeCfg.ManifestMetadata = opts.Metadata
+	attributeCfg.ManifestRevision = opts.Revision
+	files, err := manifestgen.GenerateAttributeTemplatingConfig(&attributeCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating attribute content file")
+	}
+	return files, nil
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/common/methods.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/common/methods.go
@@ -1,24 +1,37 @@
 package common
 
 import (
+	"errors"
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
+	"net/mail"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
 )
 
-// AskForOutputDirectory ask for a directory output
-func AskForOutputDirectory(msg string, defaultValue string) string{
-	directory := ""
+// ValidateFun is a function that validates the user's answers. It is used in the survey library.
+type ValidateFun func(ans interface{}) error
+
+// AskForDirectory asks for a directory. It suggests to a user a list of dirs that can be used.
+func AskForDirectory(msg string, defaultDir string) (string, error) {
+	chosenDir := ""
 	directoryPrompt := &survey.Input{
 		Message: msg,
-		Suggest: func (toComplete string) []string {
-			files, _ := filepath.Glob(toComplete + "*")
+		Suggest: func(toComplete string) []string {
+			files, err := filepath.Glob(toComplete + "*")
+			if err != nil {
+				fmt.Println("Cannot getting the names of files")
+				return nil
+			}
 			var dirs []string
 			for _, match := range files {
 				file, err := os.Stat(match)
 				if err != nil {
-					fmt.Println("Cannot stat the file")
+					fmt.Println("Cannot getting the information about the file")
+					return nil
 				}
 				if file.IsDir() {
 					dirs = append(dirs, match)
@@ -27,10 +40,123 @@ func AskForOutputDirectory(msg string, defaultValue string) string{
 			return dirs
 		},
 	}
-	if defaultValue != "" {
-		directoryPrompt.Default = defaultValue
+	if defaultDir != "" {
+		directoryPrompt.Default = defaultDir
 	}
 
-	survey.AskOne(directoryPrompt, &directory)
-	return directory
+	err := survey.AskOne(directoryPrompt, &chosenDir)
+	return chosenDir, err
+}
+
+// AskForManifestPathSuffix asks for a manifest path suffix.
+func AskForManifestPathSuffix(msg string) (string, error) {
+	var manifestPath string
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: msg,
+			},
+			Validate: func(ans interface{}) error {
+				if str, ok := ans.(string); !ok || len(strings.Split(str, ".")) < 2 {
+					return errors.New(`manifest path suffix must be in format "[PREFIX].[NAME]"`)
+				}
+				return nil
+			},
+		},
+	}
+	err := survey.Ask(prompt, &manifestPath)
+	return manifestPath, err
+}
+
+// AskForManifestRevision asks for a manifest path revision.
+func AskForManifestRevision() (string, error) {
+	var manifestRevision string
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Revision of the manifests",
+				Default: "0.1.0",
+			},
+			Validate: func(ans interface{}) error {
+				if str, ok := ans.(string); !ok || len(strings.Split(str, ".")) < 3 {
+					return errors.New(`revision must be in format "[major].[minor].[patch]"`)
+				}
+				return nil
+			},
+		},
+	}
+	err := survey.Ask(prompt, &manifestRevision)
+	return manifestRevision, err
+}
+
+// CreateManifestPath create a manifest path based on a manifest type and suffix.
+func CreateManifestPath(manifestType string, suffix string) string {
+	suffixes := map[string]string{
+		AttributeManifest:      "attribute",
+		TypeManifest:           "type",
+		InterfaceManifest:      "interface",
+		InterfaceGroupManifest: "interfaceGroup",
+		ImplementationManifest: "implementation",
+	}
+	return "cap." + suffixes[manifestType] + "." + suffix
+}
+
+// AddRevisionToPath adds revision to manifest path
+func AddRevisionToPath(path string, revision string) string {
+	return path + ":" + revision
+}
+
+// GetDefaultMetadata creates a new Metadata object and sets default values.
+func GetDefaultMetadata() Metadata {
+	var metadata Metadata
+	metadata.DocumentationURL = "https://example.com"
+	metadata.SupportURL = "https://example.com"
+	metadata.IconURL = "https://example.com/icon.png"
+	metadata.Maintainers = []Maintainers{
+		{
+			Email: "dev@example.com",
+			Name:  "Example Dev",
+			URL:   "https://example.com",
+		},
+	}
+	metadata.License.Name = &ApacheLicense
+	return metadata
+}
+
+//ManyValidators allow using many validators function in the Survey validator.
+func ManyValidators(validateFuns []ValidateFun) func(ans interface{}) error {
+	return func(ans interface{}) error {
+		for _, fun := range validateFuns {
+			if err := fun(ans); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// ValidateURL validates a URL.
+func ValidateURL(ans interface{}) error {
+	if str, ok := ans.(string); !ok || (ans != "" && !isURL(str)) {
+		return errors.New("URL is not valid")
+	}
+	return nil
+}
+
+// ValidateEmail validates an email.
+func ValidateEmail(ans interface{}) error {
+	if str, ok := ans.(string); !ok || (ans != "" && !isEmail(str)) {
+		return errors.New("email is not valid")
+	}
+	return nil
+}
+
+func isURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func isEmail(email string) bool {
+	_, err := mail.ParseAddress(email)
+	return err == nil
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/common/methods.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/common/methods.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"os"
+	"path/filepath"
+)
+
+// AskForOutputDirectory ask for a directory output
+func AskForOutputDirectory(msg string, defaultValue string) string{
+	directory := ""
+	directoryPrompt := &survey.Input{
+		Message: msg,
+		Suggest: func (toComplete string) []string {
+			files, _ := filepath.Glob(toComplete + "*")
+			var dirs []string
+			for _, match := range files {
+				file, err := os.Stat(match)
+				if err != nil {
+					fmt.Println("Cannot stat the file")
+				}
+				if file.IsDir() {
+					dirs = append(dirs, match)
+				}
+			}
+			return dirs
+		},
+	}
+	if defaultValue != "" {
+		directoryPrompt.Default = defaultValue
+	}
+
+	survey.AskOne(directoryPrompt, &directory)
+	return directory
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/common/types.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/common/types.go
@@ -1,9 +1,43 @@
 package common
 
-// ManifestGenOptions is ...
+import (
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+)
+
+// Metadata is a alias for MetaDataInfo struct
+type Metadata = manifestgen.MetaDataInfo
+
+// Maintainers is a alias for Maintainer struct
+type Maintainers = manifestgen.Maintainer
+
+// ManifestGenOptions is a struct based on which manifests are generated
 type ManifestGenOptions struct {
-	ManifestsType []string
-	ManifestPath string
-	Directory string
-	Overwrite bool
+	Directory      string
+	InterfacePath  string
+	ManifestsType  []string
+	ManifestPath   string
+	Metadata       Metadata
+	Overwrite      bool
+	Revision       string
+	TypeInputPath  string
+	TypeOutputPath string
 }
+
+var (
+	// ApacheLicense hold a name for Apache License
+	ApacheLicense = "Apache 2.0"
+	// AWSProvider hold a name for AWS Provider
+	AWSProvider = "AWS"
+	// AttributeManifest hold a name for Attribute Manifest
+	AttributeManifest = "Attribute"
+	// GCPProvider hold a name for GCP Provider
+	GCPProvider = "GCP"
+	// InterfaceManifest hold a name for Interface Manifest
+	InterfaceManifest = "Interface"
+	// InterfaceGroupManifest hold a name for InterfaceGroup Manifest
+	InterfaceGroupManifest = "InterfaceGroup"
+	// ImplementationManifest hold a name for Implementation Manifest
+	ImplementationManifest = "Implementation"
+	// TypeManifest hold a name for Type Manifest
+	TypeManifest = "Type"
+)

--- a/cmd/cli/cmd/alpha/manifest-gen/common/types.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/common/types.go
@@ -1,0 +1,9 @@
+package common
+
+// ManifestGenOptions is ...
+type ManifestGenOptions struct {
+	ManifestsType []string
+	ManifestPath string
+	Directory string
+	Overwrite bool
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/handlers.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/handlers.go
@@ -1,0 +1,70 @@
+package manifestgen
+
+import (
+	"strings"
+
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/attribute"
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/implementation"
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/interfacegen"
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"github.com/pkg/errors"
+	"k8s.io/utils/strings/slices"
+)
+
+type genManifestFun func(opts common.ManifestGenOptions) (map[string]string, error)
+
+func generateAttribute(opts common.ManifestGenOptions) (map[string]string, error) {
+	files, err := attribute.GenerateAttributeFile(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating attribute file")
+	}
+	return files, nil
+}
+
+func generateType(opts common.ManifestGenOptions) (map[string]string, error) {
+	if slices.Contains(opts.ManifestsType, common.ImplementationManifest) {
+		// type files has been already generated in the implementation step
+		return nil, nil
+	}
+	files, err := interfacegen.GenerateInterfaceFile(opts, manifestgen.GenerateTypeTemplatingConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating type templating config")
+	}
+	return files, nil
+}
+
+func generateInterfaceGroup(opts common.ManifestGenOptions) (map[string]string, error) {
+	files, err := interfacegen.GenerateInterfaceFile(opts, manifestgen.GenerateInterfaceGroupTemplatingConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating interface group templating config")
+	}
+	return files, nil
+}
+
+func generateInterface(opts common.ManifestGenOptions) (map[string]string, error) {
+	if slices.Contains(opts.ManifestsType, common.TypeManifest) || slices.Contains(opts.ManifestsType, common.ImplementationManifest) {
+		inputPath := common.CreateManifestPath(common.TypeManifest, opts.ManifestPath) + "-input"
+		opts.TypeInputPath = common.AddRevisionToPath(inputPath, opts.Revision)
+	}
+
+	if slices.Contains(opts.ManifestsType, common.TypeManifest) {
+		outputsuffix := strings.Split(opts.ManifestPath, ".")
+		outputPath := common.CreateManifestPath(common.TypeManifest, outputsuffix[0]) + ".config"
+		opts.TypeOutputPath = common.AddRevisionToPath(outputPath, opts.Revision)
+	}
+
+	files, err := interfacegen.GenerateInterfaceFile(opts, manifestgen.GenerateInterfaceTemplatingConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating interface templating config")
+	}
+	return files, nil
+}
+
+func generateImplementation(opts common.ManifestGenOptions) (map[string]string, error) {
+	files, err := implementation.GenerateImplementationManifest(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating implementation manifest")
+	}
+	return files, nil
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/empty.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/empty.go
@@ -1,0 +1,75 @@
+package implementation
+
+import (
+	"strings"
+
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewEmpty returns a cobra.Command to bootstrap empty Implementation manifests.
+func NewEmpty() *cobra.Command {
+	var emptyCfg manifestgen.EmptyImplementationConfig
+
+	cmd := &cobra.Command{
+		Use:   "empty [MANIFEST_PATH]",
+		Short: "Generate empty Implementation manifests",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("accepts one argument: [MANIFEST_PATH]")
+			}
+
+			path := args[0]
+			if !strings.HasPrefix(path, "cap.implementation.") || len(strings.Split(path, ".")) < 4 {
+				return errors.New(`manifest path must be in format "cap.implementation.[PREFIX].[NAME]"`)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			emptyCfg.ManifestPath = args[0]
+			emptyCfg.ManifestMetadata = common.GetDefaultMetadata()
+
+			files, err := manifestgen.GenerateEmptyManifests(&emptyCfg)
+			if err != nil {
+				return errors.Wrap(err, "while generating empty implementation manifests")
+			}
+
+			outputDir, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return errors.Wrap(err, "while reading output flag")
+			}
+
+			overrideManifests, err := cmd.Flags().GetBool("overwrite")
+			if err != nil {
+				return errors.Wrap(err, "while reading overwrite flag")
+			}
+
+			if err := manifestgen.WriteManifestFiles(outputDir, files, overrideManifests); err != nil {
+				return errors.Wrap(err, "while writing manifest files")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&emptyCfg.InterfacePathWithRevision, "interface", "i", "", "Path with revision of the Interface, which is implemented by this Implementation")
+	cmd.Flags().StringVarP(&emptyCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Implementation manifest")
+
+	return cmd
+}
+
+func generateEmptyManifests(opts common.ManifestGenOptions) (map[string]string, error) {
+	var emptyManifestCfg manifestgen.EmptyImplementationConfig
+	emptyManifestCfg.ManifestPath = common.CreateManifestPath(common.ImplementationManifest, opts.ManifestPath)
+	emptyManifestCfg.ManifestMetadata = opts.Metadata
+	emptyManifestCfg.ManifestRevision = opts.Revision
+	emptyManifestCfg.InterfacePathWithRevision = opts.InterfacePath
+	files, err := manifestgen.GenerateEmptyManifests(&emptyManifestCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating empty implementation manifests")
+	}
+	return files, nil
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/implementation.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/implementation.go
@@ -1,6 +1,17 @@
 package implementation
 
-import "github.com/spf13/cobra"
+import (
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	helmType = "Helm"
+	terraformType = "Terraform"
+)
 
 // NewCmd returns a cobra.Command for Implementation manifest generation operations.
 func NewCmd() *cobra.Command {
@@ -15,4 +26,50 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(NewHelm())
 
 	return cmd
+}
+
+// HandleInteractiveSession is responsible for handling interactive session with user
+func HandleInteractiveSession(opts common.ManifestGenOptions) error{
+	tool := askForImplementationTool()
+	basedToolDir := common.AskForOutputDirectory("Path to based tool template", "")
+	if tool == helmType {
+		var helmCfg manifestgen.HelmConfig
+		helmCfg.ManifestPath = opts.ManifestPath
+		helmCfg.ChartName = basedToolDir
+		files, err := manifestgen.GenerateHelmManifests(&helmCfg)
+		if err != nil {
+			return errors.Wrap(err, "while generating Helm manifests")
+		}
+
+		if err := manifestgen.WriteManifestFiles(opts.Directory, files, opts.Overwrite); err != nil {
+			return errors.Wrap(err, "while writing manifest files")
+		}
+	}
+
+	if tool == terraformType {
+		var tfContentCfg manifestgen.TerraformConfig
+		tfContentCfg.ManifestPath = opts.ManifestPath
+		tfContentCfg.ModulePath = basedToolDir
+		files, err := manifestgen.GenerateTerraformManifests(&tfContentCfg)
+		if err != nil {
+			return errors.Wrap(err, "while generating content files")
+		}
+
+		if err := manifestgen.WriteManifestFiles(opts.Directory, files, opts.Overwrite); err != nil {
+			return errors.Wrap(err, "while writing manifest files")
+		}
+	}
+
+	return nil
+}
+
+func askForImplementationTool() string{
+	var selectType string
+	availableManifestsType := []string{helmType, terraformType}
+	typePrompt := &survey.Select{
+		Message: "Based on which tool do you want to generate implementation:",
+		Options: availableManifestsType,
+	}
+	survey.AskOne(typePrompt, &selectType)
+	return selectType
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/questions.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/questions.go
@@ -1,0 +1,119 @@
+package implementation
+
+import (
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
+)
+
+type helmChart struct {
+	// URL is address to helm repository
+	URL string
+	// Version defines a helm chart version
+	Version string
+}
+
+func askForImplementationTool() (string, error) {
+	var selectedTool string
+	availableTool := []string{helmTool, terraformTool, emptyManifest}
+	prompt := &survey.Select{
+		Message: "Based on which tool do you want to generate implementation:",
+		Options: availableTool,
+	}
+	err := survey.AskOne(prompt, &selectedTool)
+	return selectedTool, err
+}
+
+func askForInterface() (string, error) {
+	path, err := common.AskForManifestPathSuffix("Interface manifest path suffix")
+	if err != nil {
+		return "", errors.Wrap(err, "while asking for interface manifest path suffix")
+	}
+
+	revision, err := common.AskForManifestRevision()
+	if err != nil {
+		return "", errors.Wrap(err, "while asking for interface revision")
+	}
+	return common.AddRevisionToPath(path, revision), nil
+}
+
+func askForLicense() (types.License, error) {
+	var licenseName, licenseRef string
+	name := &survey.Input{
+		Message: "Name of the license",
+		Default: common.ApacheLicense,
+	}
+	err := survey.AskOne(name, &licenseName)
+	if err != nil {
+		return types.License{}, err
+	}
+
+	// TODO: can be extended to a list of licenses that do not need a ref
+	if licenseName == common.ApacheLicense {
+		return types.License{
+			Name: &licenseName,
+		}, nil
+	}
+
+	ref := &survey.Input{
+		Message: "Reference for the license",
+		Default: "",
+	}
+	err = survey.AskOne(ref, &licenseRef)
+	if err != nil {
+		return types.License{}, err
+	}
+	return types.License{
+		Name: &licenseName,
+		Ref:  &licenseRef,
+	}, nil
+}
+
+func askForProvider() (manifestgen.Provider, error) {
+	var selectedProvider string
+	availableProviders := []string{string(manifestgen.ProviderAWS), string(manifestgen.ProviderGCP)}
+	prompt := &survey.Select{
+		Message: "Create a provider-specific workflow:",
+		Options: availableProviders,
+	}
+	err := survey.AskOne(prompt, &selectedProvider)
+	return manifestgen.Provider(selectedProvider), err
+}
+
+func askForSource() (string, error) {
+	var source string
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Path to the Terraform module, such as URL to Tarball or Git repository",
+				Default: "",
+			},
+		},
+	}
+	err := survey.Ask(prompt, &source)
+	return source, err
+}
+
+func askForHelmChartDetails() (helmChart, error) {
+	var helmChartInfo helmChart
+	var qs = []*survey.Question{
+		{
+			Name: "URL",
+			Prompt: &survey.Input{
+				Message: "URL of the Helm repository",
+				Default: "",
+			},
+		},
+		{
+			Name: "Version",
+			Prompt: &survey.Input{
+				Message: "Version of the Helm chart",
+				Default: "",
+			},
+		},
+	}
+	err := survey.Ask(qs, &helmChartInfo)
+	return helmChartInfo, err
+}

--- a/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/implementation/terraform.go
@@ -74,3 +74,4 @@ func NewTerraform() *cobra.Command {
 
 	return cmd
 }
+

--- a/cmd/cli/cmd/alpha/manifest-gen/interface/interface.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/interface/interface.go
@@ -1,7 +1,9 @@
-package manifestgen
+package _interface
 
 import (
 	"strings"
+
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
 
 	"capact.io/capact/internal/cli"
 	"capact.io/capact/internal/cli/alpha/manifestgen"
@@ -63,4 +65,46 @@ func NewInterface() *cobra.Command {
 	cmd.Flags().StringVarP(&interfaceCfg.ManifestRevision, "revision", "r", "0.1.0", "Revision of the Interface manifest")
 
 	return cmd
+}
+
+func GenerateInterfaceFile(opts common.ManifestGenOptions) error {
+	var interfaceCfg manifestgen.InterfaceConfig
+	interfaceCfg.ManifestPath = opts.ManifestPath
+	files, err := manifestgen.GenerateInterfaceTemplatingConfig(&interfaceCfg)
+	if err != nil {
+		return errors.Wrap(err, "while generating content files")
+	}
+
+	if err := manifestgen.WriteManifestFiles(opts.Directory, files, opts.Overwrite); err != nil {
+		return errors.Wrap(err, "while writing manifest files")
+	}
+	return nil
+}
+
+func GenerateInterfaceGroupFile(opts common.ManifestGenOptions) error {
+	var interfaceCfg manifestgen.InterfaceConfig
+	interfaceCfg.ManifestPath = opts.ManifestPath
+	files, err := manifestgen.GenerateInterfaceGroupTemplatingConfig(&interfaceCfg)
+	if err != nil {
+		return errors.Wrap(err, "while generating content files")
+	}
+
+	if err := manifestgen.WriteManifestFiles(opts.Directory, files, opts.Overwrite); err != nil {
+		return errors.Wrap(err, "while writing manifest files")
+	}
+	return nil
+}
+
+func GenerateTypeFile(opts common.ManifestGenOptions) error {
+	var interfaceCfg manifestgen.InterfaceConfig
+	interfaceCfg.ManifestPath = opts.ManifestPath
+	files, err := manifestgen.GenerateTypeTemplatingConfig(&interfaceCfg)
+	if err != nil {
+		return errors.Wrap(err, "while generating content files")
+	}
+
+	if err := manifestgen.WriteManifestFiles(opts.Directory, files, opts.Overwrite); err != nil {
+		return errors.Wrap(err, "while writing manifest files")
+	}
+	return nil
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/manifest-gen.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/manifest-gen.go
@@ -1,23 +1,116 @@
 package manifestgen
 
 import (
+	"fmt"
+	"strings"
+
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
 	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/implementation"
+	_interface "capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/interface"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/utils/strings/slices"
+)
+
+var (
+	interfaceType      = "interface"
+	interfaceGroupType = "interfaceGroup"
+	implementationType = "implementation"
+	typeType           = "type"
 )
 
 // NewCmd returns a cobra.Command for content generation operations.
 func NewCmd() *cobra.Command {
+	var opts common.ManifestGenOptions
 	cmd := &cobra.Command{
 		Use:   "manifest-gen",
 		Short: "Manifests generation",
 		Long:  "Subcommand for various manifest generation operations",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				fmt.Println("To handle") //TODO
+			}
+			return askInteractivelyForParameters(opts)
+		},
 	}
 
-	cmd.AddCommand(NewInterface())
+	cmd.AddCommand(_interface.NewInterface())
 	cmd.AddCommand(implementation.NewCmd())
 
 	cmd.PersistentFlags().StringP("output", "o", "generated", "Path to the output directory for the generated manifests")
 	cmd.PersistentFlags().Bool("overwrite", false, "Overwrite existing manifest files")
 
 	return cmd
+}
+
+func askInteractivelyForParameters(opts common.ManifestGenOptions) error {
+	opts.ManifestsType = askForManifestType()
+	opts.Directory = common.AskForOutputDirectory("path to the output directory for the generated manifests", "generated")
+	opts.Overwrite = askIfOverwrite()
+	opts.ManifestPath = askForManifestPath()
+
+	if slices.Contains(opts.ManifestsType, interfaceType) {
+		_interface.GenerateInterfaceFile(opts)
+	}
+
+	if slices.Contains(opts.ManifestsType, interfaceGroupType) {
+		_interface.GenerateInterfaceGroupFile(opts)
+	}
+
+	if slices.Contains(opts.ManifestsType, typeType) {
+		_interface.GenerateTypeFile(opts)
+	}
+
+	if slices.Contains(opts.ManifestsType, implementationType) {
+		implementation.HandleInteractiveSession(opts)
+	}
+
+	return nil
+}
+
+func askForManifestType() []string {
+	var manifestTypes []string
+	availableManifestsType := []string{implementationType, interfaceType, interfaceGroupType, typeType}
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.MultiSelect{
+				Message: "Which manifests do you want to generate:",
+				Options: availableManifestsType,
+			},
+			Validate: survey.MinItems(1),
+		},
+	}
+	survey.Ask(prompt, &manifestTypes)
+	return manifestTypes
+}
+
+func askForManifestPath() string {
+	var manifestPath string
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Manifest path",
+			},
+			Validate: func(ans interface{}) error {
+				if str, ok := ans.(string); !ok || !strings.HasPrefix(str, "cap.interface.") || len(strings.Split(str, ".")) < 4 {
+					return errors.New(`manifest path must be in format "cap.interface.[PREFIX].[NAME]"`)
+
+				}
+				return nil
+			},
+		},
+	}
+	survey.Ask(prompt, &manifestPath)
+	return manifestPath
+}
+
+func askIfOverwrite() bool {
+	overwrite := false
+	prompt := &survey.Confirm{
+		Message: "Do you want to overwrite existing manifest files?",
+	}
+	survey.AskOne(prompt, &overwrite)
+	return overwrite
 }

--- a/cmd/cli/cmd/alpha/manifest-gen/questions.go
+++ b/cmd/cli/cmd/alpha/manifest-gen/questions.go
@@ -1,0 +1,134 @@
+package manifestgen
+
+import (
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
+)
+
+func askForManifestType() ([]string, error) {
+	var manifestTypes []string
+	availableManifestsType := []string{common.AttributeManifest, common.TypeManifest, common.InterfaceGroupManifest, common.InterfaceManifest, common.ImplementationManifest}
+	prompt := []*survey.Question{
+		{
+			Prompt: &survey.MultiSelect{
+				Message: "Which manifests do you want to generate:",
+				Options: availableManifestsType,
+			},
+			Validate: survey.MinItems(1),
+		},
+	}
+	err := survey.Ask(prompt, &manifestTypes)
+	return manifestTypes, err
+}
+
+func askForCommonMetadataInformation() (*common.Metadata, error) {
+	var metadata common.Metadata
+	var qs = []*survey.Question{
+		{
+			Name: "DocumentationURL",
+			Prompt: &survey.Input{
+				Message: "What is documentation URL?",
+				Default: "",
+			},
+			Validate: common.ValidateURL,
+		},
+		{
+			Name: "SupportURL",
+			Prompt: &survey.Input{
+				Message: "What is support URL?",
+				Default: "",
+			},
+			Validate: common.ValidateURL,
+		},
+		{
+			Name: "IconURL",
+			Prompt: &survey.Input{
+				Message: "What is icon URL?",
+				Default: "",
+			},
+			Validate: common.ValidateURL,
+		},
+	}
+	err := survey.Ask(qs, &metadata)
+	if err != nil {
+		return nil, errors.Wrap(err, "while asking for metadata")
+	}
+
+	maintainers, err := askForMaintainers()
+	if err != nil {
+		return nil, errors.Wrap(err, "while asking for maintainers")
+	}
+	metadata.Maintainers = maintainers
+	return &metadata, nil
+}
+
+func askForMaintainers() ([]common.Maintainers, error) {
+	var maintainers []common.Maintainers
+	for {
+		addMore := false
+		message := ""
+		if len(maintainers) < 1 {
+			message = "Do you want to add maintainer?"
+		} else {
+			message = "Do you want to add another maintainer?"
+		}
+		prompt := &survey.Confirm{
+			Message: message,
+		}
+		err := survey.AskOne(prompt, &addMore)
+		if err != nil {
+			return nil, errors.Wrap(err, "while asking if add maintainers")
+		}
+		if !addMore {
+			return maintainers, nil
+		}
+
+		maintainer, err := askForMaintainer()
+		if err != nil {
+			return nil, errors.Wrap(err, "while asking for maintainer details")
+		}
+		maintainers = append(maintainers, maintainer)
+	}
+}
+
+func askForMaintainer() (common.Maintainers, error) {
+	var maintainer common.Maintainers
+	var qs = []*survey.Question{
+		{
+			Name: "Email",
+			Prompt: &survey.Input{
+				Message: "What is email",
+				Default: "",
+			},
+			Validate: common.ManyValidators([]common.ValidateFun{survey.Required, common.ValidateEmail}),
+		},
+		{
+			Name: "Name",
+			Prompt: &survey.Input{
+				Message: "What is a name?",
+				Default: "",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "URL",
+			Prompt: &survey.Input{
+				Message: "What is a Url?",
+				Default: "",
+			},
+			Validate: common.ManyValidators([]common.ValidateFun{survey.Required, common.ValidateURL}),
+		},
+	}
+	err := survey.Ask(qs, &maintainer)
+	return maintainer, err
+}
+
+func askIfOverwrite() (bool, error) {
+	overwrite := false
+	prompt := &survey.Confirm{
+		Message: "Do you want to overwrite existing manifest files?",
+	}
+	err := survey.AskOne(prompt, &overwrite)
+	return overwrite, err
+}

--- a/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
+++ b/cmd/cli/docs/capact_alpha_manifest-gen_interface.md
@@ -18,7 +18,7 @@ capact alpha manifest-gen interface [PATH] [flags]
 
 ```
 # Generate manifests for the cap.interface.database.postgresql.install Interface
-capact alpha content interface cap.interface.database.postgresql install
+capact alpha manifest-gen interface cap.interface.database.postgresql.install
 ```
 
 ### Options

--- a/internal/cli/alpha/manifestgen/attribute.go
+++ b/internal/cli/alpha/manifestgen/attribute.go
@@ -1,0 +1,45 @@
+package manifestgen
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// GenerateAttributeTemplatingConfig generates an attribute templating config.
+func GenerateAttributeTemplatingConfig(cfg *AttributeConfig) (map[string]string, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting path and prefix for manifests")
+	}
+
+	tc := &templatingConfig{
+		Template: attributeManifestTemplate,
+		Input: &attributeTemplatingInput{
+			templatingInput: templatingInput{
+				Metadata: cfg.ManifestMetadata,
+				Name:     name,
+				Prefix:   prefix,
+				Revision: cfg.ManifestRevision,
+			},
+		},
+	}
+
+	generated, err := generateManifests([]*templatingConfig{tc})
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating manifests")
+	}
+
+	result := make(map[string]string, len(generated))
+
+	for _, m := range generated {
+		metadata, err := unmarshalMetadata([]byte(m))
+		if err != nil {
+			return nil, errors.Wrap(err, "while getting metadata for manifest")
+		}
+		manifestPath := fmt.Sprintf("%s.%s", metadata.Metadata.Prefix, metadata.Metadata.Name)
+		result[manifestPath] = m
+	}
+
+	return result, nil
+}

--- a/internal/cli/alpha/manifestgen/empty_interface.go
+++ b/internal/cli/alpha/manifestgen/empty_interface.go
@@ -1,0 +1,100 @@
+package manifestgen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// GenerateEmptyManifests generates empty manifest files to be filled by the content developer.
+func GenerateEmptyManifests(cfg *EmptyImplementationConfig) (map[string]string, error) {
+	cfgs := make([]*templatingConfig, 0, 2)
+
+	inputTypeCfg, err := getEmptyInputTypeTemplatingConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Implementation templating config")
+	}
+	cfgs = append(cfgs, inputTypeCfg)
+
+	implCfg, err := getEmptyImplementationTemplatingConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting Implementation templating config")
+	}
+	cfgs = append(cfgs, implCfg)
+
+	generated, err := generateManifests(cfgs)
+	if err != nil {
+		return nil, errors.Wrap(err, "while generating empty manifests")
+	}
+
+	result := make(map[string]string, len(generated))
+
+	for _, m := range generated {
+		metadata, err := unmarshalMetadata([]byte(m))
+		if err != nil {
+			return nil, errors.Wrap(err, "while getting metadata for manifest")
+		}
+
+		manifestPath := fmt.Sprintf("%s.%s", metadata.Metadata.Prefix, metadata.Metadata.Name)
+
+		result[manifestPath] = m
+	}
+
+	return result, nil
+}
+
+func getEmptyImplementationTemplatingConfig(cfg *EmptyImplementationConfig) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
+	}
+
+	var (
+		interfacePath     = cfg.InterfacePathWithRevision
+		interfaceRevision = "0.1.0"
+	)
+
+	pathSlice := strings.Split(cfg.InterfacePathWithRevision, ":")
+	if len(pathSlice) == 2 {
+		interfacePath = pathSlice[0]
+		interfaceRevision = pathSlice[1]
+	}
+
+	input := &emptyImplementationTemplatingInput{
+		templatingInput: templatingInput{
+			Metadata: cfg.ManifestMetadata,
+			Name:     name,
+			Prefix:   prefix,
+			Revision: cfg.ManifestRevision,
+		},
+		InterfacePath:     interfacePath,
+		InterfaceRevision: interfaceRevision,
+	}
+
+	return &templatingConfig{
+		Template: emptyImplementationManifestTemplate,
+		Input:    input,
+	}, nil
+}
+
+func getEmptyInputTypeTemplatingConfig(cfg *EmptyImplementationConfig) (*templatingConfig, error) {
+	prefix, name, err := splitPathToPrefixAndName(cfg.ManifestPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting prefix and path for manifests")
+	}
+
+	input := &typeTemplatingInput{
+		templatingInput: templatingInput{
+			Metadata: cfg.ManifestMetadata,
+			Name:     name,
+			Prefix:   prefix,
+			Revision: cfg.ManifestRevision,
+		},
+	}
+
+	return &templatingConfig{
+		Template: typeManifestTemplate,
+		Input:    input,
+	}, nil
+}

--- a/internal/cli/alpha/manifestgen/helm.go
+++ b/internal/cli/alpha/manifestgen/helm.go
@@ -40,7 +40,7 @@ func GenerateHelmManifests(cfg *HelmConfig) (map[string]string, error) {
 
 	generated, err := generateManifests(cfgs)
 	if err != nil {
-		return nil, errors.Wrap(err, "while generating manifests")
+		return nil, errors.Wrap(err, "while generating helm manifests")
 	}
 
 	result := make(map[string]string, len(generated))
@@ -92,6 +92,7 @@ func getHelmInputTypeTemplatingConfig(cfg *HelmConfig, helmChart *chart.Chart) (
 
 	input := &typeTemplatingInput{
 		templatingInput: templatingInput{
+			Metadata: cfg.ManifestMetadata,
 			Name:     name,
 			Prefix:   prefix,
 			Revision: cfg.ManifestRevision,
@@ -141,6 +142,7 @@ func getHelmImplementationTemplatingConfig(cfg *HelmConfig, helmChart *chart.Cha
 
 	input := &helmImplementationTemplatingInput{
 		templatingInput: templatingInput{
+			Metadata: cfg.ManifestMetadata,
 			Name:     name,
 			Prefix:   prefix,
 			Revision: cfg.ManifestRevision,

--- a/internal/cli/alpha/manifestgen/helpers.go
+++ b/internal/cli/alpha/manifestgen/helpers.go
@@ -38,6 +38,18 @@ func WriteManifestFiles(outputDir string, files map[string]string, override bool
 	return nil
 }
 
+//ManifestsExistsInOutputDir checks if manifests exists in dir
+func ManifestsExistsInOutputDir(files map[string]string, dir string) bool {
+	for manifestPath := range files {
+		manifestFilepath := strings.ReplaceAll(strings.TrimPrefix(manifestPath, "cap."), ".", string(os.PathSeparator)) + ".yaml"
+		outputFilepath := path.Join(dir, manifestFilepath)
+		if _, err := os.Stat(outputFilepath); !os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
+}
+
 func deepCopy(dst, src interface{}) error {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(src); err != nil {

--- a/internal/cli/alpha/manifestgen/manifestgen_test.go
+++ b/internal/cli/alpha/manifestgen/manifestgen_test.go
@@ -10,16 +10,59 @@ import (
 	"fmt"
 	"testing"
 
+	"capact.io/capact/cmd/cli/cmd/alpha/manifest-gen/common"
 	"capact.io/capact/internal/cli/alpha/manifestgen"
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/golden"
 )
 
+func TestGenerateAttributeManifests(t *testing.T) {
+	cfg := &manifestgen.AttributeConfig{
+		Config: manifestgen.Config{
+			ManifestPath:     "cap.attribute.group.test",
+			ManifestRevision: "0.2.0",
+			ManifestMetadata: manifestgen.MetaDataInfo{
+				DocumentationURL: "https://example.com",
+				SupportURL:       "https://example.com",
+				Maintainers: []common.Maintainers{
+					{
+						Email: "dev@example.com",
+						Name:  "Example Dev",
+						URL:   "https://example.com",
+					},
+				},
+			},
+		},
+	}
+
+	manifests, err := manifestgen.GenerateAttributeTemplatingConfig(cfg)
+	require.NoError(t, err)
+
+	for name, manifestData := range manifests {
+		filename := fmt.Sprintf("%s.yaml", name)
+		golden.Assert(t, manifestData, filename)
+	}
+}
 func TestGenerateInterfaceManifests(t *testing.T) {
 	cfg := &manifestgen.InterfaceConfig{
+		InputPathWithRevision:  "cap.type.group.test-input:0.1.0",
+		OutputPathWithRevision: "cap.type.group.config:0.1.0",
 		Config: manifestgen.Config{
 			ManifestPath:     "cap.interface.group.test",
 			ManifestRevision: "0.2.0",
+			ManifestMetadata: manifestgen.MetaDataInfo{
+				DocumentationURL: "https://example.com",
+				SupportURL:       "https://example.com",
+				IconURL:          "https://example.com/icon.png",
+				Maintainers: []common.Maintainers{
+					{
+						Email: "dev@example.com",
+						Name:  "Example Dev",
+						URL:   "https://example.com",
+					},
+				},
+			},
 		},
 	}
 
@@ -29,6 +72,52 @@ func TestGenerateInterfaceManifests(t *testing.T) {
 	for name, manifestData := range manifests {
 		filename := fmt.Sprintf("%s.yaml", name)
 		golden.Assert(t, manifestData, filename)
+	}
+}
+
+func TestGenerateEmptyImplementationManifests(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *manifestgen.EmptyImplementationConfig
+	}{
+		{
+			name: "Implementation manifests",
+			cfg: &manifestgen.EmptyImplementationConfig{
+				ImplementationConfig: manifestgen.ImplementationConfig{
+					Config: manifestgen.Config{
+						ManifestPath:     "cap.implementation.empty.test",
+						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
+					},
+					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manifests, err := manifestgen.GenerateEmptyManifests(test.cfg)
+			require.NoError(t, err)
+
+			for name, manifestData := range manifests {
+				filename := fmt.Sprintf("%s.yaml", name)
+				golden.Assert(t, manifestData, filename)
+			}
+		})
 	}
 }
 
@@ -44,6 +133,20 @@ func TestGenerateTerraformImplementationManifests(t *testing.T) {
 					Config: manifestgen.Config{
 						ManifestPath:     "cap.implementation.terraform.generic.test",
 						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
 					},
 					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
@@ -58,6 +161,20 @@ func TestGenerateTerraformImplementationManifests(t *testing.T) {
 					Config: manifestgen.Config{
 						ManifestPath:     "cap.implementation.terraform.aws.test",
 						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
 					},
 					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
@@ -73,6 +190,20 @@ func TestGenerateTerraformImplementationManifests(t *testing.T) {
 					Config: manifestgen.Config{
 						ManifestPath:     "cap.implementation.terraform.gcp.test",
 						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
 					},
 					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
@@ -108,6 +239,20 @@ func TestGenerateHelmImplementationManifests(t *testing.T) {
 					Config: manifestgen.Config{
 						ManifestPath:     "cap.implementation.helm.test",
 						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
 					},
 					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},
@@ -123,6 +268,20 @@ func TestGenerateHelmImplementationManifests(t *testing.T) {
 					Config: manifestgen.Config{
 						ManifestPath:     "cap.implementation.helm.test-generated-schema",
 						ManifestRevision: "0.1.0",
+						ManifestMetadata: manifestgen.MetaDataInfo{
+							DocumentationURL: "https://example.com",
+							SupportURL:       "https://example.com",
+							Maintainers: []common.Maintainers{
+								{
+									Email: "dev@example.com",
+									Name:  "Example Dev",
+									URL:   "https://example.com",
+								},
+							},
+							License: types.License{
+								Name: &common.ApacheLicense,
+							},
+						},
 					},
 					InterfacePathWithRevision: "cap.interface.group.test:0.2.0",
 				},

--- a/internal/cli/alpha/manifestgen/metadata.go
+++ b/internal/cli/alpha/manifestgen/metadata.go
@@ -5,14 +5,32 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Maintainer holds metadata information about a maintainer
+type Maintainer struct {
+	// Email is a email of the maintainer
+	Email string `yaml:"email"`
+	// Name is a name of the maintainer
+	Name string `yaml:"name"`
+	// URL is a URL address
+	URL string `yaml:"url"`
+}
+
+// MetaDataInfo holds metadata information about manifest file
+type MetaDataInfo struct {
+	Name             string        `yaml:"name"`
+	Prefix           string        `yaml:"prefix"`
+	DocumentationURL string        `yaml:"documentationURL"`
+	SupportURL       string        `yaml:"supportURL"`
+	IconURL          string        `yaml:"iconURL"`
+	License          types.License `yaml:"license"`
+	Maintainers      []Maintainer  `yaml:"maintainers"`
+}
+
 // Metadata holds generic metadata information for Capact manifests.
 type Metadata struct {
 	OCFVersion types.OCFVersion   `yaml:"ocfVersion"`
 	Kind       types.ManifestKind `yaml:"kind"`
-	Metadata   struct {
-		Name   string `yaml:"name"`
-		Prefix string `yaml:"prefix"`
-	} `yaml:"metadata"`
+	Metadata   MetaDataInfo       `yaml:"metadata"`
 }
 
 // unmarshalMetadata reads the manifest metadata from a bytes slice of a Capact manifest.

--- a/internal/cli/alpha/manifestgen/templates.go
+++ b/internal/cli/alpha/manifestgen/templates.go
@@ -5,6 +5,12 @@ import (
 )
 
 var (
+	//go:embed templates/attribute.yaml.tmpl
+	attributeManifestTemplate string
+
+	//go:embed templates/empty-implementation.yaml.tmpl
+	emptyImplementationManifestTemplate string
+
 	//go:embed templates/interface-group.yaml.tmpl
 	interfaceGroupManifestTemplate string
 

--- a/internal/cli/alpha/manifestgen/templates/attribute.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/attribute.yaml.tmpl
@@ -1,11 +1,11 @@
 ocfVersion: 0.0.1
 revision: {{ .Revision }}
-kind: InterfaceGroup
+kind: Attribute
 metadata:
-  prefix: "cap.interface{{ if .Prefix }}.{{ .Prefix }}{{ end }}"
+  prefix: "cap.attribute.{{ .Prefix }}"
   name: "{{ .Name }}"
   displayName: "{{ .Name }}"
-  description: "{{ .Name }} related Interfaces"
+  description: "{{ .Name }} attribute"
   {{- if .Metadata.DocumentationURL }}
   documentationURL: {{.Metadata.DocumentationURL}}
   {{- end}}

--- a/internal/cli/alpha/manifestgen/templates/empty-implementation.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/empty-implementation.yaml.tmpl
@@ -1,0 +1,90 @@
+ocfVersion: 0.0.1
+revision: {{ .Revision }}
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.{{ .Prefix }}"
+  name: {{ .Name }}
+  displayName: "{{ .Name }} Action"
+  description: "{{ .Name }} Action"
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
+  maintainers:
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
+  license:
+    name: "{{ .Metadata.License.Name }}"
+    {{- if .Metadata.License.Ref }}
+    ref: {{.Metadata.License.Ref}}
+    {{- end}}
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      additional-parameters:
+        typeRef:
+          path: cap.type.{{ .Prefix }}.{{ .Name }}-input
+          revision: 0.1.0
+
+  outputTypeInstanceRelations:
+      config: {}
+
+  implements:
+    - path: {{if .InterfacePath}}{{ .InterfacePath }}{{else}}"cap.interface..." # TODO(ContentDeveloper): Put here the path of the implemented Interface{{end}}
+      revision: {{if .InterfaceRevision}}{{ .InterfaceRevision }}{{else}}0.1.0{{end}}
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: {{ .Name }}
+        templates:
+          - name: {{ .Name }}
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:             
+              artifacts: {} # TODO(ContentDeveloper): Put here the output artifact if needed
+            steps: {} # TODO(ContentDeveloper): Put here the steps for the interface
+
+          - name: prepare-parameters
+            inputs:
+                artifacts:
+                  - name: input-parameters
+                    path: /yamls/input.yaml
+                  - name: additional-parameters
+                    path: /yamls/additionalinput.yaml
+                    optional: true
+            outputs:
+              artifacts: {} # TODO(ContentDeveloper): Put here the output artifact if needed
+            container:
+              image: alpine:latest
+              command: [sh, -c]
+              args: ["sleep 1; echo 'greeting: hello capact'"]

--- a/internal/cli/alpha/manifestgen/templates/helm-implementation.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/helm-implementation.yaml.tmpl
@@ -6,14 +6,28 @@ metadata:
   name: {{ .Name }}
   displayName: "{{ .Name }} Action"
   description: "{{ .Name }} Action"
-  documentationURL: https://example.com
-  supportURL: https://example.com
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
   maintainers:
-    - email: dev@example.com
-      name: Example Dev
-      url: https://example.com
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
   license:
-    name: "Apache 2.0"
+    name: "{{ .Metadata.License.Name }}"
+    {{- if .Metadata.License.Ref }}
+    ref: {{.Metadata.License.Ref}}
+    {{- end}}
 
 spec:
   appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here

--- a/internal/cli/alpha/manifestgen/templates/interface.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/interface.yaml.tmpl
@@ -6,26 +6,38 @@ metadata:
   name: "{{ .Name }}"
   displayName: "{{ .Name }}"
   description: "{{ .Name }} action for {{ .Prefix }}"
-  documentationURL: https://example.com
-  supportURL: https://example.com
-  iconURL: https://example.com/icon.png
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
   maintainers:
-    - email: dev@example.cop
-      name: Example Dev
-      url: https://example.com
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
 
 spec:
   input:
     parameters:
       input-parameters:
         typeRef:
-          path: cap.type.{{ .Prefix }}.{{ .Name }}-input
-          revision: 0.1.0
+          path: {{if .InputTypeName}}{{ .InputTypeName }}{{else}}cap.type. # TODO(ContentDeveloper): Put here the path of the input Type{{end}}
+          revision: {{if .InputTypeRevision}}{{ .InputTypeRevision }}{{else}}0.1.0{{end}}
     typeInstances: {}
 
   output:
     typeInstances:
+    {{- if .OutputTypeName}}
       config:
         typeRef:
-          path: cap.type.{{ .Prefix }}.config
-          revision: 0.1.0
+          path: {{ .OutputTypeName }}
+          revision: {{if .OutputTypeRevision}}{{ .OutputTypeRevision }}{{else}}0.1.0{{end}}
+    {{else}} {} # TODO(ContentDeveloper): Configure here the output typeInstance if needed{{end}}

--- a/internal/cli/alpha/manifestgen/templates/output-type.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/output-type.yaml.tmpl
@@ -6,12 +6,23 @@ metadata:
   name: config
   displayName: "{{.Prefix }} config"
   description: "Type representing a {{ .Prefix }} config"
-  documentationURL: https://example.com
-  supportURL: https://example.com
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
   maintainers:
-    - email: dev@example.com
-      name: Example Dev
-      url: https://example.com
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
 spec:
   jsonSchema:
     # TODO(ContentDeveloper): Put the properties of your Interface output Type in form of a JSON Schema

--- a/internal/cli/alpha/manifestgen/templates/terraform-implementation.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/terraform-implementation.yaml.tmpl
@@ -6,14 +6,28 @@ metadata:
   name: {{ .Name }}
   displayName: "{{ .Name }} Action"
   description: "{{ .Name }} Action"
-  documentationURL: https://example.com
-  supportURL: https://example.com
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
   maintainers:
-    - email: dev@example.com
-      name: Example Dev
-      url: https://example.com
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
   license:
-    name: "Apache 2.0"
+    name: "{{ .Metadata.License.Name }}"
+    {{- if .Metadata.License.Ref }}
+    ref: {{.Metadata.License.Ref}}
+    {{- end}}
 
 spec:
   appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here

--- a/internal/cli/alpha/manifestgen/templates/type.yaml.tmpl
+++ b/internal/cli/alpha/manifestgen/templates/type.yaml.tmpl
@@ -6,12 +6,23 @@ metadata:
   name: {{ .Name }}-input
   displayName: "Input for {{ .Prefix }}.{{ .Name }}"
   description: Input for the "{{ .Prefix }}.{{ .Name }} Action"
-  documentationURL: https://example.com
-  supportURL: https://example.com
+  {{- if .Metadata.DocumentationURL }}
+  documentationURL: {{.Metadata.DocumentationURL}}
+  {{- end}}
+  {{- if .Metadata.SupportURL }}
+  supportURL: {{.Metadata.SupportURL}}
+  {{- end}}
+  {{- if .Metadata.IconURL }}
+  iconURL: {{.Metadata.IconURL}}
+  {{- end}}
+  {{- if .Metadata.Maintainers }}
   maintainers:
-    - email: dev@example.com
-      name: Example Dev
-      url: https://example.com
+  {{- range .Metadata.Maintainers }}
+    - email: {{.Email}}
+      name: {{.Name}}
+      url: {{.URL}}
+  {{- end}}
+  {{- end}}
 spec:
   jsonSchema:
     # TODO(ContentDeveloper): Adjust the JSON schema if needed.

--- a/internal/cli/alpha/manifestgen/terraform.go
+++ b/internal/cli/alpha/manifestgen/terraform.go
@@ -37,7 +37,7 @@ func GenerateTerraformManifests(cfg *TerraformConfig) (map[string]string, error)
 
 	generated, err := generateManifests(cfgs)
 	if err != nil {
-		return nil, errors.Wrap(err, "while generating manifests")
+		return nil, errors.Wrap(err, "while generating terraform manifests")
 	}
 
 	result := make(map[string]string, len(generated))
@@ -71,6 +71,7 @@ func getTerraformInputTypeTemplatingConfig(cfg *TerraformConfig, module *tfconfi
 		Template: typeManifestTemplate,
 		Input: &typeTemplatingInput{
 			templatingInput: templatingInput{
+				Metadata: cfg.ManifestMetadata,
 				Name:     name,
 				Prefix:   prefix,
 				Revision: cfg.ManifestRevision,
@@ -99,6 +100,7 @@ func getTerraformImplementationTemplatingConfig(cfg *TerraformConfig, module *tf
 
 	input := &terraformImplementationTemplatingInput{
 		templatingInput: templatingInput{
+			Metadata: cfg.ManifestMetadata,
 			Name:     name,
 			Prefix:   prefix,
 			Revision: cfg.ManifestRevision,

--- a/internal/cli/alpha/manifestgen/testdata/cap.attribute.group.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.attribute.group.test.yaml
@@ -1,14 +1,13 @@
 ocfVersion: 0.0.1
 revision: 0.2.0
-kind: InterfaceGroup
+kind: Attribute
 metadata:
-  prefix: "cap.interface"
-  name: "group"
-  displayName: "group"
-  description: "group related Interfaces"
+  prefix: "cap.attribute.group"
+  name: "test"
+  displayName: "test"
+  description: "test attribute"
   documentationURL: https://example.com
   supportURL: https://example.com
-  iconURL: https://example.com/icon.png
   maintainers:
     - email: dev@example.com
       name: Example Dev

--- a/internal/cli/alpha/manifestgen/testdata/cap.implementation.empty.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.implementation.empty.test.yaml
@@ -1,0 +1,76 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.empty"
+  name: test
+  displayName: "test Action"
+  description: "test Action"
+  documentationURL: https://example.com
+  supportURL: https://example.com
+  maintainers:
+    - email: dev@example.com
+      name: Example Dev
+      url: https://example.com
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "1.0.x" # TODO(ContentDeveloper): Set the supported application version here
+  additionalInput:
+    parameters:
+      additional-parameters:
+        typeRef:
+          path: cap.type.empty.test-input
+          revision: 0.1.0
+
+  outputTypeInstanceRelations:
+      config: {}
+
+  implements:
+    - path: cap.interface.group.test
+      revision: 0.2.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: test
+        templates:
+          - name: test
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: additional-parameters
+                  optional: true
+            outputs:             
+              artifacts: {} # TODO(ContentDeveloper): Put here the output artifact if needed
+            steps: {} # TODO(ContentDeveloper): Put here the steps for the interface
+
+          - name: prepare-parameters
+            inputs:
+                artifacts:
+                  - name: input-parameters
+                    path: /yamls/input.yaml
+                  - name: additional-parameters
+                    path: /yamls/additionalinput.yaml
+                    optional: true
+            outputs:
+              artifacts: {} # TODO(ContentDeveloper): Put here the output artifact if needed
+            container:
+              image: alpine:latest
+              command: [sh, -c]
+              args: ["sleep 1; echo 'greeting: hello capact'"]

--- a/internal/cli/alpha/manifestgen/testdata/cap.interface.group.test.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.interface.group.test.yaml
@@ -10,7 +10,7 @@ metadata:
   supportURL: https://example.com
   iconURL: https://example.com/icon.png
   maintainers:
-    - email: dev@example.cop
+    - email: dev@example.com
       name: Example Dev
       url: https://example.com
 
@@ -29,3 +29,4 @@ spec:
         typeRef:
           path: cap.type.group.config
           revision: 0.1.0
+    

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.empty.test-input.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.empty.test-input.yaml
@@ -1,14 +1,13 @@
 ocfVersion: 0.0.1
-revision: 0.2.0
+revision: 0.1.0
 kind: Type
 metadata:
-  prefix: "cap.type.group"
+  prefix: "cap.type.empty"
   name: test-input
-  displayName: "Input for group.test"
-  description: Input for the "group.test Action"
+  displayName: "Input for empty.test"
+  description: Input for the "empty.test Action"
   documentationURL: https://example.com
   supportURL: https://example.com
-  iconURL: https://example.com/icon.png
   maintainers:
     - email: dev@example.com
       name: Example Dev
@@ -17,6 +16,4 @@ spec:
   jsonSchema:
     # TODO(ContentDeveloper): Adjust the JSON schema if needed.
     value: |-
-      {
-        "type": "object"
-      }
+      

--- a/internal/cli/alpha/manifestgen/testdata/cap.type.group.config.yaml
+++ b/internal/cli/alpha/manifestgen/testdata/cap.type.group.config.yaml
@@ -8,6 +8,7 @@ metadata:
   description: "Type representing a group config"
   documentationURL: https://example.com
   supportURL: https://example.com
+  iconURL: https://example.com/icon.png
   maintainers:
     - email: dev@example.com
       name: Example Dev

--- a/internal/cli/alpha/manifestgen/types.go
+++ b/internal/cli/alpha/manifestgen/types.go
@@ -8,11 +8,19 @@ import (
 type Config struct {
 	ManifestPath     string
 	ManifestRevision string
+	ManifestMetadata MetaDataInfo
+}
+
+// AttributeConfig stores input parameters for Attribute content generation
+type AttributeConfig struct {
+	Config
 }
 
 // InterfaceConfig stores input parameters for Interface content generation
 type InterfaceConfig struct {
 	Config
+	InputPathWithRevision  string
+	OutputPathWithRevision string
 }
 
 // ImplementationConfig stores input parameters for Implementation content generation
@@ -39,6 +47,11 @@ type HelmConfig struct {
 	ChartVersion string
 }
 
+// EmptyImplementationConfig stores input parameters for empty Implementation content generation.
+type EmptyImplementationConfig struct {
+	ImplementationConfig
+}
+
 type templatingConfig struct {
 	Template string
 	Input    interface{}
@@ -48,6 +61,11 @@ type templatingInput struct {
 	Name     string
 	Prefix   string
 	Revision string
+	Metadata MetaDataInfo
+}
+
+type attributeTemplatingInput struct {
+	templatingInput
 }
 
 type interfaceGroupTemplatingInput struct {
@@ -56,6 +74,10 @@ type interfaceGroupTemplatingInput struct {
 
 type interfaceTemplatingInput struct {
 	templatingInput
+	InputTypeName      string
+	InputTypeRevision  string
+	OutputTypeName     string
+	OutputTypeRevision string
 }
 
 type outputTypeTemplatingInput struct {
@@ -65,6 +87,12 @@ type outputTypeTemplatingInput struct {
 type typeTemplatingInput struct {
 	templatingInput
 	JSONSchema string
+}
+
+type emptyImplementationTemplatingInput struct {
+	templatingInput
+	InterfacePath     string
+	InterfaceRevision string
 }
 
 type terraformImplementationTemplatingInput struct {


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- simplify the creation of the manifests by using interactive communication with the user,
- add an option to generate the empty implementation manifest.

In the interactive mode, there exists a list of manifests that can be generated:
- Attribute
- Type
- InterfaceGroup
- Interface
- Implementation

If the user specifies multiple manifests types, then there are questions regarding common information to all manifests (including Metadata, Versioning etc.). Then, there are questions regarding individual manifests. 

**Note**: there also implemented the sync between them. For instance, if the user specifies the Type and Interface, in the Interface corrected Types will be added. The same mechanism is for Interface and Implementation. 

As the last step, there was added the generation of the Empty manifests, previously there was Helm and Terraform option. 

Lastly, I deliberately decided to have a mismatch between interactive and non-interactive modes. In the non-interactive mode, there are fewer options  - for instance, some of the Metadata has a default value and cannot be changed.  

## Related issue(s)
- #564 
