### PR TITLE
Enable Gateway CORS by default

### DIFF
--- a/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
+++ b/deploy/kubernetes/charts/capact/charts/gateway/values.yaml
@@ -63,7 +63,7 @@ ingress:
     issuer: "letsencrypt"
     acmechallengetype: "http01"
     cors:
-      enabled: false
+      enabled: true
       allowMethods: "HEAD, GET, POST, OPTIONS"
       allowOrigins: "*"
 

--- a/internal/cli/capact/defaults.go
+++ b/internal/cli/capact/defaults.go
@@ -62,11 +62,6 @@ var (
 	capactLocalClusterOverridesYAML = fmt.Sprintf(`
 global:
   domainName: "%s"
-gateway:
-  ingress:
-    annotations:
-      cors:
-        enabled: true
 `, localDomain)
 )
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Enable Gateway CORS by default

As we have Capact Dashboard enabled by default, to make UI able to access Gateway, we need to enable CORS as well.

This change has been tested on our long-running cluster.

## Related issue(s)

#599 