### PR TITLE
Add support for Homebrew

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -220,7 +220,7 @@ jobs:
           make test-k8s-controller
       - name: Get Capact CLI for linux
         run: |
-          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
+          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact_linux_amd64/capact
           chmod +x ./capact
       - name: Run cross-functional integration tests
         env:
@@ -256,7 +256,7 @@ jobs:
           . ./hack/ci/setup-env.sh
       - name: Build Capact CLI for linux
         run: |
-          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
+          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact_linux_amd64/capact
           chmod +x ./capact
       - name: Log into Capact long-running cluster
         env:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -395,7 +395,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: cli_${{github.sha}}
-          path: ${{ github.workspace }}/bin/capact-linux-amd64
+          path: ${{ github.workspace }}/bin/capact_linux_amd64/capact
           retention-days: 1 # Default 90 days
 
   integration-tests:
@@ -406,7 +406,7 @@ jobs:
     permissions:
       contents: read
     env:
-      CAPACT_BINARY: "${{ github.workspace}}/capact-linux-amd64"
+      CAPACT_BINARY: "${{ github.workspace}}/capact_linux_amd64/capact"
 
     steps:
       - name: Checkout code

--- a/.goreleaser.latest.yml
+++ b/.goreleaser.latest.yml
@@ -47,12 +47,6 @@ changelog:
 
 dist: bin
 
-blobs:
-  -
-    provider: gs
-    bucket: capactio-binaries
-    folder: '{{ .Tag }}'
-
 release:
   # You can disable this pipe in order to not upload any artifacts.
   # Defaults to false.

--- a/.goreleaser.latest.yml
+++ b/.goreleaser.latest.yml
@@ -14,15 +14,12 @@ builds:
     goarch:
       - amd64
     main: ./cmd/cli
-    binary: 'capact-{{ .Os }}-{{ .Arch }}'
+    binary: 'capact'
     ldflags:
       - -s -w -X  capact.io/capact/cmd/cli/cmd.Version={{.Version}} -X  capact.io/capact/cmd/cli/cmd.Revision={{.ShortCommit}} -X capact.io/capact/cmd/cli/cmd.BuildDate={{.Date}} -X capact.io/capact/cmd/cli/cmd.Branch={{.Branch}}
     hooks:
       # Install upx first, https://github.com/upx/upx/releases
       post: upx -1 "{{ .Path }}"
-    # GoReleaser creates binaries inside `bin/${BuildID}_${BuildTarget}`, which is an unique directory per build target in the matrix.
-    # Currently, we use the `gsutil -m rsync ./bin/ gs://capactio-binaries/latest/` command, which is easier when binaries are not nested in nested directories.
-    no_unique_dist_dir: true
 
 archives:
   - format: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,23 +60,31 @@ archives:
     - populator
 
 brews:
-- name: capact
-  ids:
-  - capact-archive
-  homepage: &homebrew-homepage https://github.com/mkuziemko/homebrew-tap
-  tap: &homebrew-tap
-    owner: capactio
-    name: homebrew-tap
-  commit_author: &homebrew-commit-author
-      name: Capact Bot
-      email: capactbot@capact.io
+  - name: capact
+    ids:
+    - capact-archive
+    homepage: &homebrew-homepage https://github.com/capactio/homebrew-tap
+    description: "Capact CLI is a command-line tool, which manages Capact resources."
+    license: "Apache License 2.0"
+    tap: &homebrew-tap
+      owner: capactio
+      name: homebrew-tap
+    commit_author: &homebrew-commit-author
+        name: Capact Bot
+        email: capactbot@capact.io
+    test: |
+      system "#{bin}/capact version"
 
-- name: populator
-  ids:
-  - populator-archive
-  homepage: *homebrew-homepage
-  tap: *homebrew-tap
-  commit_author: *homebrew-commit-author
+  - name: populator
+    ids:
+    - populator-archive
+    homepage: *homebrew-homepage
+    description: "Populator is a command-line tool, which helps to populate various Capact content."
+    license: "Apache License 2.0"
+    tap: *homebrew-tap
+    commit_author: *homebrew-commit-author
+    test: |
+      system "#{bin}/populator version"
 
 dockers:
   - dockerfile: Dockerfile.cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,10 +32,9 @@ builds:
       # Install upx first, https://github.com/upx/upx/releases
       post: upx -9 "{{ .Path }}"
     main: ./cmd/cli
-    binary: 'capact-{{ .Os }}-{{ .Arch }}'
+    binary: 'capact'
     ldflags:
       - -s -w -X  capact.io/capact/cmd/cli/cmd.Version={{.Version}} -X  capact.io/capact/cmd/cli/cmd.Revision={{.ShortCommit}} -X capact.io/capact/cmd/cli/cmd.BuildDate={{.Date}} -X capact.io/capact/cmd/cli/cmd.Branch={{.Branch}}
-    no_unique_dist_dir: true
 
   # Capact populator
   - id: populator
@@ -45,12 +44,39 @@ builds:
     ignore: *build-ignore
     hooks: *build-hooks
     main: ./cmd/populator
-    binary: 'populator-{{ .Os }}-{{ .Arch }}'
-    no_unique_dist_dir: true
+    binary: 'populator'
 
 archives:
