### PR TITLE
Update Capact dashboard tag and fix `capact upgrade` 

### DIFF
--- a/deploy/kubernetes/charts/capact/values.yaml
+++ b/deploy/kubernetes/charts/capact/values.yaml
@@ -21,7 +21,7 @@ dashboard:
     # Overrides the image path provided in globals (`global.containerRegistry.path`).
     path: ghcr.io/capactio
     # Overrides the image tag provided in globals (`global.containerRegistry.overrideTag`).
-    tag: "34e8069"
+    tag: "c8bbaf0"
 
 integrationTest:
   image:

--- a/internal/cli/upgrade/upgrade.go
+++ b/internal/cli/upgrade/upgrade.go
@@ -385,7 +385,7 @@ func mapToInputTypeInstances(capactCfg gqllocalapi.TypeInstance) ([]*gqlengine.I
 }
 
 // isBuiltinStorage checks if a given TypeInstance is a core Hub storage
-// TODO: add support to detect other Hub storages too. This change would require external call to Local Hub
+// TODO: add support to detect other Hub storages too. This change would require external call to Public Hub
 func isBuiltinStorage(ti *gqllocalapi.TypeInstance) bool {
 	return strings.HasPrefix(ti.TypeRef.Path, types.BuiltinHubStorageTypePath)
 }

--- a/pkg/sdk/apis/0.0.1/types/types.extend.go
+++ b/pkg/sdk/apis/0.0.1/types/types.extend.go
@@ -9,8 +9,10 @@ import (
 const (
 	// OCFPathPrefix defines path prefix that all OCF manifest must have.
 	OCFPathPrefix = "cap."
-	// HubBackendParentNodeName define parent path for the core hub storage.
+	// HubBackendParentNodeName defines parent path for the core Hub storage.
 	HubBackendParentNodeName = "cap.core.type.hub.storage"
+	// BuiltinHubStorageTypePath defines Type path for built-in Hub storage.
+	BuiltinHubStorageTypePath = "cap.core.type.hub.storage.neo4j"
 )
 
 // InterfaceRef holds the full path and revision to the Interface

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,14 +24,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
+	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 )
 
 const (
 	actionPassingInterfacePath = "cap.interface.capactio.capact.validation.action.passing"
 	uploadTypePath             = "cap.type.capactio.capact.validation.upload"
-	builtinStorageTypePath     = "cap.core.type.hub.storage.neo4j"
 	singleKeyTypePath          = "cap.type.capactio.capact.validation.single-key"
 )
 
@@ -590,7 +590,7 @@ func getUploadedTypeInstanceByValue(ctx context.Context, hubClient *hubclient.Cl
 func getBuiltinStorageTypeInstance(ctx context.Context, hubClient *hubclient.Client) hublocalgraphql.TypeInstance {
 	coreStorage, err := hubClient.ListTypeInstances(ctx, &hublocalgraphql.TypeInstanceFilter{
 		TypeRef: &hublocalgraphql.TypeRefFilterInput{
-			Path:     builtinStorageTypePath,
+			Path:     types.BuiltinHubStorageTypePath,
 			Revision: ptr.String("0.1.0"),
 		},
 	}, local.WithFields(local.TypeInstanceAllFields))
@@ -601,7 +601,7 @@ func getBuiltinStorageTypeInstance(ctx context.Context, hubClient *hubclient.Cli
 }
 
 func assertOutputTypeInstancesInActionStatus(ctx context.Context, engineClient *engine.Client, actionName string,
-	match types.GomegaMatcher,
+	match gomegatypes.GomegaMatcher,
 ) {
 	Eventually(func() ([]*enginegraphql.OutputTypeInstanceDetails, error) {
 		action, err := engineClient.GetAction(ctx, actionName)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

-  Update Capact dashboard tag after all refactoring done on dashboard repo. Additionally:
  - Fixes problem with invalid policy queries in Action view
  - Displays backend info in TypeInstance view
- Fix problem with `capact upgrade`
    ```
    Error: unexpected TypeRef, expected "cap.type.helm.chart.release", got "cap.core.type.hub.storage.neo4j"
     ✗ Creating upgrade Action for 0.6.0-ee49421 💾
    ```
    Now used backend is ignored.

    Tested manually via executing:
    ```
     make build-tool-cli
     mv ./bin/capact-darwin-amd64 /usr/local/bin/capact                                                                                                                       
    
     capact upgrade \                                                                                                                                                            
        --action-name-prefix 'capact-upgrade-' \
        --version @latest \
        --helm-repo @latest \
        --override-capact-image-repo ghcr.io/capactio \
        --override-capact-image-tag ee49421 \
        --enable-test-setup true \
        --increase-resource-limits \
        --wait
    ```

Manually updated image on long-running cluster, and tested that it works properly, see: https://dashboard.stage.cluster.capact.dev/actions/continuous-purple-gerrie
