### PR TITLE
Update populator to properly resolve requires section in Implementation

### DIFF
--- a/hub-js/graphql/public/examples.graphql
+++ b/hub-js/graphql/public/examples.graphql
@@ -4,288 +4,305 @@
 # To use all queries without specifying your own variables, use the JSON from `examples.variables.json` file.
 
 query RepoMetadata {
-    repoMetadata {
-        path
-        name
-        prefix
-        revision(revision: "0.1.0") {
-            ...RepoMetadataRevision
-        }
-        latestRevision {
-            ...RepoMetadataRevision
-        }
-        revisions {
-            ...RepoMetadataRevision
-        }
+  repoMetadata {
+    path
+    name
+    prefix
+    revision(revision: "0.1.0") {
+      ...RepoMetadataRevision
     }
+    latestRevision {
+      ...RepoMetadataRevision
+    }
+    revisions {
+      ...RepoMetadataRevision
+    }
+  }
 }
 
 # Example variables: {"interfaceGroupPath": "cap.interface.productivity.mattermost"}
 query InterfaceGroup($interfaceGroupPath: NodePath!) {
-    interfaceGroup(path: $interfaceGroupPath) {
-        ...InterfaceGroup
-    }
+  interfaceGroup(path: $interfaceGroupPath) {
+    ...InterfaceGroup
+  }
 }
 
 query InterfaceGroups {
-    interfaceGroups {
-        ...InterfaceGroup
-    }
+  interfaceGroups {
+    ...InterfaceGroup
+  }
 }
 
 # Example variables: {"interfaceGroupPathPattern": "cap.interface.*"}
 query InterfaceGroupsWithPrefixFilter(
-    $interfaceGroupPathPattern: NodePathPattern!
+  $interfaceGroupPathPattern: NodePathPattern!
 ) {
-    interfaceGroups(filter: { pathPattern: $interfaceGroupPathPattern }) {
-        ...InterfaceGroup
-    }
+  interfaceGroups(filter: { pathPattern: $interfaceGroupPathPattern }) {
+    ...InterfaceGroup
+  }
 }
 
 query InterfaceGroupsWithInterfacesAndImplementations {
-    interfaceGroups {
-        ...InterfaceGroup
-        interfaces {
-            name
-            prefix
-            path
-            revision(revision: "0.1.0") {
-                ...InterfaceRevision
-            }
-            latestRevision {
-                ...InterfaceRevision
-            }
-            revisions {
-                ...InterfaceRevision
-                ...ImplementationsForInterface
-            }
-        }
+  interfaceGroups {
+    ...InterfaceGroup
+    interfaces {
+      name
+      prefix
+      path
+      revision(revision: "0.1.0") {
+        ...InterfaceRevision
+      }
+      latestRevision {
+        ...InterfaceRevision
+      }
+      revisions {
+        ...InterfaceRevision
+        ...ImplementationsForInterface
+      }
     }
+  }
 }
 
 # Example variables: {"interfacePath": "cap.interface.productivity.mattermost.install"}
 query Interface($interfacePath: NodePath!) {
-    interface(path: $interfacePath) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...InterfaceRevision
-        }
-        latestRevision {
-            ...InterfaceRevision
-        }
-        revisions {
-            ...InterfaceRevision
-        }
+  interface(path: $interfacePath) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...InterfaceRevision
     }
+    latestRevision {
+      ...InterfaceRevision
+    }
+    revisions {
+      ...InterfaceRevision
+    }
+  }
 }
 
 query Interfaces {
-    interfaces {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...InterfaceRevision
-        }
-        latestRevision {
-            ...InterfaceRevision
-        }
-        revisions {
-            ...InterfaceRevision
-        }
+  interfaces {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...InterfaceRevision
     }
+    latestRevision {
+      ...InterfaceRevision
+    }
+    revisions {
+      ...InterfaceRevision
+    }
+  }
 }
 
 query InterfacesWithImplementations {
-    interfaces {
-        path
-        revisions {
-            ...InterfaceRevision
-            ...ImplementationsForInterface
-        }
+  interfaces {
+    path
+    revisions {
+      ...InterfaceRevision
+      ...ImplementationsForInterface
     }
+  }
 }
 
 # Example variables: {"interfacesPathPattern": "cap.interface.*"}
 query InterfacesWithPrefixFilter($interfacesPathPattern: NodePathPattern!) {
-    interfaces(filter: { pathPattern: $interfacesPathPattern }) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...InterfaceRevision
-        }
-        latestRevision {
-            ...InterfaceRevision
-        }
-        revisions {
-            ...InterfaceRevision
-        }
+  interfaces(filter: { pathPattern: $interfacesPathPattern }) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...InterfaceRevision
     }