-  - format: binary
-    name_template: '{{ .Binary }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+  - id: capact-archive
+    name_template: &archives-name-template '{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format: &archives-format binary
+    builds:
+    - capact
+
+  - id: populator-archive
+    name_template: *archives-name-template
+    format: *archives-format
+    builds:
+    - populator
+
+brews:
+- name: capact
+  ids:
+  - capact-archive
+  homepage: &homebrew-homepage https://github.com/mkuziemko/homebrew-tap
+  tap: &homebrew-tap
+    owner: capactio
+    name: homebrew-tap
+  commit_author: &homebrew-commit-author
+      name: Capact Bot
+      email: capactbot@capact.io
+
+- name: populator
+  ids:
+  - populator-archive
+  homepage: *homebrew-homepage
+  tap: *homebrew-tap
+  commit_author: *homebrew-commit-author
 
 dockers:
   - dockerfile: Dockerfile.cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,7 +84,7 @@ brews:
     tap: *homebrew-tap
     commit_author: *homebrew-commit-author
     test: |
-      system "#{bin}/populator version"
+      system "#{bin}/populator help"
 
 dockers:
   - dockerfile: Dockerfile.cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,12 +111,6 @@ changelog:
 
 dist: bin
 
-blobs:
-  -
-    provider: gs
-    bucket: capactio-binaries
-    folder: '{{ .Tag }}'
-
 release:
   github:
     owner: capactio

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -6,4 +6,4 @@ ENTRYPOINT ["/capact"]
 # Copy common CA certificates from Builder image (installed by default with ca-certificates package)
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY ./capact-linux-amd64 /capact
+COPY ./capact /capact

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ release-latest-binaries: ## Release latest Capact binaries
 	# https://goreleaser.com/limitations/semver/
 	#
 	# Update binaries
-	gsutil -m rsync ./bin/ gs://capactio-binaries/latest/
+	gsutil -m rsync -x "goreleaserdocker.*" -r ./bin/ gs://capactio-binaries/latest/
 	# By default Google sets `cache-control: public, max-age=3600`.
 	# We need to change to ensure the file is not cached by http clients, so latest version is always downloaded
 	# source: https://cloud.google.com/storage/docs/caching#performance_considerations

--- a/cmd/populator/docs/populator_register-ocf-manifests.md
+++ b/cmd/populator/docs/populator_register-ocf-manifests.md
@@ -15,7 +15,7 @@ To build the binary install required [Prerequisites](https://capact.io/community
 make build-tool-populator
 ```
 
-It creates a binary for your platform in the `bin` directory. For example, for Linux systems, it is `bin/populator-linux-amd64`.
+It creates a binary for your platform in the `bin` directory. For example, for Linux systems, it is `bin/populator_linux_amd64/populator`.
 
 ## Usage
 
@@ -35,7 +35,7 @@ kubectl -n capact-system port-forward svc/neo4j-neo4j 7474:7474
 To run it and use manifests, for example from the [`hub-manifests`](https://github.com/capactio/hub-manifests) repo, run:
 
 ```shell
-./bin/populator-linux-amd64 register ocf-manifests --source {PATH_TO_THE_MAIN_DIRECTORY_OF_THE_REPO}
+./bin/populator_linux_amd64/populator register ocf-manifests --source {PATH_TO_THE_MAIN_DIRECTORY_OF_THE_REPO}
 ```
 
 To use manifests from private git repo, private key, encoded in base64 format, is needed.

--- a/hack/eks/terraform/templates/bastion_userdata.sh.tpl
+++ b/hack/eks/terraform/templates/bastion_userdata.sh.tpl
@@ -13,7 +13,7 @@ unzip awscliv2.zip
 rm -rf awscliv2.zip aws
 
 # download capact
-curl --fail -Lo /usr/local/bin/capact https://storage.googleapis.com/capactio_binaries/${capact_cli_version}/capact-linux-amd64
+curl --fail -Lo /usr/local/bin/capact https://storage.googleapis.com/capactio_binaries/${capact_cli_version}/capact_linux_amd64/capact
 chmod +x /usr/local/bin/capact
 capact --version
 

--- a/hack/eks/terraform/templates/bastion_userdata.sh.tpl
+++ b/hack/eks/terraform/templates/bastion_userdata.sh.tpl
@@ -13,7 +13,7 @@ unzip awscliv2.zip
 rm -rf awscliv2.zip aws
 
 # download capact
-curl --fail -Lo /usr/local/bin/capact https://storage.googleapis.com/capactio_binaries/${capact_cli_version}/capact_linux_amd64/capact
+curl --fail -Lo /usr/local/bin/capact https://github.com/capactio/capact/releases/download/${capact_cli_version}/capact-linux-amd64
 chmod +x /usr/local/bin/capact
 capact --version
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- add generation of brew formulae for `capact` and `populator` in `goreleaser`

There was created a [dedicated repository](https://github.com/capactio/homebrew-tap) for Homebrew formulas.

## Testing
1. clone a forked repository:
```
git clone https://github.com/mkuziemko/capact/
```
2. replace Tap details in `.goreleaser.yml` file:
```
  tap: &homebrew-tap
    owner: mkuizemko
    name: homebrew-tap
``` 

**Note**: comment out a section with a _docker_, _blobs_ and _release_ as there are not needed. 

3. generate a personal GitHub token
4. generate a test release:
```
GITHUB_TOKEN=token goreleaser release --debug --timeout 60m
```

It should generate a test release in the forked repository with binaries and create a commit in the forked homebrew-tap repository.

## Related issue(s)
- https://github.com/capactio/capact/issues/587
