### PR TITLE
Validate parent nodes in manifests

### DIFF
--- a/cmd/cli/cmd/hub/interfaces/get.go
+++ b/cmd/cli/cmd/hub/interfaces/get.go
@@ -39,7 +39,7 @@ func NewGet() *cobra.Command {
 		Example: heredoc.WithCLIName(`
 			# Show all Interfaces in table format:
 			<cli> hub interfaces get
-			
+
 			# Show "cap.interface.database.postgresql.install" Interface in JSON format:
 			<cli> hub interfaces get cap.interface.database.postgresql.install -ojson
 		`, cli.Name),

--- a/cmd/cli/cmd/login.go
+++ b/cmd/cli/cmd/login.go
@@ -130,16 +130,16 @@ func runLogin(ctx context.Context, opts loginOptions, w io.Writer) error {
 }
 
 func loginClientSide(ctx context.Context, serverURL string, creds *credstore.Credentials) error {
-	//cli, err := client.NewClusterWithCreds(serverURL, creds)
-	//if err != nil {
-	//	return err
-	//}
+	cli, err := client.NewClusterWithCreds(serverURL, creds)
+	if err != nil {
+		return err
+	}
 
 	// Only test the credentials, the actual response is irrelevant.
-	//_, err = cli.GetAction(ctx, "logintest")
-	//if err != nil {
-	//	return errors.Wrap(err, "while executing get action to test credentials")
-	//}
+	_, err = cli.GetAction(ctx, "logintest")
+	if err != nil {
+		return errors.Wrap(err, "while executing get action to test credentials")
+	}
 
 	return nil
 }

--- a/cmd/cli/cmd/login.go
+++ b/cmd/cli/cmd/login.go
@@ -130,16 +130,16 @@ func runLogin(ctx context.Context, opts loginOptions, w io.Writer) error {
 }
 
 func loginClientSide(ctx context.Context, serverURL string, creds *credstore.Credentials) error {
-	cli, err := client.NewClusterWithCreds(serverURL, creds)
-	if err != nil {
-		return err
-	}
+	//cli, err := client.NewClusterWithCreds(serverURL, creds)
+	//if err != nil {
+	//	return err
+	//}
 
 	// Only test the credentials, the actual response is irrelevant.
-	_, err = cli.GetAction(ctx, "logintest")
-	if err != nil {
-		return errors.Wrap(err, "while executing get action to test credentials")
-	}
+	//_, err = cli.GetAction(ctx, "logintest")
+	//if err != nil {
+	//	return errors.Wrap(err, "while executing get action to test credentials")
+	//}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/docker/cli v20.10.9+incompatible
 	github.com/docker/docker v20.10.9+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch/v5 v5.5.0 // indirect
 	github.com/fatih/camelcase v1.0.0
 	github.com/fatih/color v1.12.0

--- a/internal/cli/client/hub.go
+++ b/internal/cli/client/hub.go
@@ -21,6 +21,7 @@ import (
 
 // Hub aggregates operation executed by Capact CLI against Capact Hub server.
 type Hub interface {
+	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*gqlpublicapi.Type, error)
 	ListInterfaces(ctx context.Context, opts ...public.InterfaceOption) ([]*gqlpublicapi.Interface, error)
 	ListTypeInstances(ctx context.Context, filter *gqllocalapi.TypeInstanceFilter, opts ...local.TypeInstancesOption) ([]gqllocalapi.TypeInstance, error)
 	ListImplementationRevisions(ctx context.Context, opts ...public.ListImplementationRevisionsOption) ([]*gqlpublicapi.ImplementationRevision, error)
@@ -29,7 +30,6 @@ type Hub interface {
 	CreateTypeInstances(ctx context.Context, in *gqllocalapi.CreateTypeInstancesInput) ([]gqllocalapi.CreateTypeInstanceOutput, error)
 	UpdateTypeInstances(ctx context.Context, in []gqllocalapi.UpdateTypeInstancesInput, opts ...local.TypeInstancesOption) ([]gqllocalapi.TypeInstance, error)
 	DeleteTypeInstance(ctx context.Context, id string) error
-	ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter gqlpublicapi.TypeFilter) ([]*gqlpublicapi.TypeRevision, error)
 	FindInterfaceRevision(ctx context.Context, ref gqlpublicapi.InterfaceReference, opts ...public.InterfaceRevisionOption) (*gqlpublicapi.InterfaceRevision, error)
 	FindTypeInstancesTypeRef(ctx context.Context, ids []string) (map[string]gqllocalapi.TypeInstanceTypeReference, error)
 	CheckManifestRevisionsExist(ctx context.Context, manifestRefs []gqlpublicapi.ManifestReference) (map[gqlpublicapi.ManifestReference]bool, error)

--- a/internal/regexutil/string.go
+++ b/internal/regexutil/string.go
@@ -1,0 +1,11 @@
+package regexutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OrStringSlice returns or regexp for all items in a given slice.
+func OrStringSlice(in []string) string {
+	return fmt.Sprintf(`(%s)`, strings.Join(in, "|"))
+}

--- a/pkg/hub/client/client.go
+++ b/pkg/hub/client/client.go
@@ -34,6 +34,7 @@ type Local interface {
 
 // Public interface aggregates methods to interact with Capact Public Hub.
 type Public interface {
+	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*hubpublicgraphql.Type, error)
 	ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter hubpublicgraphql.TypeFilter) ([]*hubpublicgraphql.TypeRevision, error)
 	GetInterfaceLatestRevisionString(ctx context.Context, ref hubpublicgraphql.InterfaceReference) (string, error)
 	FindInterfaceRevision(ctx context.Context, ref hubpublicgraphql.InterfaceReference, opts ...public.InterfaceRevisionOption) (*hubpublicgraphql.InterfaceRevision, error)

--- a/pkg/hub/client/client.go
+++ b/pkg/hub/client/client.go
@@ -35,7 +35,6 @@ type Local interface {
 // Public interface aggregates methods to interact with Capact Public Hub.
 type Public interface {
 	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*hubpublicgraphql.Type, error)
-	ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter hubpublicgraphql.TypeFilter) ([]*hubpublicgraphql.TypeRevision, error)
 	GetInterfaceLatestRevisionString(ctx context.Context, ref hubpublicgraphql.InterfaceReference) (string, error)
 	FindInterfaceRevision(ctx context.Context, ref hubpublicgraphql.InterfaceReference, opts ...public.InterfaceRevisionOption) (*hubpublicgraphql.InterfaceRevision, error)
 	ListImplementationRevisionsForInterface(ctx context.Context, ref hubpublicgraphql.InterfaceReference, opts ...public.ListImplementationRevisionsForInterfaceOption) ([]hubpublicgraphql.ImplementationRevision, error)

--- a/pkg/hub/client/fake/fake.go
+++ b/pkg/hub/client/fake/fake.go
@@ -92,18 +92,21 @@ func (s *FileSystemClient) ListTypeInstancesTypeRef(ctx context.Context) ([]hubl
 	return typeInstanceTypeRefs, nil
 }
 
-// ListTypeRefRevisionsJSONSchemas returns the list of requested Types.
+// ListTypes returns the list of requested Types.
 // Only a few fields are populated.
-func (s *FileSystemClient) ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter hubpublicgraphql.TypeFilter) ([]*hubpublicgraphql.TypeRevision, error) {
-	var out []*hubpublicgraphql.TypeRevision
+func (s *FileSystemClient) ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*hubpublicgraphql.Type, error) {
+	typeOpts := &public.TypeOptions{}
+	typeOpts.Apply(opts...)
+
+	var out []*hubpublicgraphql.Type
 
 	for _, typeRev := range s.Types {
 		if typeRev.Metadata == nil || typeRev.Spec == nil {
 			continue
 		}
 
-		if filter.PathPattern != nil {
-			match, err := regexp.MatchString(*filter.PathPattern, typeRev.Metadata.Path)
+		if typeOpts.Filter.PathPattern != nil {
+			match, err := regexp.MatchString(*typeOpts.Filter.PathPattern, typeRev.Metadata.Path)
 			if err != nil {
 				return nil, err
 			}
@@ -113,14 +116,17 @@ func (s *FileSystemClient) ListTypeRefRevisionsJSONSchemas(ctx context.Context, 
 		}
 
 		// populate only few fields as original method
-		out = append(out, &hubpublicgraphql.TypeRevision{
-			Revision: typeRev.Revision,
-			Metadata: &hubpublicgraphql.TypeMetadata{
-				Path: typeRev.Metadata.Path,
-			},
-			Spec: &hubpublicgraphql.TypeSpec{
-				JSONSchema: typeRev.Spec.JSONSchema,
-			},
+		out = append(out, &hubpublicgraphql.Type{
+			Path: typeRev.Metadata.Path,
+			Revisions: []*hubpublicgraphql.TypeRevision{{
+				Revision: typeRev.Revision,
+				Metadata: &hubpublicgraphql.TypeMetadata{
+					Path: typeRev.Metadata.Path,
+				},
+				Spec: &hubpublicgraphql.TypeSpec{
+					JSONSchema: typeRev.Spec.JSONSchema,
+				},
+			}},
 		})
 	}
 

--- a/pkg/hub/client/public/client.go
+++ b/pkg/hub/client/public/client.go
@@ -57,44 +57,6 @@ func (c *Client) FindInterfaceRevision(ctx context.Context, ref gqlpublicapi.Int
 	return resp.Interface.Revision, nil
 }
 
-// ListTypeRefRevisionsJSONSchemas returns the list of requested Types.
-// Only a few fields are populated. Check the query fields for more information.
-func (c *Client) ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter gqlpublicapi.TypeFilter) ([]*gqlpublicapi.TypeRevision, error) {
-	req := graphql.NewRequest(`query ListTypeRefsJSONSchemas($typeFilter: TypeFilter!)  {
-		  types(filter: $typeFilter) {
-			  revisions {
-			    revision
-			    metadata {
-			  	  path
-			    }
-			    spec {
-			  	  jsonSchema
-			    }
-			  }
-		  }
-		}`)
-
-	req.Var("typeFilter", filter)
-
-	var resp struct {
-		Types []*gqlpublicapi.Type `json:"types"`
-	}
-	err := retry.Do(func() error {
-		return c.client.Run(ctx, req, &resp)
-	}, retry.Attempts(retryAttempts))
-
-	if err != nil {
-		return nil, errors.Wrap(err, "while executing query to list Types")
-	}
-
-	var out []*gqlpublicapi.TypeRevision
-	for _, t := range resp.Types {
-		out = append(out, t.Revisions...)
-	}
-
-	return out, nil
-}
-
 // ListTypes returns all requested Types. By default, only root fields are populated.
 // Use options to add latestRevision fields or apply additional filtering.
 func (c *Client) ListTypes(ctx context.Context, opts ...TypeOption) ([]*gqlpublicapi.Type, error) {

--- a/pkg/hub/client/public/type_options.go
+++ b/pkg/hub/client/public/type_options.go
@@ -1,0 +1,51 @@
+package public
+
+import (
+	"fmt"
+
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+)
+
+// TypeOption provides an option to configure the find request for Type.
+type TypeOption func(*TypeOptions)
+
+// TypeOptions stores Type filtering parameters.
+type TypeOptions struct {
+	additionalFields string
+	Filter           gqlpublicapi.TypeFilter
+}
+
+// Apply is used to configure the TypeOption.
+func (o *TypeOptions) Apply(opts ...TypeOption) {
+	// Apply overrides
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// WithTypeRevisions adds revisions field for Type query.
+func WithTypeRevisions(requestedFields TypeRevisionQueryFields) TypeOption {
+	return func(opts *TypeOptions) {
+		opts.additionalFields = fmt.Sprintf(`
+				revisions {
+					%s
+				}`, getTypeRevisionFieldsFromFlags(requestedFields))
+	}
+}
+
+// WithTypeLatestRevision adds latestRevision field for Type query.
+func WithTypeLatestRevision(requestedFields TypeRevisionQueryFields) TypeOption {
+	return func(opts *TypeOptions) {
+		opts.additionalFields = fmt.Sprintf(`
+				latestRevision {
+					%s
+				}`, getTypeRevisionFieldsFromFlags(requestedFields))
+	}
+}
+
+// WithTypeFilter adds a given filter to Type query.
+func WithTypeFilter(filter gqlpublicapi.TypeFilter) TypeOption {
+	return func(opts *TypeOptions) {
+		opts.Filter = filter
+	}
+}

--- a/pkg/hub/client/public/type_rev_fields.go
+++ b/pkg/hub/client/public/type_rev_fields.go
@@ -6,8 +6,9 @@ import "fmt"
 var typeRevisionFieldsRegistry = map[TypeRevisionQueryFields]string{
 	TypeRevisionRootFields: `
 		revision`,
-	TypeRevisionMetadataFields: typeRevisionMetadataFields,
-	TypeRevisionSpecFields:     typeRevisionSpecFields,
+	TypeRevisionMetadataFields:          typeRevisionMetadataFields,
+	TypeRevisionSpecFields:              typeRevisionSpecFields,
+	TypeRevisionSpecAdditionalRefsField: typeRevisionSpecAdditionalRefsField,
 }
 
 // typeRevisionMetadataFields for querying TypeRevision's Metadata fields.
@@ -20,6 +21,13 @@ var typeRevisionMetadataFields = fmt.Sprintf(`
 var typeRevisionSpecFields = `
       spec {
         jsonSchema
-				additionalRefs
+        additionalRefs
+      }
+`
+
+// typeRevisionSpecAdditionalRefsField for fetching TypeRevision's spec.additionalRefs field only.
+var typeRevisionSpecAdditionalRefsField = `
+      spec {
+        additionalRefs
       }
 `

--- a/pkg/hub/client/public/type_rev_fields.go
+++ b/pkg/hub/client/public/type_rev_fields.go
@@ -11,22 +11,22 @@ var typeRevisionFieldsRegistry = map[TypeRevisionQueryFields]string{
 	TypeRevisionSpecAdditionalRefsField: typeRevisionSpecAdditionalRefsField,
 }
 
-// typeRevisionMetadataFields for querying TypeRevision's Metadata fields.
+// typeRevisionMetadataFields specifies TypeRevision's Metadata fields.
 var typeRevisionMetadataFields = fmt.Sprintf(`
       metadata {
         %s
       }`, genericMetadataFields)
 
-// typeRevisionSpecFields for fetching TypeRevision's spec fields only.
-var typeRevisionSpecFields = `
+// typeRevisionSpecFields specifies TypeRevision's spec fields only.
+const typeRevisionSpecFields = `
       spec {
         jsonSchema
         additionalRefs
       }
 `
 
-// typeRevisionSpecAdditionalRefsField for fetching TypeRevision's spec.additionalRefs field only.
-var typeRevisionSpecAdditionalRefsField = `
+// typeRevisionSpecAdditionalRefsField specifies TypeRevision's spec.additionalRefs field only.
+const typeRevisionSpecAdditionalRefsField = `
       spec {
         additionalRefs
       }

--- a/pkg/hub/client/public/type_rev_fields.go
+++ b/pkg/hub/client/public/type_rev_fields.go
@@ -1,0 +1,25 @@
+package public
+
+import "fmt"
+
+// typeRevisionFieldsRegistry holds possible fields configuration for InterfaceRevision query.
+var typeRevisionFieldsRegistry = map[TypeRevisionQueryFields]string{
+	TypeRevisionRootFields: `
+		revision`,
+	TypeRevisionMetadataFields: typeRevisionMetadataFields,
+	TypeRevisionSpecFields:     typeRevisionSpecFields,
+}
+
+// typeRevisionMetadataFields for querying TypeRevision's Metadata fields.
+var typeRevisionMetadataFields = fmt.Sprintf(`
+      metadata {
+        %s
+      }`, genericMetadataFields)
+
+// typeRevisionSpecFields for fetching TypeRevision's spec fields only.
+var typeRevisionSpecFields = `
+      spec {
+        jsonSchema
+				additionalRefs
+      }
+`

--- a/pkg/hub/client/public/type_rev_options.go
+++ b/pkg/hub/client/public/type_rev_options.go
@@ -12,6 +12,8 @@ const (
 	TypeRevisionMetadataFields
 	// TypeRevisionSpecFields for fetching TypeRevision's spec fields only.
 	TypeRevisionSpecFields
+	// TypeRevisionSpecAdditionalRefsField for fetching TypeRevision's spec.additionalRefs field only.
+	TypeRevisionSpecAdditionalRefsField
 
 	typeRevMaxKey
 )

--- a/pkg/hub/client/public/type_rev_options.go
+++ b/pkg/hub/client/public/type_rev_options.go
@@ -1,0 +1,48 @@
+package public
+
+import "strings"
+
+// TypeRevisionQueryFields allows configuring which fields should be returned for TypeRevision query.
+type TypeRevisionQueryFields uint64
+
+const (
+	// TypeRevisionRootFields returns all primitive fields specified on root.
+	TypeRevisionRootFields TypeRevisionQueryFields = 1 << iota
+	// TypeRevisionMetadataFields returns TypeRevision's metadata fields.
+	TypeRevisionMetadataFields
+	// TypeRevisionSpecFields for fetching TypeRevision's spec fields only.
+	TypeRevisionSpecFields
+
+	typeRevMaxKey
+)
+
+// Has returns true if flag is set.
+func (f TypeRevisionQueryFields) Has(flag TypeRevisionQueryFields) bool { return f&flag != 0 }
+
+// TypeRevisionOption provides an option to configure the find request for Type Revision.
+type TypeRevisionOption func(*TypeRevisionOptions)
+
+// TypeRevisionOptions stores Type Revision filtering parameters.
+type TypeRevisionOptions struct {
+	fields string
+}
+
+// Apply is used to configure the TypeRevisionOption.
+func (o *TypeRevisionOptions) Apply(opts ...TypeRevisionOption) {
+	o.fields = getTypeRevisionFieldsFromFlags(TypeRevisionRootFields | TypeRevisionMetadataFields | TypeRevisionSpecFields) // defaults to all fields, backward compatible
+
+	// Apply overrides
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+func getTypeRevisionFieldsFromFlags(queryFields TypeRevisionQueryFields) string {
+	var names []string
+	for fieldOpt := TypeRevisionRootFields; fieldOpt < typeRevMaxKey; fieldOpt <<= 1 {
+		if queryFields.Has(fieldOpt) {
+			names = append(names, typeRevisionFieldsRegistry[fieldOpt])
+		}
+	}
+	return strings.Join(names, "\n")
+}

--- a/pkg/runner/helm/config_loader.go
+++ b/pkg/runner/helm/config_loader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -73,7 +74,7 @@ func setKubeconfigEnvIfTypeInstanceExists(path string, log *zap.Logger) error {
 }
 
 func extractKubeconfigFromTI(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/apis/0.0.1/types/types.extend.go
+++ b/pkg/sdk/apis/0.0.1/types/types.extend.go
@@ -1,6 +1,9 @@
 // Package types holds manually added types.
 package types
 
+// OCFPathPrefix defines path prefix that all OCF manifest must have.
+const OCFPathPrefix = "cap."
+
 // InterfaceRef holds the full path and revision to the Interface
 type InterfaceRef ManifestRefWithOptRevision
 

--- a/pkg/sdk/validation/fake_hub.go
+++ b/pkg/sdk/validation/fake_hub.go
@@ -1,0 +1,80 @@
+package validation
+
+import (
+	"context"
+
+	"capact.io/capact/internal/cli/heredoc"
+	gqllocalapi "capact.io/capact/pkg/hub/api/graphql/local"
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
+)
+
+// FakeHubCli provides an easy way to fake real Hub client. It is used for test purposes.
+type FakeHubCli struct {
+	Types          []*gqlpublicapi.Type
+	IDsTypeRefs    map[string]gqllocalapi.TypeInstanceTypeReference
+	ListTypesError error
+}
+
+// FindTypeInstancesTypeRef returns fake data
+func (f *FakeHubCli) FindTypeInstancesTypeRef(_ context.Context, _ []string) (map[string]gqllocalapi.TypeInstanceTypeReference, error) {
+	return f.IDsTypeRefs, nil
+}
+
+// ListTypes returns fake data
+func (f *FakeHubCli) ListTypes(_ context.Context, _ ...public.TypeOption) ([]*gqlpublicapi.Type, error) {
+	return f.Types, f.ListTypesError
+}
+
+// AWSCredsTypeRevFixture returns test fixture for AWS credentials Type.
+func AWSCredsTypeRevFixture() *gqlpublicapi.Type {
+	return &gqlpublicapi.Type{
+		Path: "cap.type.aws.auth.creds",
+		Revisions: []*gqlpublicapi.TypeRevision{
+			{
+				Revision: "0.1.0",
+				Spec: &gqlpublicapi.TypeSpec{
+					JSONSchema: heredoc.Doc(`
+                    {
+                      "$schema": "http://json-schema.org/draft-07/schema",
+                      "type": "object",
+                      "required": [ "key" ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        }
+                      }
+                    }`),
+				},
+			}},
+	}
+}
+
+// AWSElasticsearchTypeRevFixture returns test fixture for AWS Elasticsearch Type.
+func AWSElasticsearchTypeRevFixture() *gqlpublicapi.Type {
+	return &gqlpublicapi.Type{
+		Path: "cap.type.aws.elasticsearch.install-input",
+		Revisions: []*gqlpublicapi.TypeRevision{{
+			Metadata: &gqlpublicapi.TypeMetadata{
+				Path: "cap.type.aws.elasticsearch.install-input",
+			},
+			Revision: "0.1.0",
+			Spec: &gqlpublicapi.TypeSpec{
+				JSONSchema: heredoc.Doc(`
+                    {
+                      "$schema": "http://json-schema.org/draft-07/schema",
+                      "type": "object",
+                      "title": "The schema for Elasticsearch input parameters.",
+                      "required": ["replicas"],
+                      "properties": {
+                        "replicas": {
+                          "type": "string",
+                          "title": "Replica count for the Elasticsearch"
+                        }
+                      },
+                      "additionalProperties": false
+                    }`),
+			},
+		}},
+	}
+}

--- a/pkg/sdk/validation/interfaceio/validator.go
+++ b/pkg/sdk/validation/interfaceio/validator.go
@@ -6,6 +6,7 @@ import (
 
 	gqllocalapi "capact.io/capact/pkg/hub/api/graphql/local"
 	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"capact.io/capact/pkg/sdk/validation"
 
@@ -16,7 +17,7 @@ import (
 
 // HubClient defines external Hub calls used by Validator.
 type HubClient interface {
-	ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter gqlpublicapi.TypeFilter) ([]*gqlpublicapi.TypeRevision, error)
+	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*gqlpublicapi.Type, error)
 	FindTypeInstancesTypeRef(ctx context.Context, ids []string) (map[string]gqllocalapi.TypeInstanceTypeReference, error)
 }
 

--- a/pkg/sdk/validation/manifest/fsvalidator_test.go
+++ b/pkg/sdk/validation/manifest/fsvalidator_test.go
@@ -56,14 +56,14 @@ func TestFilesystemValidator_ValidateFile(t *testing.T) {
 			manifestPath: "testdata/invalid-implementation.yaml",
 			expectedValidationErrorMsgs: []string{
 				"OCFSchemaValidator: spec: appVersion is required",
-				"RemoteImplementationValidator: Type cap.type.platform.cloud-foundry:0.1.0 is not attached to cap.core.type.platform abstract node",
+				`RemoteImplementationValidator: Type "cap.type.database.postgresql.config:0.1.0" is not attached to "cap.core.type.platform" parent node`,
 				"RemoteImplementationValidator: manifest revision 'cap.interface.cms.wordpress:0.1.0' doesn't exist in Hub",
 			},
 			hubCli: fixHub(t, []*graphql.Type{
-				fixGQLType("cap.type.platform.cloud-foundry", "0.1.0", ""),
+				fixGQLType("cap.type.database.postgresql.config", "0.1.0", ""),
 			}, map[graphql.ManifestReference]bool{
-				manifestRef("cap.interface.cms.wordpress"):     false,
-				manifestRef("cap.type.platform.cloud-foundry"): true,
+				manifestRef("cap.interface.cms.wordpress"):         false,
+				manifestRef("cap.type.database.postgresql.config"): true,
 			}, nil),
 		},
 		"Invalid Interface": {
@@ -93,8 +93,8 @@ func TestFilesystemValidator_ValidateFile(t *testing.T) {
 		"Invalid additionalRefs in Type": {
 			manifestPath: "testdata/invalid-type_additionalRefs.yaml",
 			expectedValidationErrorMsgs: []string{
-				`TypeValidator: spec.additionalRefs: "cap.interface.postgresql" is not allowed. It can refers only to parent node under "cap.core.type." or "cap.type."`,
-				`RemoteTypeValidator: cap.core.type.platform.kubernetes cannot be used as parent node as it resolves to concrete Type`,
+				`TypeValidator: spec.additionalRefs: "cap.interface.postgresql" is not allowed. It can refer only to a parent node under "cap.core.type." or "cap.type."`,
+				`RemoteTypeValidator: "cap.core.type.platform.kubernetes" cannot be used as parent node as it resolves to concrete Type`,
 			},
 			hubCli: fixHub(t, []*graphql.Type{
 				fixGQLType("cap.core.type.platform.kubernetes", "0.1.0", ""),

--- a/pkg/sdk/validation/manifest/helpers_test.go
+++ b/pkg/sdk/validation/manifest/helpers_test.go
@@ -1,0 +1,55 @@
+package manifest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeHub struct {
+	fn                      func(ctx context.Context, manifestRefs []gqlpublicapi.ManifestReference) (map[gqlpublicapi.ManifestReference]bool, error)
+	knownTypesByPathPattern map[string][]*gqlpublicapi.Type
+}
+
+func (h *fakeHub) ListTypes(_ context.Context, opts ...public.TypeOption) ([]*gqlpublicapi.Type, error) {
+	if h.knownTypesByPathPattern == nil {
+		return nil, nil
+	}
+
+	typeOpts := &public.TypeOptions{}
+	typeOpts.Apply(opts...)
+
+	if typeOpts.Filter.PathPattern == nil {
+		return nil, nil
+	}
+	return h.knownTypesByPathPattern[*typeOpts.Filter.PathPattern], nil
+}
+
+func (h *fakeHub) CheckManifestRevisionsExist(ctx context.Context, manifestRefs []gqlpublicapi.ManifestReference) (map[gqlpublicapi.ManifestReference]bool, error) {
+	return h.fn(ctx, manifestRefs)
+}
+
+func fixHubForManifestsExistence(t *testing.T, result map[gqlpublicapi.ManifestReference]bool, err error) *fakeHub {
+	t.Helper()
+
+	hub := &fakeHub{
+		fn: func(ctx context.Context, manifestRefs []gqlpublicapi.ManifestReference) (map[gqlpublicapi.ManifestReference]bool, error) {
+			var resultManifestRefs []gqlpublicapi.ManifestReference
+			for key := range result {
+				resultManifestRefs = append(resultManifestRefs, key)
+			}
+			ok := assert.ElementsMatch(t, manifestRefs, resultManifestRefs)
+			if !ok {
+				return nil, errors.New("manifest references don't match")
+			}
+
+			return result, err
+		},
+	}
+	return hub
+}

--- a/pkg/sdk/validation/manifest/helpers_test.go
+++ b/pkg/sdk/validation/manifest/helpers_test.go
@@ -47,6 +47,12 @@ func (h *fakeHub) CheckManifestRevisionsExist(ctx context.Context, manifestRefs 
 	return h.checkManifestsFn(ctx, manifestRefs)
 }
 
+func fixHub(t *testing.T, knownListTypes []*gqlpublicapi.Type, manifests map[gqlpublicapi.ManifestReference]bool, err error) *fakeHub {
+	hub := fixHubForManifestsExistence(t, manifests, err)
+	hub.knownTypes = knownListTypes
+	return hub
+}
+
 func fixHubForManifestsExistence(t *testing.T, result map[gqlpublicapi.ManifestReference]bool, err error) *fakeHub {
 	t.Helper()
 

--- a/pkg/sdk/validation/manifest/json_interface.go
+++ b/pkg/sdk/validation/manifest/json_interface.go
@@ -40,7 +40,7 @@ func (v *InterfaceValidator) Do(_ context.Context, _ types.ManifestMetadata, jso
 		toValidate[key] = param.JSONSchema.Value
 	}
 
-	return validateJSONSchema07Definition(toValidate)
+	return checkJSONSchema07Definition(toValidate)
 }
 
 // Name returns the validator name.

--- a/pkg/sdk/validation/manifest/json_remote_helper.go
+++ b/pkg/sdk/validation/manifest/json_remote_helper.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"fmt"
 
-	hubpublicgraphql "capact.io/capact/pkg/hub/api/graphql/public"
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
+
 	"github.com/pkg/errors"
 )
 
 // Hub is an interface for Hub GraphQL client methods needed for the remote validation.
 type Hub interface {
-	CheckManifestRevisionsExist(ctx context.Context, manifestRefs []hubpublicgraphql.ManifestReference) (map[hubpublicgraphql.ManifestReference]bool, error)
+	CheckManifestRevisionsExist(ctx context.Context, manifestRefs []gqlpublicapi.ManifestReference) (map[gqlpublicapi.ManifestReference]bool, error)
+	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*gqlpublicapi.Type, error)
 }
 
-func checkManifestRevisionsExist(ctx context.Context, hub Hub, manifestRefsToCheck []hubpublicgraphql.ManifestReference) (ValidationResult, error) {
+func checkManifestRevisionsExist(ctx context.Context, hub Hub, manifestRefsToCheck []gqlpublicapi.ManifestReference) (ValidationResult, error) {
 	if len(manifestRefsToCheck) == 0 {
 		return ValidationResult{}, nil
 	}

--- a/pkg/sdk/validation/manifest/json_remote_implementation.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation.go
@@ -3,12 +3,24 @@ package manifest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
-	hubpublicgraphql "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/internal/ptr"
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
+
+	"github.com/dustin/go-humanize/english"
 	"github.com/pkg/errors"
 )
+
+const ocfPathPrefix = "cap."
+
+// ParentNodesAssociation represents relations between parent node and associated other types.
+// - key holds the parent node path
+// - value holds list of associated Types
+type ParentNodesAssociation map[string][]string
 
 // RemoteImplementationValidator is a validator for Implementation manifest, which calls Hub in order to do validation checks.
 type RemoteImplementationValidator struct {
@@ -30,11 +42,11 @@ func (v *RemoteImplementationValidator) Do(ctx context.Context, _ types.Manifest
 		return ValidationResult{}, errors.Wrap(err, "while unmarshalling JSON into Implementation type")
 	}
 
-	var manifestRefsToCheck []hubpublicgraphql.ManifestReference
+	var manifestRefsToCheck []gqlpublicapi.ManifestReference
 
 	// Attributes
 	for path, attr := range entity.Metadata.Attributes {
-		manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference{
+		manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference{
 			Path:     path,
 			Revision: attr.Revision,
 		})
@@ -44,12 +56,12 @@ func (v *RemoteImplementationValidator) Do(ctx context.Context, _ types.Manifest
 	if entity.Spec.AdditionalInput != nil {
 		// Parameters
 		for _, param := range entity.Spec.AdditionalInput.Parameters {
-			manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference(param.TypeRef))
+			manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference(param.TypeRef))
 		}
 
 		// TypeInstances
 		for _, ti := range entity.Spec.AdditionalInput.TypeInstances {
-			manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference(ti.TypeRef))
+			manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference(ti.TypeRef))
 		}
 	}
 
@@ -60,38 +72,40 @@ func (v *RemoteImplementationValidator) Do(ctx context.Context, _ types.Manifest
 				continue
 			}
 
-			manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference(*ti.TypeRef))
+			manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference(*ti.TypeRef))
 		}
 	}
 
 	// Implements
 	for _, implementsItem := range entity.Spec.Implements {
-		manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference(implementsItem))
+		manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference(implementsItem))
 	}
 
 	// Requires
-	for requiresKey, requiresValue := range entity.Spec.Requires {
-		var itemsToCheck []types.RequireEntity
-		itemsToCheck = append(itemsToCheck, requiresValue.OneOf...)
-		itemsToCheck = append(itemsToCheck, requiresValue.AllOf...)
-		itemsToCheck = append(itemsToCheck, requiresValue.AnyOf...)
+	parentNodeTypesToCheck := ParentNodesAssociation{}
+	for requiresKey, reqItem := range entity.Spec.Requires {
+		typesThatShouldExist, typesThatHasParentNode := v.resolveRequiresPath(requiresKey, reqItem)
+		manifestRefsToCheck = append(manifestRefsToCheck, typesThatShouldExist...)
 
-		for _, requiresSubItem := range itemsToCheck {
-			manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference{
-				Path:     strings.Join([]string{requiresKey, requiresSubItem.Name}, "."),
-				Revision: requiresSubItem.Revision,
-			})
+		for k, v := range typesThatHasParentNode {
+			parentNodeTypesToCheck[k] = append(parentNodeTypesToCheck[k], v...)
 		}
 	}
 
 	// Imports
 	for _, importsItem := range entity.Spec.Imports {
 		for _, method := range importsItem.Methods {
-			manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference{
+			manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference{
 				Path:     strings.Join([]string{importsItem.InterfaceGroupPath, method.Name}, "."),
 				Revision: method.Revision,
 			})
 		}
+	}
+
+	// TODO: refactor after https://github.com/capactio/capact/pull/610
+	res, err := v.checkParentNodesAssociation(ctx, parentNodeTypesToCheck)
+	if !res.Valid() || err != nil {
+		return res, err
 	}
 
 	return checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
@@ -100,4 +114,95 @@ func (v *RemoteImplementationValidator) Do(ctx context.Context, _ types.Manifest
 // Name returns the validator name.
 func (v *RemoteImplementationValidator) Name() string {
 	return "RemoteImplementationValidator"
+}
+
+func (v *RemoteImplementationValidator) resolveRequiresPath(abstractPrefix string, reqItem types.Require) ([]gqlpublicapi.ManifestReference, ParentNodesAssociation) {
+	var (
+		typesThatShouldExist   []gqlpublicapi.ManifestReference
+		typesThatHasParentNode = ParentNodesAssociation{}
+	)
+
+	var allReqItems []types.RequireEntity
+	allReqItems = append(allReqItems, reqItem.OneOf...)
+	allReqItems = append(allReqItems, reqItem.AllOf...)
+	allReqItems = append(allReqItems, reqItem.AnyOf...)
+
+	for _, requiresSubItem := range allReqItems {
+		path := strings.Join([]string{abstractPrefix, requiresSubItem.Name}, ".")
+
+		// Check if item is concrete Type. If yes, it needs to be attached to parent node. For example:
+		// requires:
+		//   cap.core.type.platform:
+		//    oneOf:
+		//      - name: cap.type.platform.cloud-foundry # this MUST be attached to `cap.core.type.platform`
+		//        revision: 0.1.0
+		if strings.HasPrefix(requiresSubItem.Name, ocfPathPrefix) {
+			path = requiresSubItem.Name
+			typesThatHasParentNode[abstractPrefix] = append(typesThatHasParentNode[abstractPrefix], path)
+		}
+
+		typesThatShouldExist = append(typesThatShouldExist, gqlpublicapi.ManifestReference{
+			Path:     path,
+			Revision: requiresSubItem.Revision,
+		})
+	}
+
+	return typesThatShouldExist, typesThatHasParentNode
+}
+
+// TODO: revisions
+func (v *RemoteImplementationValidator) checkParentNodesAssociation(ctx context.Context, relations ParentNodesAssociation) (ValidationResult, error) {
+	if len(relations) == 0 {
+		return ValidationResult{}, nil
+	}
+
+	var validationErrs []error
+	for abstractNode, expAttachedTypes := range relations {
+		res, err := v.hub.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
+			PathPattern: ptr.String(abstractNode),
+		}))
+		if err != nil {
+			return ValidationResult{}, errors.Wrap(err, "while fetching Types based on abstract node")
+		}
+
+		var gotAttachedTypes []string
+		for _, item := range res {
+			gotAttachedTypes = append(gotAttachedTypes, item.Path)
+		}
+
+		missingEntries := v.detectMissingEntriesInASet(gotAttachedTypes, expAttachedTypes)
+		if len(missingEntries) == 0 {
+			continue
+		}
+
+		validationErrs = append(validationErrs, fmt.Errorf("%s %s %s not attached to %s abstract node",
+			english.PluralWord(len(missingEntries), "Type", ""),
+			english.WordSeries(missingEntries, "and"),
+			english.PluralWord(len(missingEntries), "is", "are"),
+			abstractNode,
+		))
+	}
+
+	return ValidationResult{Errors: validationErrs}, nil
+}
+
+func (v *RemoteImplementationValidator) detectMissingEntriesInASet(a, b []string) []string {
+	// we don't do `len(a) != len(b)` as it only informs us that there will be definitely
+	// some missing entries, but we need to find out names
+
+	aSetIndex := make(map[string]struct{}, len(a))
+	for _, val := range a {
+		aSetIndex[val] = struct{}{}
+	}
+
+	var missingEntries []string
+	for _, val := range b {
+		if _, found := aSetIndex[val]; found {
+			continue
+		}
+
+		missingEntries = append(missingEntries, val)
+	}
+
+	return missingEntries
 }

--- a/pkg/sdk/validation/manifest/json_remote_implementation.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation.go
@@ -167,7 +167,6 @@ func (v *RemoteImplementationValidator) checkParentNodesAssociation(ctx context.
 		typesPath, expAttachedTypes := v.mapToPathAndPathRevIndex(expTypesRefs)
 
 		filter := regexutil.OrStringSlice(typesPath)
-
 		res, err := v.hub.ListTypes(ctx, public.WithTypeRevisions(typeListQueryFields), public.WithTypeFilter(gqlpublicapi.TypeFilter{
 			PathPattern: ptr.String(filter),
 		}))

--- a/pkg/sdk/validation/manifest/json_remote_implementation.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation.go
@@ -107,12 +107,18 @@ func (v *RemoteImplementationValidator) Do(ctx context.Context, _ types.Manifest
 	}
 
 	// TODO: refactor after https://github.com/capactio/capact/pull/610
-	res, err := v.checkParentNodesAssociation(ctx, parentNodeTypesToCheck)
-	if !res.Valid() || err != nil {
-		return res, err
+	resAssociation, err := v.checkParentNodesAssociation(ctx, parentNodeTypesToCheck)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+	resExist, err := checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
+	if err != nil {
+		return ValidationResult{}, err
 	}
 
-	return checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
+	return ValidationResult{
+		Errors: append(resAssociation.Errors, resExist.Errors...),
+	}, nil
 }
 
 // Name returns the validator name.

--- a/pkg/sdk/validation/manifest/json_remote_implementation_export_test.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation_export_test.go
@@ -1,0 +1,9 @@
+package manifest
+
+import "context"
+
+// CheckParentNodesAssociation is just a hack to export the internal method for testing purposes.
+// The *_test.go files are not compiled into final binary, and as it's under _test.go it's also not accessible for other non-testing packages.
+func (v *RemoteImplementationValidator) CheckParentNodesAssociation(ctx context.Context, relations map[string][]string) (ValidationResult, error) {
+	return v.checkParentNodesAssociation(ctx, relations)
+}

--- a/pkg/sdk/validation/manifest/json_remote_implementation_export_test.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation_export_test.go
@@ -4,6 +4,6 @@ import "context"
 
 // CheckParentNodesAssociation is just a hack to export the internal method for testing purposes.
 // The *_test.go files are not compiled into final binary, and as it's under _test.go it's also not accessible for other non-testing packages.
-func (v *RemoteImplementationValidator) CheckParentNodesAssociation(ctx context.Context, relations map[string][]string) (ValidationResult, error) {
+func (v *RemoteImplementationValidator) CheckParentNodesAssociation(ctx context.Context, relations ParentNodesAssociation) (ValidationResult, error) {
 	return v.checkParentNodesAssociation(ctx, relations)
 }

--- a/pkg/sdk/validation/manifest/json_remote_implementation_test.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation_test.go
@@ -14,56 +14,88 @@ import (
 
 func TestCheckParentNodesAssociation(t *testing.T) {
 	tests := map[string]struct {
-		knownTypesByPathPattern map[string][]*gqlpublicapi.Type
-		relationsToParentNode   manifest.ParentNodesAssociation
-		expErrors               []error
+		knownTypes            []*gqlpublicapi.Type
+		relationsToParentNode manifest.ParentNodesAssociation
+		expErrors             []error
 	}{
 		"should success as all nodes are attached to parent nodes": {
-			knownTypesByPathPattern: map[string][]*gqlpublicapi.Type{
-				"cap.core.type.platform": {
-					{Path: "cap.type.platform.cloud-foundry"},
-					{Path: "cap.type.platform.nomad"},
-				},
+			knownTypes: []*gqlpublicapi.Type{
+				fixGQLType("cap.type.platform.cloud-foundry", "0.1.0", "cap.core.type.platform"),
+				fixGQLType("cap.type.platform.nomad", "0.1.0", "cap.core.type.platform"),
 			},
 
 			relationsToParentNode: manifest.ParentNodesAssociation{
 				"cap.core.type.platform": {
-					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad",
+					{Path: "cap.type.platform.cloud-foundry", Revision: "0.1.0"},
+					{Path: "cap.type.platform.nomad", Revision: "0.1.0"},
 				},
 			},
 
 			expErrors: nil, // no errors
 		},
-		"should detect that one Type is not attached to parent node (singular)": {
-			knownTypesByPathPattern: map[string][]*gqlpublicapi.Type{
-				"cap.core.type.platform": {
-					{Path: "cap.type.platform.nomad"},
-				},
+		"should detect that both Type with different revision is not attached to parent node": {
+			knownTypes: []*gqlpublicapi.Type{
+				fixGQLType("cap.type.platform.cloud-foundry", "0.1.0", "cap.core.type.platform"),
+				fixGQLType("cap.type.platform.cloud-foundry", "0.2.0", ""),
 			},
 			relationsToParentNode: manifest.ParentNodesAssociation{
 				"cap.core.type.platform": {
-					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad",
+					{Path: "cap.type.platform.cloud-foundry", Revision: "0.2.0"},
 				},
 			},
 
-			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry is not attached to cap.core.type.platform abstract node")},
+			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry:0.2.0 is not attached to cap.core.type.platform abstract node")},
+		},
+		"should detect that one Type is not attached to parent node (singular)": {
+			knownTypes: []*gqlpublicapi.Type{
+				fixGQLType("cap.type.platform.nomad", "0.1.0", "cap.core.type.platform"),
+				fixGQLType("cap.type.platform.cloud-foundry", "0.1.0", ""),
+			},
+			relationsToParentNode: manifest.ParentNodesAssociation{
+				"cap.core.type.platform": {
+					{Path: "cap.type.platform.cloud-foundry", Revision: "0.1.0"},
+					{Path: "cap.type.platform.nomad", Revision: "0.1.0"},
+				},
+			},
+
+			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry:0.1.0 is not attached to cap.core.type.platform abstract node")},
 		},
 		"should detect that both Types are not attached to parent node (plural)": {
-			knownTypesByPathPattern: nil, // no relations are registered
+			knownTypes: []*gqlpublicapi.Type{
+				fixGQLType("cap.type.platform.nomad", "0.1.0", ""),
+				fixGQLType("cap.type.platform.cloud-foundry", "0.1.0", ""),
+				fixGQLType("cap.type.platform.mesos", "0.1.0", ""),
+			},
 
 			relationsToParentNode: manifest.ParentNodesAssociation{
 				"cap.core.type.platform": {
-					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad", "cap.type.platform.mesos",
+					{Path: "cap.type.platform.cloud-foundry", Revision: "0.1.0"},
+					{Path: "cap.type.platform.nomad", Revision: "0.1.0"},
+					{Path: "cap.type.platform.mesos", Revision: "0.1.0"},
 				},
 			},
 
-			expErrors: []error{errors.New("Types cap.type.platform.cloud-foundry, cap.type.platform.nomad and cap.type.platform.mesos are not attached to cap.core.type.platform abstract node")},
+			expErrors: []error{errors.New("Types cap.type.platform.cloud-foundry:0.1.0, cap.type.platform.nomad:0.1.0 and cap.type.platform.mesos:0.1.0 are not attached to cap.core.type.platform abstract node")},
+		},
+
+		"should not report problems with parents for unknown Types": {
+			knownTypes: nil, // not Types in Hub
+
+			relationsToParentNode: manifest.ParentNodesAssociation{
+				"cap.core.type.platform": {
+					{Path: "cap.type.platform.cloud-foundry", Revision: "0.1.0"},
+					{Path: "cap.type.platform.nomad", Revision: "0.1.0"},
+					{Path: "cap.type.platform.mesos", Revision: "0.1.0"},
+				},
+			},
+
+			expErrors: nil, // no error about parents.
 		},
 	}
 	for tn, tc := range tests {
 		t.Run(tn, func(t *testing.T) {
 			// given
-			fakeHubCli := &fakeHub{knownTypesByPathPattern: tc.knownTypesByPathPattern}
+			fakeHubCli := &fakeHub{knownTypes: tc.knownTypes}
 
 			implValidator := manifest.NewRemoteImplementationValidator(fakeHubCli)
 
@@ -72,7 +104,20 @@ func TestCheckParentNodesAssociation(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			assert.Equal(t, result.Errors, tc.expErrors)
+			assert.Equal(t, tc.expErrors, result.Errors)
 		})
+	}
+}
+
+func fixGQLType(path, rev, parent string) *gqlpublicapi.Type {
+	return &gqlpublicapi.Type{
+		Path: path,
+		Revisions: []*gqlpublicapi.TypeRevision{
+			{
+				Revision: rev,
+				Spec: &gqlpublicapi.TypeSpec{
+					AdditionalRefs: []string{parent},
+				},
+			}},
 	}
 }

--- a/pkg/sdk/validation/manifest/json_remote_implementation_test.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation_test.go
@@ -1,0 +1,78 @@
+package manifest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/sdk/validation/manifest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckParentNodesAssociation(t *testing.T) {
+	tests := map[string]struct {
+		knownTypesByPathPattern map[string][]*gqlpublicapi.Type
+		relationsToParentNode   manifest.ParentNodesAssociation
+		expErrors               []error
+	}{
+		"should success as all nodes are attached to parent nodes": {
+			knownTypesByPathPattern: map[string][]*gqlpublicapi.Type{
+				"cap.core.type.platform": {
+					{Path: "cap.type.platform.cloud-foundry"},
+					{Path: "cap.type.platform.nomad"},
+				},
+			},
+
+			relationsToParentNode: manifest.ParentNodesAssociation{
+				"cap.core.type.platform": {
+					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad",
+				},
+			},
+
+			expErrors: nil, // no errors
+		},
+		"should detect that one Type is not attached to parent node (singular)": {
+			knownTypesByPathPattern: map[string][]*gqlpublicapi.Type{
+				"cap.core.type.platform": {
+					{Path: "cap.type.platform.nomad"},
+				},
+			},
+			relationsToParentNode: manifest.ParentNodesAssociation{
+				"cap.core.type.platform": {
+					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad",
+				},
+			},
+
+			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry is not attached to cap.core.type.platform abstract node")},
+		},
+		"should detect that both Types are not attached to parent node (plural)": {
+			knownTypesByPathPattern: nil, // no relations are registered
+
+			relationsToParentNode: manifest.ParentNodesAssociation{
+				"cap.core.type.platform": {
+					"cap.type.platform.cloud-foundry", "cap.type.platform.nomad", "cap.type.platform.mesos",
+				},
+			},
+
+			expErrors: []error{errors.New("Types cap.type.platform.cloud-foundry, cap.type.platform.nomad and cap.type.platform.mesos are not attached to cap.core.type.platform abstract node")},
+		},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			fakeHubCli := &fakeHub{knownTypesByPathPattern: tc.knownTypesByPathPattern}
+
+			implValidator := manifest.NewRemoteImplementationValidator(fakeHubCli)
+
+			// when
+			result, err := implValidator.CheckParentNodesAssociation(context.Background(), tc.relationsToParentNode)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, result.Errors, tc.expErrors)
+		})
+	}
+}

--- a/pkg/sdk/validation/manifest/json_remote_implementation_test.go
+++ b/pkg/sdk/validation/manifest/json_remote_implementation_test.go
@@ -44,7 +44,7 @@ func TestCheckParentNodesAssociation(t *testing.T) {
 				},
 			},
 
-			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry:0.2.0 is not attached to cap.core.type.platform abstract node")},
+			expErrors: []error{errors.New(`Type "cap.type.platform.cloud-foundry:0.2.0" is not attached to "cap.core.type.platform" parent node`)},
 		},
 		"should detect that one Type is not attached to parent node (singular)": {
 			knownTypes: []*gqlpublicapi.Type{
@@ -58,7 +58,7 @@ func TestCheckParentNodesAssociation(t *testing.T) {
 				},
 			},
 
-			expErrors: []error{errors.New("Type cap.type.platform.cloud-foundry:0.1.0 is not attached to cap.core.type.platform abstract node")},
+			expErrors: []error{errors.New(`Type "cap.type.platform.cloud-foundry:0.1.0" is not attached to "cap.core.type.platform" parent node`)},
 		},
 		"should detect that both Types are not attached to parent node (plural)": {
 			knownTypes: []*gqlpublicapi.Type{
@@ -75,7 +75,7 @@ func TestCheckParentNodesAssociation(t *testing.T) {
 				},
 			},
 
-			expErrors: []error{errors.New("Types cap.type.platform.cloud-foundry:0.1.0, cap.type.platform.nomad:0.1.0 and cap.type.platform.mesos:0.1.0 are not attached to cap.core.type.platform abstract node")},
+			expErrors: []error{errors.New(`Types "cap.type.platform.cloud-foundry:0.1.0", "cap.type.platform.nomad:0.1.0" and "cap.type.platform.mesos:0.1.0" are not attached to "cap.core.type.platform" parent node`)},
 		},
 
 		"should not report problems with parents for unknown Types": {

--- a/pkg/sdk/validation/manifest/json_remote_type.go
+++ b/pkg/sdk/validation/manifest/json_remote_type.go
@@ -1,10 +1,14 @@
 package manifest
 
 import (
+	"capact.io/capact/internal/ptr"
+	"capact.io/capact/internal/regexutil"
+	"capact.io/capact/pkg/hub/client/public"
 	"context"
 	"encoding/json"
+	"fmt"
 
-	hubpublicgraphql "capact.io/capact/pkg/hub/api/graphql/public"
+	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"github.com/pkg/errors"
 )
@@ -29,17 +33,52 @@ func (v *RemoteTypeValidator) Do(ctx context.Context, _ types.ManifestMetadata, 
 		return ValidationResult{}, errors.Wrap(err, "while unmarshalling JSON into Type type")
 	}
 
-	var manifestRefsToCheck []hubpublicgraphql.ManifestReference
+	var manifestRefsToCheck []gqlpublicapi.ManifestReference
 
 	// Attributes
 	for path, attr := range entity.Metadata.Attributes {
-		manifestRefsToCheck = append(manifestRefsToCheck, hubpublicgraphql.ManifestReference{
+		manifestRefsToCheck = append(manifestRefsToCheck, gqlpublicapi.ManifestReference{
 			Path:     path,
 			Revision: attr.Revision,
 		})
 	}
 
-	return checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
+	existRes, err := checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+
+	refsCheck, err := v.checkAdditionalRefs(ctx, entity)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+
+	return ValidationResult{
+		Errors: append(existRes.Errors, refsCheck.Errors...),
+	}, nil
+}
+
+func (v *RemoteTypeValidator) checkAdditionalRefs(ctx context.Context, entity types.Type) (ValidationResult, error) {
+	res := ValidationResult{}
+	if len(entity.Spec.AdditionalRefs) == 0 {
+		return res, nil
+	}
+
+	// AdditionalRefs should point to a concrete path.
+	// It can point only to parent node.
+	filter := regexutil.OrStringSlice(entity.Spec.AdditionalRefs)
+	gotTypes, err := v.hub.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
+		PathPattern: ptr.String(filter),
+	}))
+
+	if err != nil {
+		return res, err
+	}
+
+	for _, item := range gotTypes {
+		res.Errors = append(res.Errors, fmt.Errorf("%s cannot be used as parent node as it resolves to concrete Type", item.Path))
+	}
+	return res, nil
 }
 
 // Name returns the validator name.

--- a/pkg/sdk/validation/manifest/json_remote_type.go
+++ b/pkg/sdk/validation/manifest/json_remote_type.go
@@ -1,12 +1,13 @@
 package manifest
 
 import (
-	"capact.io/capact/internal/ptr"
-	"capact.io/capact/internal/regexutil"
-	"capact.io/capact/pkg/hub/client/public"
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"capact.io/capact/internal/ptr"
+	"capact.io/capact/internal/regexutil"
+	"capact.io/capact/pkg/hub/client/public"
 
 	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
@@ -43,18 +44,18 @@ func (v *RemoteTypeValidator) Do(ctx context.Context, _ types.ManifestMetadata, 
 		})
 	}
 
-	existRes, err := checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
+	resExist, err := checkManifestRevisionsExist(ctx, v.hub, manifestRefsToCheck)
 	if err != nil {
 		return ValidationResult{}, err
 	}
 
-	refsCheck, err := v.checkAdditionalRefs(ctx, entity)
+	resNodes, err := v.checkAdditionalRefs(ctx, entity)
 	if err != nil {
 		return ValidationResult{}, err
 	}
 
 	return ValidationResult{
-		Errors: append(existRes.Errors, refsCheck.Errors...),
+		Errors: append(resExist.Errors, resNodes.Errors...),
 	}, nil
 }
 

--- a/pkg/sdk/validation/manifest/json_remote_type.go
+++ b/pkg/sdk/validation/manifest/json_remote_type.go
@@ -65,8 +65,8 @@ func (v *RemoteTypeValidator) checkAdditionalRefs(ctx context.Context, entity ty
 		return res, nil
 	}
 
-	// AdditionalRefs should point to a concrete path.
-	// It can point only to parent node.
+	// AdditionalRefs cannot point to a concrete path.
+	// It must point to a parent (abstract) node.
 	filter := regexutil.OrStringSlice(entity.Spec.AdditionalRefs)
 	gotTypes, err := v.hub.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 		PathPattern: ptr.String(filter),
@@ -77,7 +77,7 @@ func (v *RemoteTypeValidator) checkAdditionalRefs(ctx context.Context, entity ty
 	}
 
 	for _, item := range gotTypes {
-		res.Errors = append(res.Errors, fmt.Errorf("%s cannot be used as parent node as it resolves to concrete Type", item.Path))
+		res.Errors = append(res.Errors, fmt.Errorf("%q cannot be used as parent node as it resolves to concrete Type", item.Path))
 	}
 	return res, nil
 }

--- a/pkg/sdk/validation/manifest/json_type.go
+++ b/pkg/sdk/validation/manifest/json_type.go
@@ -3,10 +3,17 @@ package manifest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 
 	"github.com/pkg/errors"
+)
+
+const (
+	coreTypePrefix   = "cap.core.type."
+	customTypePrefix = "cap.type."
 )
 
 // TypeValidator is a validator for Type manifest.
@@ -19,15 +26,29 @@ func NewTypeValidator() *TypeValidator {
 
 // Do is a method which triggers the validation.
 func (v *TypeValidator) Do(_ context.Context, _ types.ManifestMetadata, jsonBytes []byte) (ValidationResult, error) {
-	var typeEntity types.Type
-	err := json.Unmarshal(jsonBytes, &typeEntity)
+	var entity types.Type
+	err := json.Unmarshal(jsonBytes, &entity)
 	if err != nil {
 		return ValidationResult{}, errors.Wrap(err, "while unmarshalling JSON into Type type")
 	}
 
-	return validateJSONSchema07Definition(jsonSchemaCollection{
-		"spec.jsonSchema.value": typeEntity.Spec.JSONSchema.Value,
+	var resNodes []error
+	for _, ref := range entity.Spec.AdditionalRefs {
+		if strings.HasPrefix(ref, coreTypePrefix) || strings.HasPrefix(ref, customTypePrefix) {
+			continue
+		}
+		resNodes = append(resNodes, fmt.Errorf("spec.additionalRefs: %q is not allowed. It can refers only to parent node under %q or %q", ref, coreTypePrefix, customTypePrefix))
+	}
+
+	resSchema, err := checkJSONSchema07Definition(jsonSchemaCollection{
+		"spec.jsonSchema.value": entity.Spec.JSONSchema.Value,
 	})
+	if err != nil {
+		return ValidationResult{}, err
+	}
+	return ValidationResult{
+		Errors: append(resNodes, resSchema.Errors...),
+	}, nil
 }
 
 // Name returns the validator name.

--- a/pkg/sdk/validation/manifest/json_type.go
+++ b/pkg/sdk/validation/manifest/json_type.go
@@ -37,7 +37,7 @@ func (v *TypeValidator) Do(_ context.Context, _ types.ManifestMetadata, jsonByte
 		if strings.HasPrefix(ref, coreTypePrefix) || strings.HasPrefix(ref, customTypePrefix) {
 			continue
 		}
-		resNodes = append(resNodes, fmt.Errorf("spec.additionalRefs: %q is not allowed. It can refers only to parent node under %q or %q", ref, coreTypePrefix, customTypePrefix))
+		resNodes = append(resNodes, fmt.Errorf("spec.additionalRefs: %q is not allowed. It can refer only to a parent node under %q or %q", ref, coreTypePrefix, customTypePrefix))
 	}
 
 	resSchema, err := checkJSONSchema07Definition(jsonSchemaCollection{

--- a/pkg/sdk/validation/manifest/schema_validate.go
+++ b/pkg/sdk/validation/manifest/schema_validate.go
@@ -10,9 +10,9 @@ import (
 // jsonSchemaCollection defines JSONSchema collection index by the name.
 type jsonSchemaCollection map[string]string
 
-// validateJSONSchema07Definition validate a given JSONSchema collection.
+// checkJSONSchema07Definition validate a given JSONSchema collection.
 // Fast return on internal error, otherwise returns aggregated ValidationResult for all schemas.
-func validateJSONSchema07Definition(schemas jsonSchemaCollection) (ValidationResult, error) {
+func checkJSONSchema07Definition(schemas jsonSchemaCollection) (ValidationResult, error) {
 	result := ValidationResult{}
 
 	schemaLoader := gojsonschema.NewReferenceLoader("http://json-schema.org/draft-07/schema")

--- a/pkg/sdk/validation/manifest/schema_validate_test.go
+++ b/pkg/sdk/validation/manifest/schema_validate_test.go
@@ -24,7 +24,7 @@ func TestValidateJSONSchema07DefinitionSuccess(t *testing.T) {
 			}`)
 
 	// when
-	res, err := validateJSONSchema07Definition(jsonSchemaCollection{
+	res, err := checkJSONSchema07Definition(jsonSchemaCollection{
 		"valid-schema": validJSONSchema,
 	})
 
@@ -59,7 +59,7 @@ func TestValidateJSONSchema07DefinitionFailures(t *testing.T) {
 	for tn, tc := range tests {
 		t.Run(tn, func(t *testing.T) {
 			// when
-			res, err := validateJSONSchema07Definition(jsonSchemaCollection{
+			res, err := checkJSONSchema07Definition(jsonSchemaCollection{
 				"schema-name": tc.JSONSchema,
 			})
 

--- a/pkg/sdk/validation/manifest/testdata/invalid-implementation.yaml
+++ b/pkg/sdk/validation/manifest/testdata/invalid-implementation.yaml
@@ -18,6 +18,13 @@ spec:
   # MISSING SECTION
   # appVersion: "5.4.x - 5.5.x, 5.6.0-alpha0"
 
+  # WRONG PARENT NODE
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: cap.type.platform.cloud-foundry
+          revision: 0.1.0
+
   implements:
     - path: cap.interface.cms.wordpress
       revision: "0.1.0"

--- a/pkg/sdk/validation/manifest/testdata/invalid-implementation.yaml
+++ b/pkg/sdk/validation/manifest/testdata/invalid-implementation.yaml
@@ -22,7 +22,7 @@ spec:
   requires:
     cap.core.type.platform:
       oneOf:
-        - name: cap.type.platform.cloud-foundry
+        - name: cap.type.database.postgresql.config
           revision: 0.1.0
 
   implements:

--- a/pkg/sdk/validation/manifest/testdata/invalid-type_additionalRefs.yaml
+++ b/pkg/sdk/validation/manifest/testdata/invalid-type_additionalRefs.yaml
@@ -1,0 +1,54 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: config
+  prefix: cap.type.database.postgresql
+  displayName: PostgreSQL config
+  description: Defines configuration for PostgreSQL
+  documentationURL: https://capact.io
+  supportURL: https://capact.io
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+spec:
+  additionalRefs:
+    - cap.interface.postgresql
+    - cap.core.type.platform.kubernetes
+  jsonSchema:
+    value: |-
+      {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The schema for Mattermost configuration",
+        "required": [
+          "version"
+        ],
+        "definitions": {
+          "semVer": {
+            "type": "string",
+            "minLength": 5,
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "title": "Semantic Versioning version",
+            "examples": [
+              "1.19.0",
+              "2.0.1-alpha1"
+            ]
+          },
+          "hostname": {
+            "type": "string",
+            "format": "hostname",
+            "title": "Hostname"
+          }
+        },
+        "properties": {
+          "version": {
+            "$ref": "#/definitions/semVer"
+          },
+          "host": {
+            "$ref": "#/definitions/hostname"
+          }
+        },
+        "additionalProperties": true
+      }

--- a/pkg/sdk/validation/policy/fixtures_test.go
+++ b/pkg/sdk/validation/policy/fixtures_test.go
@@ -1,10 +1,8 @@
 package policy_test
 
 import (
-	"capact.io/capact/internal/cli/heredoc"
 	"capact.io/capact/internal/ptr"
 	"capact.io/capact/pkg/engine/k8s/policy"
-	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 )
 
@@ -96,53 +94,6 @@ func fixPolicyWithTypeRef() policy.Policy {
 					},
 				},
 			},
-		},
-	}
-}
-
-func fixAWSElasticsearchTypeRev() *gqlpublicapi.TypeRevision {
-	return &gqlpublicapi.TypeRevision{
-		Metadata: &gqlpublicapi.TypeMetadata{
-			Path: "cap.type.aws.elasticsearch.install-input",
-		},
-		Revision: "0.1.0",
-		Spec: &gqlpublicapi.TypeSpec{
-			JSONSchema: heredoc.Doc(`
-                    {
-                      "$schema": "http://json-schema.org/draft-07/schema",
-                      "type": "object",
-                      "title": "The schema for Elasticsearch input parameters.",
-                      "required": ["replicas"],
-                      "properties": {
-                        "replicas": {
-                          "type": "string",
-                          "title": "Replica count for the Elasticsearch"
-                        }
-                      },
-                      "additionalProperties": false
-                    }`),
-		},
-	}
-}
-
-func fixAWSCredsTypeRev() *gqlpublicapi.TypeRevision {
-	return &gqlpublicapi.TypeRevision{
-		Metadata: &gqlpublicapi.TypeMetadata{
-			Path: "cap.type.aws.auth.creds",
-		},
-		Revision: "0.1.0",
-		Spec: &gqlpublicapi.TypeSpec{
-			JSONSchema: heredoc.Doc(`
-                    {
-                      "$schema": "http://json-schema.org/draft-07/schema",
-                      "type": "object",
-                      "required": [ "key" ],
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        }
-                      }
-                    }`),
 		},
 	}
 }

--- a/pkg/sdk/validation/type_refs.go
+++ b/pkg/sdk/validation/type_refs.go
@@ -8,12 +8,14 @@ import (
 	"capact.io/capact/internal/multierror"
 	"capact.io/capact/internal/ptr"
 	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
+	"capact.io/capact/pkg/hub/client/public"
+
 	"github.com/pkg/errors"
 )
 
 // HubClient defines Hub methods needed for ResolveTypeRefsToJSONSchemas.
 type HubClient interface {
-	ListTypeRefRevisionsJSONSchemas(ctx context.Context, filter gqlpublicapi.TypeFilter) ([]*gqlpublicapi.TypeRevision, error)
+	ListTypes(ctx context.Context, opts ...public.TypeOption) ([]*gqlpublicapi.Type, error)
 }
 
 // ResolveTypeRefsToJSONSchemas resolves Type references to theirs JSON schemas.
@@ -29,20 +31,27 @@ func ResolveTypeRefsToJSONSchemas(ctx context.Context, hubCli HubClient, inTypeR
 	}
 
 	typeRefsPathFilter := fmt.Sprintf(`(%s)`, strings.Join(typeRefsPath, "|"))
-	gotTypes, err := hubCli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+	gotTypes, err := hubCli.ListTypes(ctx, public.WithTypeRevisions(public.TypeRevisionSpecFields|public.TypeRevisionRootFields), public.WithTypeFilter(gqlpublicapi.TypeFilter{
 		PathPattern: ptr.String(typeRefsPathFilter),
-	})
+	}))
 	if err != nil {
 		return nil, errors.Wrap(err, "while fetching JSONSchemas for input TypeRefs")
 	}
 
 	indexedTypes := map[string]interface{}{}
-	for _, rev := range gotTypes {
-		if rev == nil || rev.Spec == nil {
+	for _, gotType := range gotTypes {
+		if gotType == nil {
 			continue
 		}
-		key := fmt.Sprintf("%s:%s", rev.Metadata.Path, rev.Revision)
-		indexedTypes[key] = rev.Spec.JSONSchema
+
+		for _, rev := range gotType.Revisions {
+			if rev == nil || rev.Spec == nil {
+				continue
+			}
+
+			key := fmt.Sprintf("%s:%s", gotType.Path, rev.Revision)
+			indexedTypes[key] = rev.Spec.JSONSchema
+		}
 	}
 
 	var (

--- a/pkg/sdk/validation/type_refs.go
+++ b/pkg/sdk/validation/type_refs.go
@@ -3,10 +3,10 @@ package validation
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"capact.io/capact/internal/multierror"
 	"capact.io/capact/internal/ptr"
+	"capact.io/capact/internal/regexutil"
 	gqlpublicapi "capact.io/capact/pkg/hub/api/graphql/public"
 	"capact.io/capact/pkg/hub/client/public"
 
@@ -30,7 +30,7 @@ func ResolveTypeRefsToJSONSchemas(ctx context.Context, hubCli HubClient, inTypeR
 		return nil, nil
 	}
 
-	typeRefsPathFilter := fmt.Sprintf(`(%s)`, strings.Join(typeRefsPath, "|"))
+	typeRefsPathFilter := regexutil.OrStringSlice(typeRefsPath)
 	gotTypes, err := hubCli.ListTypes(ctx, public.WithTypeRevisions(public.TypeRevisionSpecFields|public.TypeRevisionRootFields), public.WithTypeFilter(gqlpublicapi.TypeFilter{
 		PathPattern: ptr.String(typeRefsPathFilter),
 	}))

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -48,8 +48,8 @@ var _ = BeforeSuite(func() {
 	err := envconfig.Init(&cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	//waitTillServiceEndpointsAreReady()
-	//waitTillDataIsPopulated()
+	waitTillServiceEndpointsAreReady()
+	waitTillDataIsPopulated()
 })
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -48,8 +48,8 @@ var _ = BeforeSuite(func() {
 	err := envconfig.Init(&cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	waitTillServiceEndpointsAreReady()
-	waitTillDataIsPopulated()
+	//waitTillServiceEndpointsAreReady()
+	//waitTillDataIsPopulated()
 })
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/hub_test.go
+++ b/test/e2e/hub_test.go
@@ -34,22 +34,23 @@ var _ = Describe("GraphQL API", func() {
 			It("based on full path name", func() {
 				const fullTypePath = "cap.core.type.platform.kubernetes"
 
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+				gotTypes, err := cli.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 					PathPattern: ptr.String(fullTypePath),
-				})
+				}))
 
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(gotTypes).To(HaveLen(1))
-				Expect(gotTypes[0].Metadata.Path).To(Equal(fullTypePath))
+				Expect(gotTypes[0].Path).To(Equal(fullTypePath))
 			})
+
 			It("based on a prefix of the parent node", func() {
 				const parentNode = "cap.core.type.platform.*"
 				expAssociatedPaths := []string{"cap.core.type.platform.kubernetes", "cap.type.platform.cloud-foundry"}
 
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+				gotTypes, err := cli.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 					PathPattern: ptr.String(parentNode),
-				})
+				}))
 
 				Expect(err).ToNot(HaveOccurred())
 
@@ -58,45 +59,35 @@ var _ = Describe("GraphQL API", func() {
 			It("only child node if full path name specified", func() {
 				const fullTypePath = "cap.type.platform.cloud-foundry"
 
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+				gotTypes, err := cli.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 					PathPattern: ptr.String(fullTypePath),
-				})
+				}))
 
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(gotTypes).To(HaveLen(1))
-				Expect(gotTypes[0].Metadata.Path).To(Equal(fullTypePath))
+				Expect(gotTypes[0].Path).To(Equal(fullTypePath))
 			})
 			It("entries matching or regex (cap.core.type.generic.value|cap.type.platform.cloud-foundry)", func() {
 				expTypePaths := []string{"cap.core.type.generic.value", "cap.type.platform.cloud-foundry"}
 				typePathORFilter := fmt.Sprintf(`(%s)`, strings.Join(expTypePaths, "|"))
 
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+				gotTypes, err := cli.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 					PathPattern: ptr.String(typePathORFilter),
-				})
+				}))
 
 				Expect(err).ToNot(HaveOccurred())
 
 				HasOnlyExpectTypePaths(gotTypes, expTypePaths)
 			})
 			It("all entries if there is no filter", func() {
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
+				gotTypes, err := cli.ListTypes(ctx, public.WithTypeFilter(gqlpublicapi.TypeFilter{
 					// no path filter
-				})
+				}))
 
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(gotTypes)).Should(BeNumerically(">=", 50))
-			})
-			It("no entries if prefix is not a regex and there is no Type with such explicit path", func() {
-				const parentNode = "cap.core.type.platform"
-
-				gotTypes, err := cli.ListTypeRefRevisionsJSONSchemas(ctx, gqlpublicapi.TypeFilter{
-					PathPattern: ptr.String(parentNode),
-				})
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(gotTypes).To(HaveLen(0))
 			})
 		})
 		Describe("should return ImplementationRevision", func() {
@@ -829,14 +820,14 @@ func allPermutations(in []string) string {
 	return fmt.Sprintf(`(%s)`, strings.Join(opts, "|"))
 }
 
-func HasOnlyExpectTypePaths(gotTypes []*gqlpublicapi.TypeRevision, expectedPaths []string) {
+func HasOnlyExpectTypePaths(gotTypes []*gqlpublicapi.Type, expectedPaths []string) {
 	Expect(gotTypes).To(HaveLen(len(expectedPaths)))
 	var gotPaths []string
 	for _, t := range gotTypes {
 		if t == nil {
 			continue
 		}
-		gotPaths = append(gotPaths, t.Metadata.Path)
+		gotPaths = append(gotPaths, t.Path)
 	}
 	Expect(gotPaths).To(ConsistOf(expectedPaths))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Validate parent nodes in manifests
   Check if item under `requires` section is a concrete Type. If yes, it needs to be attached to the parent node. For example:
    ```yaml
    requires:
      cap.core.type.platform:
       oneOf:
         - name: cap.type.platform.cloud-foundry # this MUST be attached to `cap.core.type.platform`
           revision: 0.1.0
    ```
- Validate that **additionalRefs** always point to abstract node (parent node) not to a concrete Type.
- In `fsvalidator_test.go` I added only simple cases. Corner cases were extracted to `json_remote_implementation_test.go`.
- Replace “hard-coded” `ListTypeRefRevisionsJSONSchemas` with generic `ListTypes` function in Hub client
- Introduce a single FakeHubCli with related "fixtures" and remove all copies inside our code
- Detects situation where the new revision is not attached to previous parent node. Introduced here: https://github.com/capactio/capact/pull/621/commits/8b9ff424e5738748a52ce0ccf80f03e6c4a0e03f
  - it complicates our logic but give us more robustness
  - I didn't have more time to try to make it more readable but current state IMO is enough


## Testing


1. Build CLI: `make build-tool-cli`
1. Pick some Implementation manifest and add change `requires` property:
    ```yaml
        cap.core.type.platform:
          oneOf:
            - name: kubernetes
              revision: 0.1.0
            - name: cap.type.platform.cloud-foundry
              revision: 0.1.0
            - name: cap.type.aws.auth.credentials
              revision: 0.1.0
    ```

1. Execute validation against local manifests:
    NOTE: use the CLI from this PR
    ```bash
    capact manifest validate --server-side ./manifests/ --recursive
    ```

    you should see:
    ```bash
    Validating files in 5 concurrent jobs...
    - ✗ "manifests/implementation/mattermost/mattermost-team-edition/install.yaml":
        * RemoteImplementationValidator: Type cap.type.aws.auth.credentials is not attached to cap.core.type.platform abstract node
    ```

1. Change **additionalRefs** in  the `cap.type.platform.cloud-foundry` manifests from `cap.core.type.platform` to `cap.core.type.platform.kubernetes`

1. Execute validation one more time to see error with wrong parent node:
    ```bash
    - ✗ "manifests/type/platform/cloud-foundry.yaml":
        * RemoteTypeValidator: cap.core.type.platform.kubernetes cannot be used as parent node as it resolves to concrete Type
    ```

## Related issue(s)

- https://github.com/capactio/capact/issues/601