### PR TITLE
Order returned TypeInstances by path:revision and createdAt

### DIFF
--- a/hub-js/graphql/local/examples.graphql
+++ b/hub-js/graphql/local/examples.graphql
@@ -162,6 +162,9 @@ mutation DeleteLockedTypeInstance($typeInstanceID: ID!) {
 
 fragment TypeInstance on TypeInstance {
   id
+  createdAt {
+    formatted
+  }
   typeRef {
     path
     revision

--- a/hub-js/graphql/local/schema.graphql
+++ b/hub-js/graphql/local/schema.graphql
@@ -13,6 +13,11 @@ directive @index on FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
 
 """
+Represents date, time and time zone
+"""
+scalar DateTime
+
+"""
 Arbitrary data
 """
 scalar Any
@@ -34,7 +39,7 @@ scalar LockOwnerID
 
 type TypeInstance {
   id: ID! @id
-
+  createdAt: DateTime
   lockedBy: LockOwnerID
 
   """
@@ -42,8 +47,19 @@ type TypeInstance {
   """
   typeRef: TypeInstanceTypeReference!
     @relation(name: "OF_TYPE", direction: "OUT")
-  uses: [TypeInstance!]! @relation(name: "USES", direction: "OUT")
-  usedBy: [TypeInstance!]! @relation(name: "USES", direction: "IN")
+  """
+  Return TypeInstance that are used. List is sorted by TypeInstance's TypeRef path in ascending order.
+  If TypeRef path is same for multiple TypeInstance then it's additionally sorted by Type revision in descending order (newest revision are first).
+  If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
+  """
+  uses: [TypeInstance!]!
+    @cypher(
+      statement: "MATCH (this)-[:USES]->(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
+    )
+  usedBy: [TypeInstance!]!
+    @cypher(
+      statement: "MATCH (this)<-[:USES]-(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
+    )
   backend: TypeInstanceBackendReference! @relation(name: "STORED_IN", direction: "OUT")
 
   latestResourceVersion: TypeInstanceResourceVersion
@@ -334,7 +350,9 @@ type Query {
         )
       )
 
-      RETURN DISTINCT ti
+      WITH DISTINCT ti, typeRef
+      ORDER BY typeRef.path ASC, typeRef.revision DESC, ti.createdAt DESC
+      RETURN ti
       """
     )
 
@@ -356,7 +374,7 @@ type Mutation {
   createTypeInstance(in: CreateTypeInstanceInput!): TypeInstance!
     @cypher(
       statement: """
-      CREATE (ti:TypeInstance {id: apoc.create.uuid()})
+      CREATE (ti:TypeInstance {id: apoc.create.uuid(), createdAt: datetime()})
 
       // Backend
       WITH *

--- a/hub-js/graphql/local/schema.graphql
+++ b/hub-js/graphql/local/schema.graphql
@@ -48,14 +48,17 @@ type TypeInstance {
   typeRef: TypeInstanceTypeReference!
     @relation(name: "OF_TYPE", direction: "OUT")
   """
-  Return TypeInstance that are used. List is sorted by TypeInstance's TypeRef path in ascending order.
-  If TypeRef path is same for multiple TypeInstance then it's additionally sorted by Type revision in descending order (newest revision are first).
+  Returns TypeInstances that are used. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
   If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
   """
   uses: [TypeInstance!]!
     @cypher(
       statement: "MATCH (this)-[:USES]->(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
     )
+  """
+  Returns TypeInstances that uses this TypeInstance. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
+  If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
+  """
   usedBy: [TypeInstance!]!
     @cypher(
       statement: "MATCH (this)<-[:USES]-(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
@@ -302,6 +305,10 @@ input UnlockTypeInstancesInput {
 }
 
 type Query {
+  """
+  Returns all TypeInstances. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
+  If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
+  """
   typeInstances(filter: TypeInstanceFilter = {}): [TypeInstance!]!
     @cypher(
       statement: """

--- a/hub-js/src/schema/local.ts
+++ b/hub-js/src/schema/local.ts
@@ -73,7 +73,7 @@ export const schema = makeAugmentedSchema({
               // create TypeInstances
               const createTypeInstanceResult = await tx.run(
                 `UNWIND $typeInstances AS typeInstance
-               CREATE (ti:TypeInstance {id: apoc.create.uuid()})
+               CREATE (ti:TypeInstance {id: apoc.create.uuid(), createdAt: datetime()})
 
                // Backend
                WITH *
@@ -500,6 +500,7 @@ export async function ensureCoreStorageTypeInstance(context: ContextWithDriver) 
 				    MERGE (ti)-[:CONTAINS]->(tir)
 				    MERGE (tir)-[:DESCRIBED_BY]->(metadata:TypeInstanceResourceVersionMetadata)
 				    MERGE (tir)-[:SPECIFIED_BY]->(spec)
+				    SET ti.createdAt = CASE WHEN ti.createdAt IS NOT NULL THEN ti.createdAt ELSE datetime() END
 
 				    RETURN ti
 					`, {value});

--- a/pkg/hub/api/graphql/local/models_gen.go
+++ b/pkg/hub/api/graphql/local/models_gen.go
@@ -52,10 +52,14 @@ type LockTypeInstancesInput struct {
 }
 
 type TypeInstance struct {
-	ID       string  `json:"id"`
-	LockedBy *string `json:"lockedBy"`
+	ID        string  `json:"id"`
+	CreatedAt *string `json:"createdAt"`
+	LockedBy  *string `json:"lockedBy"`
 	// Common properties for all TypeInstances which cannot be changed
-	TypeRef                 *TypeInstanceTypeReference     `json:"typeRef"`
+	TypeRef *TypeInstanceTypeReference `json:"typeRef"`
+	// Return TypeInstance that are used. List is sorted by TypeInstance's TypeRef path in ascending order.
+	// If TypeRef path is same for multiple TypeInstance then it's additionally sorted by Type revision in descending order (newest revision are first).
+	// If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
 	Uses                    []*TypeInstance                `json:"uses"`
 	UsedBy                  []*TypeInstance                `json:"usedBy"`
 	Backend                 *TypeInstanceBackendReference  `json:"backend"`

--- a/pkg/hub/api/graphql/local/models_gen.go
+++ b/pkg/hub/api/graphql/local/models_gen.go
@@ -57,10 +57,11 @@ type TypeInstance struct {
 	LockedBy  *string `json:"lockedBy"`
 	// Common properties for all TypeInstances which cannot be changed
 	TypeRef *TypeInstanceTypeReference `json:"typeRef"`
-	// Return TypeInstance that are used. List is sorted by TypeInstance's TypeRef path in ascending order.
-	// If TypeRef path is same for multiple TypeInstance then it's additionally sorted by Type revision in descending order (newest revision are first).
+	// Returns TypeInstances that are used. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
 	// If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
-	Uses                    []*TypeInstance                `json:"uses"`
+	Uses []*TypeInstance `json:"uses"`
+	// Returns TypeInstances that uses this TypeInstance. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
+	// If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
 	UsedBy                  []*TypeInstance                `json:"usedBy"`
 	Backend                 *TypeInstanceBackendReference  `json:"backend"`
 	LatestResourceVersion   *TypeInstanceResourceVersion   `json:"latestResourceVersion"`

--- a/pkg/hub/api/graphql/local/schema_gen.go
+++ b/pkg/hub/api/graphql/local/schema_gen.go
@@ -629,14 +629,17 @@ type TypeInstance {
   typeRef: TypeInstanceTypeReference!
     @relation(name: "OF_TYPE", direction: "OUT")
   """
-  Return TypeInstance that are used. List is sorted by TypeInstance's TypeRef path in ascending order.
-  If TypeRef path is same for multiple TypeInstance then it's additionally sorted by Type revision in descending order (newest revision are first).
+  Returns TypeInstances that are used. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
   If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
   """
   uses: [TypeInstance!]!
     @cypher(
       statement: "MATCH (this)-[:USES]->(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
     )
+  """
+  Returns TypeInstances that uses this TypeInstance. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
+  If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
+  """
   usedBy: [TypeInstance!]!
     @cypher(
       statement: "MATCH (this)<-[:USES]-(ti:TypeInstance)-[:OF_TYPE]-(tr: TypeInstanceTypeReference) RETURN ti ORDER BY tr.path ASC, tr.revision DESC, ti.createdAt DESC"
@@ -883,6 +886,10 @@ input UnlockTypeInstancesInput {
 }
 
 type Query {
+  """
+  Returns all TypeInstances. List is sorted by TypeInstance's TypeRef path in ascending order, and then by revision in descending order (newest revision are first).
+  If both TypeRef path and revision are same, then it's additionally sorted by TypeInstance createdAt field (newly created are first).
+  """
   typeInstances(filter: TypeInstanceFilter = {}): [TypeInstance!]!
     @cypher(
       statement: """


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Order returned TypeInstances by TypeRef.path ASC and TypeRef.revision DESC and TypeInstance.createdAt DESC
- Add `createdAt` property

Questions:
- should we also sort by ID? so if TIs has the same createdAt time we still sort it by sth that is always different and the result is predictable.


## Testing

1. Run neo4j:
    ```bash
    docker run -d \
      -p 7687:7687 -p 7474:7474 \
      -e "NEO4J_AUTH=neo4j/okon" \
      -e "NEO4JLABS_PLUGINS=[\"apoc\"]" \
      --name hub-neo4j-instance \
      ghcr.io/capactio/neo4j:4.2.13-apoc
    ```
1. Run Local Hub:
    ```bash
    APP_NEO4J_ENDPOINT=bolt://localhost:7687 APP_NEO4J_PASSWORD=okon APP_HUB_MODE=local npm run dev
    ```
1. Execute GraphQL mutations and queries:
    ```graphql
    
    mutation CreateTypeInstances {
      createTypeInstances(
        in: {
          typeInstances: [
            {
              alias: "child"
              typeRef: { path: "cap.type.simple", revision: "0.1.0" }
              attributes: [{ path: "cap.attribute.sample", revision: "0.1.0" }]
              value: { name: "Luke Skywalker" }
            }
            {
              alias: "child2"
              typeRef: { path: "cap.type.simple", revision: "0.2.0" }
              attributes: [{ path: "cap.attribute.sample", revision: "0.1.0" }]
              value: { name: "Leia Organa" }
            }
            {
              alias: "parent"
              typeRef: { path: "cap.type.simple", revision: "0.1.0" }
              attributes: [{ path: "cap.attribute.sample", revision: "0.1.0" }]
              value: { name: "Darth Vader" }
            }
          ]
          usesRelations: [{ from: "parent", to: "child" }, { from: "parent", to: "child2" }]
        }
      ) {
        id
        alias
      }
    }
    
    mutation AddTypeInstanceToRel {
      createTypeInstances(
        in: {
          typeInstances: [
            {
              alias: "child"
              typeRef: { path: "cap.type.simple", revision: "0.2.0" }
              attributes: [{ path: "cap.attribute.sample", revision: "0.1.0" }]
              value: { name: "Me" }
            }
          ]
          usesRelations: [{ from:  <parent_id>, to: "child" }]
        }
      ) {
        id
        alias
      }
    }
    
    
    # Lists TypeInstances.
    query ListTypeInstances {
      typeInstances{
        ...TypeInstance
      }
    }
    
    # Lists TypeInstances.
    query GetTypeInstance {
      typeInstance(id:  <parent_id> ) {
        ...TypeInstanceWithUses
      }
    }
    
    fragment TypeInstance on TypeInstance {
      id
	    createdAt {
		    formatted
	    }
      typeRef {
        path
        revision
      }
      lockedBy
      backend {
        id
        abstract
      }
    
    
    }
    
    fragment TypeInstanceWithUses on TypeInstance {
      ...TypeInstance
      uses {
        ...TypeInstance
      }
      usedBy {
        ...TypeInstance
      }
    }
    ```

You can do the same testing on main branch to see the diff.


CI test were executed twice:
 - https://github.com/capactio/capact/runs/5273985599?check_suite_focus=true
 - and current execution
## Related issue(s)

Fix https://github.com/capactio/capact/issues/640
