### PR TITLE
Add support to find Types based on prefix of parent nodes

### DIFF
--- a/hub-js/README.md
+++ b/hub-js/README.md
@@ -31,7 +31,7 @@ docker run -d \
   -e "NEO4J_AUTH=neo4j/okon" \
   -e "NEO4JLABS_PLUGINS=[\"apoc\"]" \
   --name hub-neo4j-instance \
-  neo4j:4.2.3
+  ghcr.io/capactio/neo4j:4.2.13-apoc
 ```
 
 When you are done, remove the Docker container:
@@ -100,13 +100,20 @@ To access Neo4j Browser, follow the steps:
 
 1. Run the following commands:
 
-```bash
-kubectl -n capact-system port-forward svc/neo4j-neo4j 7474:7474
-kubectl -n capact-system port-forward svc/neo4j-neo4j 7687:7687
-```
+   - Capact cluster:
+     ```bash
+     kubectl -n capact-system port-forward svc/neo4j-neo4j 7474:7474
+     kubectl -n capact-system port-forward svc/neo4j-neo4j 7687:7687
+     ```
+   - Docker:
+     Make sure that `-p 7687:7687 -p 7474:7474` flags were specified for the `docker run` command.
 
-1. Navigate to [http://localhost:7474](http://localhost:7474).
-1. Change the connection URL to `neo4j://localhost:7687`.
-1. Use `neo4j` user and password configured during Helm chart installation. See the default values in [`values.yaml`](../deploy/kubernetes/charts/neo4j/values.yaml) file.
+2. Navigate to [http://localhost:7474](http://localhost:7474).
+3. Change the connection URL to `neo4j://localhost:7687`.
+4. Use `neo4j` configured user and password:
+   - Capact cluster:
+     See the default values in [`values.yaml`](../deploy/kubernetes/charts/neo4j/values.yaml) file.
+   - Docker:
+     Use values set by the `NEO4J_AUTH` enviroment variable.
 
 To read more about development, see the [Development guide](https://capact.io/community/development/development-guide).

--- a/hub-js/README.md
+++ b/hub-js/README.md
@@ -84,7 +84,7 @@ query {
 The following environment variables can be set to configure Hub:
 
 | Name                        | Required | Default                 | Description                                            |
-| --------------------------- | -------- | ----------------------- | ------------------------------------------------------ |
+|-----------------------------|----------|-------------------------|--------------------------------------------------------|
 | APP_HUB_MODE                | no       | `public`                | Mode, in which Hub is run. Must be "public" or "local" |
 | APP_GRAPH_QL_ADDR           | no       | `:8080`                 | The address, where GraphQL endpoints binds to          |
 | APP_NEO4J_ENDPOINT          | no       | `bolt://localhost:7687` | The Neo4j database Bolt protocol endpoint              |
@@ -114,6 +114,6 @@ To access Neo4j Browser, follow the steps:
    - Capact cluster:
      See the default values in [`values.yaml`](../deploy/kubernetes/charts/neo4j/values.yaml) file.
    - Docker:
-     Use values set by the `NEO4J_AUTH` enviroment variable.
+     Use values set by the `NEO4J_AUTH` environment variable.
 
 To read more about development, see the [Development guide](https://capact.io/community/development/development-guide).

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -576,10 +576,24 @@ type Query @additionalLabels(labels: ["published"]) {
   types(filter: TypeFilter = {}): [Type!]!
     @cypher(
       statement: """
-      OPTIONAL MATCH (this:VirtualType:published)-[:CONTAINS]->(types)
-      MATCH (types:Type:published)
-      WHERE $filter = {} OR $filter.pathPattern IS NULL OR (this.path =~ $filter.pathPattern OR types.path =~ $filter.pathPattern)
-      RETURN DISTINCT types
+      // Find all children associated with a given path pattern
+      OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern
+
+      WITH children
+
+      // Find all specific Types that matches a given pattern
+      MATCH (type:Type:published)
+         WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern
+
+      // Flat collection of specify Types and attached children
+      UNWIND [type, children] AS res
+
+			WITH res
+			// OPTIONAL MATCH may produce NULL values
+      WHERE res is NOT NULL
+			// Get rid of duplicates
+      RETURN DISTINCT res
       """
     )
   type(path: NodePath!): Type

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -578,13 +578,13 @@ type Query @additionalLabels(labels: ["published"]) {
       statement: """
       // Find all children associated with a given path pattern
       OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)
-      WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = "*" OR b.path =~ $filter.pathPattern
 
       WITH children
 
       // Find all specific Types that matches a given pattern
       MATCH (type:Type:published)
-         WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = "*" OR type.path =~ $filter.pathPattern
 
       // Flat collection of specify Types and attached children
       UNWIND [type, children] AS res

--- a/hub-js/graphql/public/schema.graphql
+++ b/hub-js/graphql/public/schema.graphql
@@ -576,8 +576,10 @@ type Query @additionalLabels(labels: ["published"]) {
   types(filter: TypeFilter = {}): [Type!]!
     @cypher(
       statement: """
-      MATCH (this:Type:published)
-      WHERE $filter = {} OR this.path =~ $filter.pathPattern RETURN this
+      OPTIONAL MATCH (this:VirtualType:published)-[:CONTAINS]->(types)
+      MATCH (types:Type:published)
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR (this.path =~ $filter.pathPattern OR types.path =~ $filter.pathPattern)
+      RETURN DISTINCT types
       """
     )
   type(path: NodePath!): Type

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -2175,13 +2175,13 @@ type Query @additionalLabels(labels: ["published"]) {
       statement: """
       // Find all children associated with a given path pattern
       OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)
-      WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = "*" OR b.path =~ $filter.pathPattern
 
       WITH children
 
       // Find all specific Types that matches a given pattern
       MATCH (type:Type:published)
-         WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = "*" OR type.path =~ $filter.pathPattern
 
       // Flat collection of specify Types and attached children
       UNWIND [type, children] AS res
@@ -8739,7 +8739,7 @@ func (ec *executionContext) _Query_types(ctx context.Context, field graphql.Coll
 			return ec.directives.AdditionalLabels(ctx, nil, directive0, labels)
 		}
 		directive2 := func(ctx context.Context) (interface{}, error) {
-			statement, err := ec.unmarshalOString2ᚖstring(ctx, "   // Find all children associated with a given path pattern\n   OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)\n   WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern\n\n   WITH children\n\n   // Find all specific Types that matches a given pattern\n   MATCH (type:Type:published)\n      WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern\n\n   // Flat collection of specify Types and attached children\n   UNWIND [type, children] AS res\n\nWITH res\n// OPTIONAL MATCH may produce NULL values\n   WHERE res is NOT NULL\n// Get rid of duplicates\n   RETURN DISTINCT res")
+			statement, err := ec.unmarshalOString2ᚖstring(ctx, "   // Find all children associated with a given path pattern\n   OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)\n   WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = \"*\" OR b.path =~ $filter.pathPattern\n\n   WITH children\n\n   // Find all specific Types that matches a given pattern\n   MATCH (type:Type:published)\n   WHERE $filter = {} OR $filter.pathPattern IS NULL OR $filter.pathPattern = \"*\" OR type.path =~ $filter.pathPattern\n\n   // Flat collection of specify Types and attached children\n   UNWIND [type, children] AS res\n\nWITH res\n// OPTIONAL MATCH may produce NULL values\n   WHERE res is NOT NULL\n// Get rid of duplicates\n   RETURN DISTINCT res")
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/hub/api/graphql/public/schema_gen.go
+++ b/pkg/hub/api/graphql/public/schema_gen.go
@@ -2173,8 +2173,24 @@ type Query @additionalLabels(labels: ["published"]) {
   types(filter: TypeFilter = {}): [Type!]!
     @cypher(
       statement: """
-      MATCH (this:Type:published)
-      WHERE $filter = {} OR this.path =~ $filter.pathPattern RETURN this
+      // Find all children associated with a given path pattern
+      OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)
+      WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern
+
+      WITH children
+
+      // Find all specific Types that matches a given pattern
+      MATCH (type:Type:published)
+         WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern
+
+      // Flat collection of specify Types and attached children
+      UNWIND [type, children] AS res
+
+			WITH res
+			// OPTIONAL MATCH may produce NULL values
+      WHERE res is NOT NULL
+			// Get rid of duplicates
+      RETURN DISTINCT res
       """
     )
   type(path: NodePath!): Type
@@ -8723,7 +8739,7 @@ func (ec *executionContext) _Query_types(ctx context.Context, field graphql.Coll
 			return ec.directives.AdditionalLabels(ctx, nil, directive0, labels)
 		}
 		directive2 := func(ctx context.Context) (interface{}, error) {
-			statement, err := ec.unmarshalOString2ᚖstring(ctx, "MATCH (this:Type:published)\nWHERE $filter = {} OR this.path =~ $filter.pathPattern RETURN this")
+			statement, err := ec.unmarshalOString2ᚖstring(ctx, "   // Find all children associated with a given path pattern\n   OPTIONAL MATCH (b:VirtualType:published)-[:CONTAINS]->(children:Type:published)\n   WHERE $filter = {} OR $filter.pathPattern IS NULL OR b.path =~ $filter.pathPattern\n\n   WITH children\n\n   // Find all specific Types that matches a given pattern\n   MATCH (type:Type:published)\n      WHERE $filter = {} OR $filter.pathPattern IS NULL OR type.path =~ $filter.pathPattern\n\n   // Flat collection of specify Types and attached children\n   UNWIND [type, children] AS res\n\nWITH res\n// OPTIONAL MATCH may produce NULL values\n   WHERE res is NOT NULL\n// Get rid of duplicates\n   RETURN DISTINCT res")
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/hub/client/public/client.go
+++ b/pkg/hub/client/public/client.go
@@ -62,15 +62,15 @@ func (c *Client) FindInterfaceRevision(ctx context.Context, ref gqlpublicapi.Int
 func (c *Client) ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter gqlpublicapi.TypeFilter) ([]*gqlpublicapi.TypeRevision, error) {
 	req := graphql.NewRequest(`query ListTypeRefsJSONSchemas($typeFilter: TypeFilter!)  {
 		  types(filter: $typeFilter) {
-			revisions {
-			  revision
-			  metadata {
-				path
+			  revisions {
+			    revision
+			    metadata {
+			  	  path
+			    }
+			    spec {
+			  	  jsonSchema
+			    }
 			  }
-			  spec {
-				jsonSchema
-			  }
-			}
 		  }
 		}`)
 
@@ -153,7 +153,7 @@ func (c *Client) GetInterfaceLatestRevisionString(ctx context.Context, ref gqlpu
 			latestRevision {
 				revision
 			}
-		}		
+		}
 	}`)
 
 	req.Var("interfacePath", ref.Path)

--- a/pkg/sdk/dbpopulator/populator.go
+++ b/pkg/sdk/dbpopulator/populator.go
@@ -77,10 +77,6 @@ CREATE (typeSpec:TypeSpec:unpublished {
   additionalRefs: value.spec.additionalRefs})
 CREATE (typeRevision:TypeRevision:unpublished {revision: value.revision})
 
-// VirtualType allows us to find types which define spec.additionalRefs
-CREATE (vType:VirtualType:unpublished {path: "<PREFIX>"})
-CREATE (vType)-[:CONTAINS]->(type)
-
 CREATE (typeRevision)-[:SPECIFIED_BY]->(typeSpec)
 CREATE (typeRevision)-[:DESCRIBED_BY]->(metadata)
 CREATE (type)-[:CONTAINS]->(typeRevision)
@@ -89,7 +85,9 @@ WITH *, value.spec.additionalRefs as refs
 CALL {
  WITH *
  UNWIND refs AS path
-  MATCH (baseType:VirtualType:unpublished {path:path})
+	// VirtualType is used to easily find children for a given abstract node.
+  // Thanks to MERGE, it's created only if necessary
+  MERGE (baseType:VirtualType:unpublished {path:path})
   CREATE (baseType)-[:CONTAINS]->(type)
  RETURN count([]) as _tmp1
 }

--- a/pkg/sdk/dbpopulator/populator.go
+++ b/pkg/sdk/dbpopulator/populator.go
@@ -48,7 +48,7 @@ CREATE (attributeRevision: AttributeRevision:unpublished {revision: value.revisi
 CREATE (attributeRevision)-[:DESCRIBED_BY]->(metadata)
 CREATE (attribute)-[:CONTAINS]->(attributeRevision)
 
-WITH value, metadata 
+WITH value, metadata
 UNWIND value.metadata.maintainers as m
 MERGE (maintainer:Maintainer:unpublished {
   email: m.email,
@@ -72,7 +72,9 @@ CREATE (metadata:TypeMetadata:unpublished {
   supportURL: value.metadata.supportURL,
   iconURL: value.metadata.iconURL})
 
-CREATE (typeSpec:TypeSpec:unpublished {jsonSchema: value.spec.jsonSchema.value})
+CREATE (typeSpec:TypeSpec:unpublished {
+	jsonSchema: value.spec.jsonSchema.value,
+  additionalRefs: value.spec.additionalRefs})
 CREATE (typeRevision:TypeRevision:unpublished {revision: value.revision})
 
 // VirtualType allows us to find types which define spec.additionalRefs
@@ -92,7 +94,7 @@ CALL {
  RETURN count([]) as _tmp1
 }
 
-WITH value, metadata 
+WITH value, metadata
 UNWIND value.metadata.maintainers as m
 MERGE (maintainer:Maintainer:unpublished {
   email: m.email,
@@ -130,7 +132,7 @@ CREATE (interfaceGroup:InterfaceGroup:unpublished{
 
 CREATE (interfaceGroup)-[:DESCRIBED_BY]->(metadata)
 
-WITH value, metadata 
+WITH value, metadata
 UNWIND value.metadata.maintainers as m
 MERGE (maintainer:Maintainer:unpublished {
   email: m.email,

--- a/test/e2e/hub_test.go
+++ b/test/e2e/hub_test.go
@@ -43,7 +43,6 @@ var _ = Describe("GraphQL API", func() {
 				Expect(gotTypes).To(HaveLen(1))
 				Expect(gotTypes[0].Metadata.Path).To(Equal(fullTypePath))
 			})
-
 			It("based on a prefix of the parent node", func() {
 				const parentNode = "cap.core.type.platform.*"
 				expAssociatedPaths := []string{"cap.core.type.platform.kubernetes", "cap.type.platform.cloud-foundry"}
@@ -88,6 +87,16 @@ var _ = Describe("GraphQL API", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(gotTypes)).Should(BeNumerically(">=", 50))
+			})
+			It("no entries if prefix is not a regex and there is no Type with such explicit path", func() {
+				const parentNode = "cap.core.type.platform"
+
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					PathPattern: ptr.String(parentNode),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gotTypes).To(HaveLen(0))
 			})
 		})
 		Describe("should return ImplementationRevision", func() {

--- a/test/e2e/hub_test.go
+++ b/test/e2e/hub_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package e2e
@@ -7,17 +8,16 @@ import (
 	"fmt"
 	"strings"
 
-	prmt "github.com/gitchander/permutation"
-
-	"github.com/MakeNowJust/heredoc"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"capact.io/capact/internal/ptr"
 	gqllocalapi "capact.io/capact/pkg/hub/api/graphql/local"
 	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	hubclient "capact.io/capact/pkg/hub/client"
 	"capact.io/capact/pkg/hub/client/public"
+
+	"github.com/MakeNowJust/heredoc"
+	prmt "github.com/gitchander/permutation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GraphQL API", func() {
@@ -30,6 +30,66 @@ var _ = Describe("GraphQL API", func() {
 			cli = getHubGraphQLClient()
 		})
 
+		Describe("should return Types", func() {
+			It("based on full path name", func() {
+				const fullTypePath = "cap.core.type.platform.kubernetes"
+
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					PathPattern: ptr.String(fullTypePath),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(gotTypes).To(HaveLen(1))
+				Expect(gotTypes[0].Metadata.Path).To(Equal(fullTypePath))
+			})
+
+			It("based on a prefix of the parent node", func() {
+				const parentNode = "cap.core.type.platform.*"
+				expAssociatedPaths := []string{"cap.core.type.platform.kubernetes", "cap.type.platform.cloud-foundry"}
+
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					PathPattern: ptr.String(parentNode),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+
+				HasOnlyExpectTypePaths(gotTypes, expAssociatedPaths)
+			})
+			It("only child node if full path name specified", func() {
+				const fullTypePath = "cap.type.platform.cloud-foundry"
+
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					PathPattern: ptr.String(fullTypePath),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(gotTypes).To(HaveLen(1))
+				Expect(gotTypes[0].Metadata.Path).To(Equal(fullTypePath))
+			})
+			It("entries matching or regex (cap.core.type.generic.value|cap.type.platform.cloud-foundry)", func() {
+				expTypePaths := []string{"cap.core.type.generic.value", "cap.type.platform.cloud-foundry"}
+				typePathORFilter := fmt.Sprintf(`(%s)`, strings.Join(expTypePaths, "|"))
+
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					PathPattern: ptr.String(typePathORFilter),
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+
+				HasOnlyExpectTypePaths(gotTypes, expTypePaths)
+			})
+			It("all entries if there is no filter", func() {
+				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+					// no path filter
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(gotTypes)).Should(BeNumerically(">=", 50))
+			})
+		})
 		Describe("should return ImplementationRevision", func() {
 			const (
 				interfacePath  = "cap.interface.capactio.capact.validation.hub.install"
@@ -730,7 +790,7 @@ func expectedParentTypeInstance(ID string) *gqllocalapi.TypeInstance {
 
 // We cannot write specs using Context and It which are connected with each other
 // see: https://github.com/onsi/ginkgo/issues/246
-// this functions just adds syntax suggar which can be used when we have just one single `It` block
+// this functions just adds syntax sugar which can be used when we have just one single `It` block
 // with sequential test-cases
 func scenario(format string, args ...interface{}) {
 	fmt.Fprintf(GinkgoWriter, "[Scenario]: "+format+"\n", args...)
@@ -758,4 +818,16 @@ func allPermutations(in []string) string {
 		opts = append(opts, fmt.Sprintf(`"%s"`, strings.Join(in, `", "`)))
 	}
 	return fmt.Sprintf(`(%s)`, strings.Join(opts, "|"))
+}
+
+func HasOnlyExpectTypePaths(gotTypes []*gqlpublicapi.TypeRevision, expectedPaths []string) {
+	Expect(gotTypes).To(HaveLen(len(expectedPaths)))
+	var gotPaths []string
+	for _, t := range gotTypes {
+		if t == nil {
+			continue
+		}
+		gotPaths = append(gotPaths, t.Metadata.Path)
+	}
+	Expect(gotPaths).To(ConsistOf(expectedPaths))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add support to find Types based on prefix of parent nodes
- Update `hub-js` development documentation
- Populate **additionalRefs** to database, so it can be returned on GraphQL side
- Add integration tests to test that Types are properly returned:
  - based on full path name
  - based on a prefix of the parent node
  - only child node if full path name specified
  - entries matching **_or_** regex (cap.core.type.generic.value|cap.type.platform.cloud-foundry)
  - all entries if there is no filter
  - no entries if prefix is not a regex and there is no Type with such explicit path
- Fix bug that for current `main` version (https://github.com/capactio/capact/commit/43c74007d15f748f1210bb965eb2fd4c81fe44cf) where no entries are returned for empty filter:
    ```go
    gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
	    // no path filter
    })
    ```

   Problem: The Go JSONMarshaler marshals nil `pathPattern` as `null` which was not handled properly in Cyper query.
## Testing

Integration test proves that it works.

To check that manually, you can test it directly with Public Hub:

1. Run Neo4j:

    ```bash
    docker run -d \
      -p 7687:7687 -p 7474:7474 \
      -e "NEO4J_AUTH=neo4j/okon" \
      -e "NEO4JLABS_PLUGINS=[\"apoc\"]" \
      --name hub-neo4j-instance \
      ghcr.io/capactio/neo4j:4.2.13-apoc
    ```
2. Populate database:
    1.  Build populator: `make build-tool-populator`


    **NOTE:** ensure that you use newly built populator!
    
    ```bash
    env APP_JSONPUBLISHADDR=http://$(ipconfig getifaddr en0) APP_JSON_PUBLISH_PORT="8888" APP_MANIFESTS_PATH="manifests" populator register ocf-manifests --source github.com/capactio/hub-manifests/
    ```

3. Run Public Hub:

    ```bash
   cd hub-js; APP_NEO4J_ENDPOINT=bolt://localhost:7687 APP_NEO4J_PASSWORD=okon APP_HUB_MODE=public npm start
    ```

4. Run queries (e.g. use [Insomnia](https://insomnia.rest/download)):

    ```graphql
    query GetExplicitItem {
	    types(filter: { pathPattern: "cap.core.type.platform.kubernetes" }) {
		    prefix
		    path
		    revisions {
			    revision
			    spec {
				    additionalRefs
			    }
		    }
	    }
    }
    
    query GetAllCorePlatforms {
	    types(filter: { pathPattern: "cap.core.type.platform.*" }) {
		    prefix
		    path
		    revisions {
			    revision
			    spec {
				    additionalRefs
			    }
		    }
	    }
    }
    
    query GetAllCoreTypes {
	    types(filter: { pathPattern: "cap.core.type.*" }) {
		    prefix
		    path
		    revisions {
			    revision
			    spec {
				    additionalRefs
			    }
		    }
	    }
    }
    
    query GetCloudPlatform {
	    types(filter: { pathPattern: "cap.type.platform.cloud-foundry" }) {
		    prefix
		    path
		    revisions {
			    revision
			    spec {
				    additionalRefs
			    }
		    }
	    }
    }
    
    query GetWithOR {
	    types(
		    filter: {
			    pathPattern: "(cap.core.type.generic.value|cap.type.platform.cloud-foundry)"
		    }
	    ) {
		    prefix
		    path
		    revisions {
			    revision
			    spec {
				    additionalRefs
			    }
		    }
	    }
    }
    ```

## Related issue(s)

- https://github.com/capactio/capact/issues/601