+    latestRevision {
+      ...InterfaceRevision
+    }
+    revisions {
+      ...InterfaceRevision
+    }
+  }
 }
 
 # Example variables: {"implementationPath": "cap.implementation.database.postgresql.create-db"}
 query Implementation($implementationPath: NodePath!) {
-    implementation(path: $implementationPath) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...ImplementationRevision
-        }
-        latestRevision {
-            ...ImplementationRevision
-        }
-        revisions {
-            ...ImplementationRevision
-        }
+  implementation(path: $implementationPath) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...ImplementationRevision
     }
+    latestRevision {
+      ...ImplementationRevision
+    }
+    revisions {
+      ...ImplementationRevision
+    }
+  }
 }
 
 query Implementations {
-    implementations {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...ImplementationRevision
-        }
-        latestRevision {
-            ...ImplementationRevision
-        }
-        revisions {
-            ...ImplementationRevision
-        }
+  implementations {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...ImplementationRevision
     }
+    latestRevision {
+      ...ImplementationRevision
+    }
+    revisions {
+      ...ImplementationRevision
+    }
+  }
 }
 
 # Example variables: {"implementationsPathPattern": "cap.implementation.gcp.*"}
 query ImplementationsWithPrefixFilter(
-    $implementationsPathPattern: NodePathPattern!
+  $implementationsPathPattern: NodePathPattern!
 ) {
-    implementations(filter: { pathPattern: $implementationsPathPattern }) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...ImplementationRevision
-        }
-        latestRevision {
-            ...ImplementationRevision
-        }
-        revisions {
-            ...ImplementationRevision
-        }
+  implementations(filter: { pathPattern: $implementationsPathPattern }) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...ImplementationRevision
     }
+    latestRevision {
+      ...ImplementationRevision
+    }
+    revisions {
+      ...ImplementationRevision
+    }
+  }
 }
 
 # Example variables: {"typePath": "cap.core.type.networking.hostname"}
 query Type($typePath: NodePath!) {
-    type(path: $typePath) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...TypeRevision
-        }
-        latestRevision {
-            ...TypeRevision
-        }
-        revisions {
-            ...TypeRevision
-        }
+  type(path: $typePath) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...TypeRevision
     }
+    latestRevision {
+      ...TypeRevision
+    }
+    revisions {
+      ...TypeRevision
+    }
+  }
 }
 
 query Types {
-    types {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...TypeRevision
-        }
-        latestRevision {
-            ...TypeRevision
-        }
-        revisions {
-            ...TypeRevision
-        }
+  types {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...TypeRevision
     }
+    latestRevision {
+      ...TypeRevision
+    }
+    revisions {
+      ...TypeRevision
+    }
+  }
 }
 
 # Example variables: {"typesPathPattern": "cap.core.type.*"}
 query TypesWithPrefixFilter($typesPathPattern: NodePathPattern!) {
-    types(filter: { pathPattern: $typesPathPattern }) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...TypeRevision
-        }
-        latestRevision {
-            ...TypeRevision
-        }
-        revisions {
-            ...TypeRevision
-        }
+  types(filter: { pathPattern: $typesPathPattern }) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...TypeRevision
     }
+    latestRevision {
+      ...TypeRevision
+    }
+    revisions {
+      ...TypeRevision
+    }
+  }
+}
+
+query TypesWithORPrefixFilter {
+  types(
+    filter: {
+      pathPattern: "(cap.core.type.generic.value|cap.type.platform.cloud-foundry)"
+    }
+  ) {
+    prefix
+    path
+    revisions {
+      revision
+      spec {
+        additionalRefs
+      }
+    }
+  }
 }
 
 # Example variables: {"attributePath": "cap.core.attribute.workload.stateless"}
 query Attribute($attributePath: NodePath!) {
-    attribute(path: $attributePath) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...AttributeRevision
-        }
-        latestRevision {
-            ...AttributeRevision
-        }
-        revisions {
-            ...AttributeRevision
-        }
+  attribute(path: $attributePath) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...AttributeRevision
     }
+    latestRevision {
+      ...AttributeRevision
+    }
+    revisions {
+      ...AttributeRevision
+    }
+  }
 }
 
 query Attributes {
-    attributes {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...AttributeRevision
-        }
-        latestRevision {
-            ...AttributeRevision
-        }
-        revisions {
-            ...AttributeRevision
-        }
+  attributes {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...AttributeRevision
     }
+    latestRevision {
+      ...AttributeRevision
+    }
+    revisions {
+      ...AttributeRevision
+    }
+  }
 }
 
 # Lists all Attributes with a given prefix.
 # Example variables: {"attributesPathPattern": "cap.core.attribute.workload.*"}
 query AttributesWithPrefixFilter($attributesPathPattern: NodePathPattern!) {
-    attributes(filter: { pathPattern: $attributesPathPattern }) {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...AttributeRevision
-        }
-        latestRevision {
-            ...AttributeRevision
-        }
-        revisions {
-            ...AttributeRevision
-        }
+  attributes(filter: { pathPattern: $attributesPathPattern }) {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...AttributeRevision
     }
+    latestRevision {
+      ...AttributeRevision
+    }
+    revisions {
+      ...AttributeRevision
+    }
+  }
 }
 
 #
@@ -293,218 +310,218 @@ query AttributesWithPrefixFilter($attributesPathPattern: NodePathPattern!) {
 #
 
 fragment InterfaceGroup on InterfaceGroup {
-    metadata {
-        ...GenericMetadata
+  metadata {
+    ...GenericMetadata
+  }
+  interfaces {
+    name
+    prefix
+    path
+    revision(revision: "0.1.0") {
+      ...InterfaceRevision
     }
-    interfaces {
-        name
-        prefix
-        path
-        revision(revision: "0.1.0") {
-            ...InterfaceRevision
-        }
-        latestRevision {
-            ...InterfaceRevision
-        }
-        revisions {
-            ...InterfaceRevision
-        }
+    latestRevision {
+      ...InterfaceRevision
     }
+    revisions {
+      ...InterfaceRevision
+    }
+  }
 }
 
 fragment GenericMetadata on MetadataBaseFields {
+  prefix
+  path
+  name
+  displayName
+  description
+  maintainers {
+    name
+    email
+  }
+  iconURL
+  documentationURL
+  supportURL
+  iconURL
+}
+
+fragment InterfaceRevision on InterfaceRevision {
+  metadata {
     prefix
     path
     name
     displayName
     description
     maintainers {
-        name
-        email
+      name
+      email
     }
     iconURL
-    documentationURL
-    supportURL
-    iconURL
-}
-
-fragment InterfaceRevision on InterfaceRevision {
-    metadata {
-        prefix
-        path
+  }
+  revision
+  spec {
+    input {
+      parameters {
         name
-        displayName
-        description
-        maintainers {
-            name
-            email
+        jsonSchema
+      }
+      typeInstances {
+        name
+        typeRef {
+          path
+          revision
         }
-        iconURL
+        verbs
+      }
     }
-    revision
-    spec {
-        input {
-            parameters {
-                name
-                jsonSchema
-            }
-            typeInstances {
-                name
-                typeRef {
-                    path
-                    revision
-                }
-                verbs
-            }
+    output {
+      typeInstances {
+        name
+        typeRef {
+          path
+          revision
         }
-        output {
-            typeInstances {
-                name
-                typeRef {
-                    path
-                    revision
-                }
-            }
-        }
+      }
     }
+  }
 }
 
 fragment ImplementationRevision on ImplementationRevision {
-    metadata {
-        ...GenericMetadata
-        attributes {
-            ...AttributeRevision
-        }
+  metadata {
+    ...GenericMetadata
+    attributes {
+      ...AttributeRevision
     }
-    revision
-    spec {
-        appVersion
-        implements {
-            path
-            revision
-        }
-        requires {
-            prefix
-            oneOf {
-                alias
-                typeRef {
-                    path
-                    revision
-                }
-                valueConstraints
-            }
-            anyOf {
-                alias
-                typeRef {
-                    path
-                    revision
-                }
-                valueConstraints
-            }
-            allOf {
-                alias
-                typeRef {
-                    path
-                    revision
-                }
-                valueConstraints
-            }
-        }
-        imports {
-            interfaceGroupPath
-            alias
-            appVersion
-            methods {
-                name
-                revision
-            }
-        }
-        additionalInput {
-            typeInstances {
-                name
-                typeRef {
-                    path
-                    revision
-                }
-                verbs
-            }
-            parameters {
-                typeRef {
-                    path
-                    revision
-                }
-            }
-        }
-        additionalOutput {
-            typeInstances {
-                name
-                typeRef {
-                    path
-                    revision
-                }
-            }
-        }
-        outputTypeInstanceRelations {
-            typeInstanceName
-            uses
-        }
-        action {
-            runnerInterface
-            args
-        }
+  }
+  revision
+  spec {
+    appVersion
+    implements {
+      path
+      revision
     }
+    requires {
+      prefix
+      oneOf {
+        alias
+        typeRef {
+          path
+          revision
+        }
+        valueConstraints
+      }
+      anyOf {
+        alias
+        typeRef {
+          path
+          revision
+        }
+        valueConstraints
+      }
+      allOf {
+        alias
+        typeRef {
+          path
+          revision
+        }
+        valueConstraints
+      }
+    }
+    imports {
+      interfaceGroupPath
+      alias
+      appVersion
+      methods {
+        name
+        revision
+      }
+    }
+    additionalInput {
+      typeInstances {
+        name
+        typeRef {
+          path
+          revision
+        }
+        verbs
+      }
+      parameters {
+        typeRef {
+          path
+          revision
+        }
+      }
+    }
+    additionalOutput {
+      typeInstances {
+        name
+        typeRef {
+          path
+          revision
+        }
+      }
+    }
+    outputTypeInstanceRelations {
+      typeInstanceName
+      uses
+    }
+    action {
+      runnerInterface
+      args
+    }
+  }
 }
 
 fragment AttributeRevision on AttributeRevision {
-    metadata {
-        ...GenericMetadata
-    }
-    revision
-    spec {
-        additionalRefs
-    }
+  metadata {
+    ...GenericMetadata
+  }
+  revision
+  spec {
+    additionalRefs
+  }
 }
 
 fragment TypeRevision on TypeRevision {
-    revision
-    metadata {
-        ...GenericMetadata
-        attributes {
-            ...AttributeRevision
-        }
+  revision
+  metadata {
+    ...GenericMetadata
+    attributes {
+      ...AttributeRevision
     }
-    spec {
-        additionalRefs
-        jsonSchema
-    }
+  }
+  spec {
+    additionalRefs
+    jsonSchema
+  }
 }
 
 fragment RepoMetadataRevision on RepoMetadataRevision {
-    revision
-    metadata {
-        ...GenericMetadata
+  revision
+  metadata {
+    ...GenericMetadata
+  }
+  spec {
+    hubVersion
+    ocfVersion {
+      supported
+      default
     }
-    spec {
-        hubVersion
-        ocfVersion {
-            supported
-            default
+    implementation {
+      appVersion {
+        semVerTaggingStrategy {
+          latest {
+            pointsTo
+          }
         }
-        implementation {
-            appVersion {
-                semVerTaggingStrategy {
-                    latest {
-                        pointsTo
-                    }
-                }
-            }
-        }
+      }
     }
+  }
 }
 
 # Additional resolvers for Interface
 fragment ImplementationsForInterface on InterfaceRevision {
-    implementationRevisions {
-        ...ImplementationRevision
-    }
+  implementationRevisions {
+    ...ImplementationRevision
+  }
 }

--- a/hub-js/graphql/public/examples.variables.json
+++ b/hub-js/graphql/public/examples.variables.json
@@ -6,7 +6,7 @@
   "implementationPath": "cap.implementation.mattermost.mattermost-team-edition.install",
   "implementationsPathPattern": "cap.implementation.gcp.*",
   "typePath": "cap.core.type.networking.hostname",
-  "typesPathPattern": "cap.core.type.*",
+  "typesPathPattern": "cap.core.type.platform.*",
   "attributePath": "cap.core.attribute.workload.stateless",
   "attributesPathPattern": "cap.core.attribute.workload.*"
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Update populator to properly resolve requires section in Implementation

Requires https://github.com/capactio/capact/pull/620 to be merged before.

## Testing

1. Build CLI: `make build-tool-populator`
1. Pick some Implementation manifest and add change `requires` property:
    ```yaml
        cap.core.type.platform:
          oneOf:
            - name: kubernetes
              revision: 0.1.0
            - name: cap.type.platform.cloud-foundry
              revision: 0.1.0
    ```


1. Run Neo4j:

    ```bash
    docker run -d \
      -p 7687:7687 -p 7474:7474 \
      -e "NEO4J_AUTH=neo4j/okon" \
      -e "NEO4JLABS_PLUGINS=[\"apoc\"]" \
      --name hub-neo4j-instance \
      ghcr.io/capactio/neo4j:4.2.13-apoc
    ```
1. Populate database:
    1.  Build populator: `make build-tool-populator`


    **NOTE:** ensure that you use newly built populator!
    
    ```bash
    env APP_JSONPUBLISHADDR=http://$(ipconfig getifaddr en0) APP_JSON_PUBLISH_PORT="8888" APP_MANIFESTS_PATH="manifests" populator register ocf-manifests --source github.com/capactio/hub-manifests/
    ```

1. Run Public Hub:

    ```bash
   cd hub-js; APP_NEO4J_ENDPOINT=bolt://localhost:7687 APP_NEO4J_PASSWORD=okon APP_HUB_MODE=public npm start
    ```


1. Run query to fetch your Implementation (e.g. use [Insomnia](https://insomnia.rest/download)):

    In my case, I used `"cap.implementation.mattermost.mattermost-team-edition.install"`: 
    ```graphql
    query Impl {
	    implementation(
		    path: "cap.implementation.mattermost.mattermost-team-edition.install"
	    ) {
		    latestRevision {
			    spec {
				    requires {
					    prefix
					    oneOf {
						    typeRef {
							    path
							    revision
						    }
						    alias
					    }
				    }
			    }
		    }
	    }
    }
    ```
    Output:
    ```json
    {
      "data": {
        "implementation": {
          "latestRevision": {
            "spec": {
              "requires": [
                {
                  "prefix": "cap.core.type",
                  "oneOf": [
                    {
                	    "typeRef": {
                		    "path": "cap.type.platform.cloud-foundry",
                		    "revision": "0.1.0"
                	    },
                	    "alias": null
                    },
                    {
                	    "typeRef": {
                		    "path": "cap.core.type.platform.kubernetes",
                		    "revision": "0.1.0"
                	    },
                	    "alias": null
                    }
                  ]
                }
              ]
            }
          }
        }
      }
    }
    ```


### Option 2


1. Create cluster and populate it with `https://github.com/mszostok/os-hub-manifests/tree/support-parent-nodes`
1. Create TypeInstance:
	```bash
	cat > /tmp/helm-ti.yaml << ENDOFFILE
	typeInstances:
    - alias: helm-ti
      typeRef:
        path: cap.type.helm.storage
        revision: 0.1.0
      value:
        url: "http://example.com/grpc"
	ENDOFFILE

	export TI_ID=$(capact ti create -f /tmp/helm-ti.yaml -ojson | jq -r '.[].id')
	```

2. Create Action Policy:
	```bash
	cat <<EOF > /tmp/act-policy.yaml
	rules:
    - interface:
        path: cap.interface.capactio.capact.validation.hub.install
      oneOf:
        - implementationConstraints:
            path: "cap.implementation.capactio.capact.validation.io.install"
          inject:
            additionalParameters:
              - name: "mattermost-parameters"
                value:
                  replicaCount: 3
              - name: "rocketchat-parameters"
                value:
                  replicaCount: 5
            requiredTypeInstances:
              - id: ${TI_ID}
                description: "Helm storage"
	EOF
	```
3. Create and run Action:

	```bash
	capact act create cap.interface.capactio.capact.validation.hub.install --name test --action-policy-from-file /tmp/act-policy.yaml
	```

	```
	capact act run test
	capact act watch test
	argo logs test
	```
    You should that TypeInstance was injected and details are available in workflow:
    ```bash
    cat /helm-storage.yaml
    url: http://example.com/grpc
    ```
## Related issue(s)

- https://github.com/capactio/capact/issues/601