### PR TITLE
Create Helm chart for Secret Storage Backend and support default secret provider

### DIFF
--- a/cmd/secret-storage-backend/README.md
+++ b/cmd/secret-storage-backend/README.md
@@ -19,6 +19,7 @@ By default, the Secret Storage Backend has the `aws_secretsmanager` provider ena
 2. Export environment variables:
 
    ```bash
+    export AWS_DEFAULT_REGION="{region}" # e.g. eu-west-1
     export AWS_ACCESS_KEY_ID="{accessKey}"
     export AWS_SECRET_ACCESS_KEY="{secretKey}"
     ```

--- a/cmd/secret-storage-backend/README.md
+++ b/cmd/secret-storage-backend/README.md
@@ -7,7 +7,7 @@ Secret Storage Backend is a service which handles multiple secret storages for T
 ## Prerequisites
 
 - [Go](https://golang.org)
-- (Optional - if AWS Secrets Manager provider should be used) an AWS account with **AdministratorAccess** permissions on it
+- (Optional - if AWS Secrets Manager provider should be used) an AWS account with **AdministratorAccess** permissions
 
 ## Usage
 
@@ -28,8 +28,7 @@ By default, the Secret Storage Backend has the `aws_secretsmanager` provider ena
     APP_LOGGER_DEV_MODE=true go run ./cmd/secret-storage-backend/main.go
     ```
 
-The server listens to gRPC calls according to the [Storage Backend Protocol Buffers schema](../../hub-js/proto/storage_backend.proto).
-To perform such calls, you can use e.g. [Insomnia](https://insomnia.rest/) tool.
+The server listens to gRPC calls according to the [Storage Backend Protocol Buffers schema](../../hub-js/proto/storage_backend.proto). To perform such calls, you can use e.g. [Insomnia](https://insomnia.rest/) tool.
 
 ### Dotenv provider
 
@@ -43,14 +42,15 @@ To run the server with `dotenv` provider enabled, which stores data in files, ex
 
 ## Configuration
 
-| Name                    | Required | Default              | Description                                                                                                                   |
-|-------------------------|----------|----------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| APP_GRPC_ADDR           | no       | `:50051`             | TCP address the gRPC server binds to.                                                                                         |
-| APP_HEALTHZ_ADDR        | no       | `:8082`              | TCP address the health probes endpoint binds to.                                                                              |
-| APP_SUPPORTED_PROVIDERS | no       | `aws_secretsmanager` | Supported secret providers separated by `,`. A given provider must be passed in additional parameters of gRPC request inputs. |
-| APP_LOGGER_DEV_MODE     | no       | `false`              | Enable development mode logging.                                                                                              |
+| Name                    | Required | Default              | Description                                                                                                                                                                                                                                                             |
+|-------------------------|----------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| APP_GRPC_ADDR           | no       | `:50051`             | TCP address the gRPC server binds to.                                                                                                                                                                                                                                   |
+| APP_HEALTHZ_ADDR        | no       | `:8082`              | TCP address the health probes endpoint binds to.                                                                                                                                                                                                                        |
+| APP_SUPPORTED_PROVIDERS | no       | `aws_secretsmanager` | Supported secret providers separated by `,`. If multiple secret providers are configured, a specific provider must be passed in the gRPC request input context. If there is only one storage backend configured, the provider doesn't need to be passed in the context. |
+| APP_LOGGER_DEV_MODE     | no       | `false`              | Enable development mode logging.                                                                                                                                                                                                                                        |
 
-To configure providers, use environmental variables described in the [Providers](https://github.com/SpectralOps/teller#providers) paragraph for Teller's Readme.
+To configure providers, use environmental variables described in
+the [Providers](https://github.com/SpectralOps/teller#providers) paragraph for Teller's Readme.
 
 ## Development
 

--- a/cmd/secret-storage-backend/main.go
+++ b/cmd/secret-storage-backend/main.go
@@ -53,6 +53,7 @@ func main() {
 	healthzServer := healthz.NewHTTPServer(logger, cfg.HealthzAddr, appName)
 	parallelServers.Go(func() error { return healthzServer.Start(ctx) })
 
+	logger.Info("loaded secret providers", zap.Strings("providers", cfg.SupportedProviders))
 	providers, err := loadProviders(cfg.SupportedProviders)
 	exitOnError(err, "while loading providers")
 
@@ -98,6 +99,10 @@ func loadProviders(providerNames []string) (map[string]tellercore.Provider, erro
 		}
 
 		providersMap[providerName] = provider
+	}
+
+	if len(providersMap) == 0 {
+		return nil, errors.New("at least one secret provider has to be configured")
 	}
 
 	return providersMap, nil

--- a/deploy/kubernetes/charts/secret-storage-backend/.helmignore
+++ b/deploy/kubernetes/charts/secret-storage-backend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/kubernetes/charts/secret-storage-backend/Chart.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: secret-storage-backend
+description: A Helm chart for Secret Storage Backend for Capact Local Hub
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.6.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secret-storage-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "secret-storage-backend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secret-storage-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secret-storage-backend.labels" -}}
+helm.sh/chart: {{ include "secret-storage-backend.chart" . }}
+{{ include "secret-storage-backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secret-storage-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "secret-storage-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "secret-storage-backend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "secret-storage-backend.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/deployment.yaml
@@ -56,9 +56,11 @@ spec:
               value: "true"
             - name: APP_SUPPORTED_PROVIDERS
               value: "{{ join "," .Values.supportedProviders }}"
-            {{- with .Values.additionalEnvs }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- if .Values.additionalEnvs }}
+          envFrom:
+            - secretRef:
+                name: {{ include "secret-storage-backend.fullname" . }}
+          {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "secret-storage-backend.fullname" . }}
+  labels:
+    {{- include "secret-storage-backend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "secret-storage-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "secret-storage-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "secret-storage-backend.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: APP_GRPC_ADDR
+              value: ":50051"
+            - name: APP_HEALTHZ_ADDR
+              value: ":8082"
+            - name: APP_LOGGER_DEV_MODE
+              value: "true"
+            - name: APP_SUPPORTED_PROVIDERS
+              value: "{{ join "," .Values.supportedProviders }}"
+            {{- with .Values.additionalEnvs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/hpa.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hub.fullname" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hub.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/secret.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.additionalEnvs }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secret-storage-backend.fullname" . }}
+  labels:
+    {{- include "secret-storage-backend.labels" . | nindent 4 }}
+stringData:
+  {{- toYaml .Values.additionalEnvs | nindent 4 }}
+{{- end }}

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/service.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "secret-storage-backend.fullname" . }}
+  labels:
+    {{- include "secret-storage-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "secret-storage-backend.selectorLabels" . | nindent 4 }}

--- a/deploy/kubernetes/charts/secret-storage-backend/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "secret-storage-backend.serviceAccountName" . }}
+  labels:
+    {{- include "secret-storage-backend.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/secret-storage-backend/values.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/values.yaml
@@ -12,7 +12,7 @@ image:
 supportedProviders:
   - "dotenv"
 
-additionalEnvs: []
+additionalEnvs: {}
 
 replicaCount: 1
 

--- a/deploy/kubernetes/charts/secret-storage-backend/values.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/values.yaml
@@ -44,17 +44,13 @@ service:
   type: ClusterIP
   port: 50051
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 100m
+    memory: 32Mi
+  requests:
+    cpu: 30m
+    memory: 16Mi
 
 autoscaling:
   enabled: false

--- a/deploy/kubernetes/charts/secret-storage-backend/values.yaml
+++ b/deploy/kubernetes/charts/secret-storage-backend/values.yaml
@@ -1,0 +1,70 @@
+# Default values for secret-storage-backend.
+global:
+  containerRegistry:
+    path: ghcr.io/capactio
+    # Overrides the image tag for all Capact components and extensions. Default is the appVersion.
+    overrideTag: "latest"
+
+image:
+  name: secret-storage-backend
+  pullPolicy: IfNotPresent
+
+supportedProviders:
+  - "dotenv"
+
+additionalEnvs: []
+
+replicaCount: 1
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 50051
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371
 	github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spectralops/teller v1.4.1-0.20220220074628-10ea63fb3d8e
+	github.com/spectralops/teller v1.4.1-0.20220302155019-433a633e34b9
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
@@ -100,6 +100,4 @@ replace (
 
 	github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.8
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-
-	github.com/spectralops/teller => github.com/pkosiec/teller v1.4.1-0.20220225072420-11c5a1dd402f
 )

--- a/go.sum
+++ b/go.sum
@@ -1609,8 +1609,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pkosiec/teller v1.4.1-0.20220225072420-11c5a1dd402f h1:6pOhYy2XJhyNPDWJJhafxG50AyBUE7buJ3nMYEFeaWE=
-github.com/pkosiec/teller v1.4.1-0.20220225072420-11c5a1dd402f/go.mod h1:x2B4YYysArnF/yH+IWmEwSef+5kK+CFD/ySgQHEboC0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -1763,6 +1761,8 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spectralops/teller v1.4.1-0.20220302155019-433a633e34b9 h1:BKFG347ADMKQvqhLYDjDgtOAOfv5gdho1dCGZ4iT+DY=
+github.com/spectralops/teller v1.4.1-0.20220302155019-433a633e34b9/go.mod h1:x2B4YYysArnF/yH+IWmEwSef+5kK+CFD/ySgQHEboC0=
 github.com/spf13/afero v1.1.0/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/hack/release-charts.sh
+++ b/hack/release-charts.sh
@@ -26,6 +26,7 @@ readonly charts=(
   "monitoring"
   "neo4j"
   "capact"
+  "secret-storage-backend"
 )
 
 # shellcheck source=./hack/lib/utilities.sh

--- a/internal/secret-storage-backend/export_test.go
+++ b/internal/secret-storage-backend/export_test.go
@@ -1,0 +1,7 @@
+package secretstoragebackend
+
+import tellercore "github.com/spectralops/teller/pkg/core"
+
+func (h *Handler) GetProviderFromContext(contextBytes []byte) (tellercore.Provider, error) {
+	return h.getProviderFromContext(contextBytes)
+}

--- a/internal/secret-storage-backend/fake_provider_test.go
+++ b/internal/secret-storage-backend/fake_provider_test.go
@@ -11,10 +11,15 @@ var _ tellercore.Provider = &fakeProvider{}
 
 type fakeProvider struct {
 	secrets map[string]map[string]string
+	name    string
+}
+
+func newFakeProvider(secrets map[string]map[string]string) *fakeProvider {
+	return &fakeProvider{secrets: secrets, name: "fake"}
 }
 
 func (f *fakeProvider) Name() string {
-	return "fake"
+	return f.name
 }
 
 func (f *fakeProvider) GetMapping(kp tellercore.KeyPath) ([]tellercore.EnvEntry, error) {
@@ -45,6 +50,9 @@ func (f *fakeProvider) Get(kp tellercore.KeyPath) (*tellercore.EnvEntry, error) 
 func (f *fakeProvider) PutMapping(kp tellercore.KeyPath, m map[string]string) error {
 	secrets := f.getSecret(kp)
 
+	if f.secrets == nil {
+		f.secrets = make(map[string]map[string]string)
+	}
 	f.secrets[kp.Path] = tellerutils.Merge(secrets, m)
 
 	return nil

--- a/internal/secret-storage-backend/server_test.go
+++ b/internal/secret-storage-backend/server_test.go
@@ -42,24 +42,20 @@ func TestHandler_GetValue(t *testing.T) {
 		},
 		{
 			Name: "Success",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"2": `{"key":true}`,
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"2": `{"key":true}`,
 				},
-			},
+			}),
 			ExpectedValue: []byte(`{"key":true}`),
 		},
 		{
 			Name: "Empty value", // empty value is also a valid one
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"2": "",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"2": "",
 				},
-			},
+			}),
 			ExpectedValue: []byte{},
 		},
 	}
@@ -113,30 +109,26 @@ func TestHandler_GetLockedBy(t *testing.T) {
 	}{
 		{
 			Name:                 "No data",
-			InputProvider:        &fakeProvider{},
+			InputProvider:        newFakeProvider(nil),
 			ExpectedLockedBy:     nil,
 			ExpectedErrorMessage: ptr.String("rpc error: code = NotFound desc = TypeInstance \"uuid\" not found: secret from path \"/capact/uuid\" is empty"),
 		},
 		{
 			Name: "Empty value",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1": "bar",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1": "bar",
 				},
-			},
+			}),
 			ExpectedLockedBy: nil,
 		},
 		{
 			Name: "Success",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"locked_by": "service/foo",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"locked_by": "service/foo",
 				},
-			},
+			}),
 			ExpectedLockedBy: ptr.String("service/foo"),
 		},
 	}
@@ -193,7 +185,7 @@ func TestHandler_OnCreate(t *testing.T) {
 	}{
 		{
 			Name:          "No data",
-			InputProvider: &fakeProvider{secrets: map[string]map[string]string{}},
+			InputProvider: newFakeProvider(map[string]map[string]string{}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1": string(valueBytes),
@@ -202,11 +194,9 @@ func TestHandler_OnCreate(t *testing.T) {
 		},
 		{
 			Name: "Empty value",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {},
-				},
-			},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1": string(valueBytes),
@@ -215,13 +205,11 @@ func TestHandler_OnCreate(t *testing.T) {
 		},
 		{
 			Name: "Already existing",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1": "original",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1": "original",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1": "original",
@@ -288,11 +276,9 @@ func TestHandler_OnUpdate(t *testing.T) {
 	}{
 		{
 			Name: "Non-existing secret",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {},
-				},
-			},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {},
 			},
@@ -300,14 +286,12 @@ func TestHandler_OnUpdate(t *testing.T) {
 		},
 		{
 			Name: "Already existing locked",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1":         "original",
-						"locked_by": "service/foo",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1":         "original",
+					"locked_by": "service/foo",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1":         "original",
@@ -318,13 +302,11 @@ func TestHandler_OnUpdate(t *testing.T) {
 		},
 		{
 			Name: "Already existing not locked",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"3": "original",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"3": "original",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"3": "original",
@@ -389,7 +371,7 @@ func TestHandler_OnLock(t *testing.T) {
 	}{
 		{
 			Name:          "No data",
-			InputProvider: &fakeProvider{secrets: map[string]map[string]string{}},
+			InputProvider: newFakeProvider(nil),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"locked_by": "foo/sample",
@@ -398,11 +380,9 @@ func TestHandler_OnLock(t *testing.T) {
 		},
 		{
 			Name: "Empty value",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {},
-				},
-			},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"locked_by": "foo/sample",
@@ -411,13 +391,11 @@ func TestHandler_OnLock(t *testing.T) {
 		},
 		{
 			Name: "Already existing without conflict",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1": "original",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1": "original",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1":         "original",
@@ -427,14 +405,12 @@ func TestHandler_OnLock(t *testing.T) {
 		},
 		{
 			Name: "Already existing locked",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"3":         "original",
-						"locked_by": "previous",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"3":         "original",
+					"locked_by": "previous",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"3":         "original",
@@ -498,20 +474,18 @@ func TestHandler_OnUnlock(t *testing.T) {
 	}{
 		{
 			Name:                  "No data",
-			InputProvider:         &fakeProvider{secrets: map[string]map[string]string{}},
-			ExpectedProviderState: map[string]map[string]string{},
+			InputProvider:         newFakeProvider(nil),
+			ExpectedProviderState: nil,
 			ExpectedErrorMessage:  ptr.String("rpc error: code = NotFound desc = path \"/capact/uuid\" in provider \"fake\" not found"),
 		},
 		{
 			Name: "Already existing without conflict",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1":         "original",
-						"locked_by": "foo/bar",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1":         "original",
+					"locked_by": "foo/bar",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1": "original",
@@ -520,14 +494,12 @@ func TestHandler_OnUnlock(t *testing.T) {
 		},
 		{
 			Name: "Already existing empty property",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"3":         "original",
-						"locked_by": "",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"3":         "original",
+					"locked_by": "",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"3": "original",
@@ -536,13 +508,11 @@ func TestHandler_OnUnlock(t *testing.T) {
 		},
 		{
 			Name: "Already existing without lockedBy property",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"3": "original",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"3": "original",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"3": "original",
@@ -604,33 +574,29 @@ func TestHandler_OnDelete(t *testing.T) {
 	}{
 		{
 			Name:                  "No data",
-			InputProvider:         &fakeProvider{secrets: map[string]map[string]string{}},
-			ExpectedProviderState: map[string]map[string]string{},
+			InputProvider:         newFakeProvider(nil),
+			ExpectedProviderState: nil,
 			ExpectedErrorMessage:  ptr.String("rpc error: code = NotFound desc = path \"/capact/uuid\" in provider \"fake\" not found"),
 		},
 		{
 			Name: "Empty value",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {},
-				},
-			},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {},
+			}),
 			ExpectedProviderState: map[string]map[string]string{path: {}},
 			ExpectedErrorMessage:  ptr.String("rpc error: code = NotFound desc = path \"/capact/uuid\" in provider \"fake\" not found"),
 		},
 		{
 			Name: "Already existing not locked",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1": "original",
-					},
-					"cant-touch-this": {
-						"Music":        "hits me so hard",
-						"Makes me say": "Oh, my Lord",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1": "original",
 				},
-			},
+				"cant-touch-this": {
+					"Music":        "hits me so hard",
+					"Makes me say": "Oh, my Lord",
+				},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				"cant-touch-this": {
 					"Music":        "hits me so hard",
@@ -640,14 +606,12 @@ func TestHandler_OnDelete(t *testing.T) {
 		},
 		{
 			Name: "Already existing locked",
-			InputProvider: &fakeProvider{
-				secrets: map[string]map[string]string{
-					path: {
-						"1":         "original",
-						"locked_by": "foo/bar",
-					},
+			InputProvider: newFakeProvider(map[string]map[string]string{
+				path: {
+					"1":         "original",
+					"locked_by": "foo/bar",
 				},
-			},
+			}),
 			ExpectedProviderState: map[string]map[string]string{
 				path: {
 					"1":         "original",
@@ -688,6 +652,85 @@ func TestHandler_OnDelete(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, res)
+		})
+	}
+}
+
+func TestHandler_GetProviderFromContext(t *testing.T) {
+	// given
+	testCases := []struct {
+		Name                 string
+		InputContextBytes    []byte
+		InputProviders       map[string]tellercore.Provider
+		ExpectedProviderName string
+		ExpectedErrorMessage *string
+	}{
+		{
+			Name: "Empty context",
+			InputProviders: secret_storage_backend.Providers{
+				"one": &fakeProvider{name: "one"},
+			},
+			InputContextBytes:    nil,
+			ExpectedProviderName: "one",
+		},
+		{
+			Name: "Invalid context",
+			InputProviders: secret_storage_backend.Providers{
+				"one": &fakeProvider{name: "one"},
+			},
+			InputContextBytes:    []byte(`{foo}`),
+			ExpectedErrorMessage: ptr.String("rpc error: code = Internal desc = while unmarshaling additional parameters: invalid character 'f' looking for beginning of object key string"),
+		},
+		{
+			// this case shouldn't happen as the server validates list of input providers during start
+			Name:                 "Empty context without default provider",
+			InputProviders:       secret_storage_backend.Providers{},
+			ExpectedErrorMessage: ptr.String("rpc error: code = FailedPrecondition desc = while getting default provider based on empty context: invalid number of providers configured to get default one: expected: 1, actual: 0"),
+		},
+		{
+			Name: "Empty context with multiple providers",
+			InputProviders: secret_storage_backend.Providers{
+				"one": &fakeProvider{name: "one"},
+				"two": &fakeProvider{name: "two"},
+			},
+			ExpectedErrorMessage: ptr.String("rpc error: code = FailedPrecondition desc = while getting default provider based on empty context: invalid number of providers configured to get default one: expected: 1, actual: 2"),
+		},
+		{
+			Name: "Provider passed in context",
+			InputProviders: secret_storage_backend.Providers{
+				"one": &fakeProvider{name: "one"},
+				"two": &fakeProvider{name: "two"},
+			},
+			InputContextBytes:    []byte(`{"provider": "two"}`),
+			ExpectedProviderName: "two",
+		},
+		{
+			Name: "No such provider",
+			InputProviders: secret_storage_backend.Providers{
+				"one": &fakeProvider{name: "one"},
+			},
+			InputContextBytes:    []byte(`{"provider": "non-existing"}`),
+			ExpectedErrorMessage: ptr.String("rpc error: code = FailedPrecondition desc = missing loaded provider with name \"non-existing\""),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			handler := secret_storage_backend.NewHandler(logger.Noop(), testCase.InputProviders)
+
+			// when
+			provider, err := handler.GetProviderFromContext(testCase.InputContextBytes)
+
+			// then
+			if testCase.ExpectedErrorMessage != nil {
+				assert.Nil(t, provider)
+				require.Error(t, err)
+				assert.EqualError(t, err, *testCase.ExpectedErrorMessage)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.ExpectedProviderName, provider.Name())
 		})
 	}
 }

--- a/pkg/hub/api/grpc/storage_backend/client_test.go
+++ b/pkg/hub/api/grpc/storage_backend/client_test.go
@@ -21,7 +21,7 @@ const secretStorageBackendAddrEnv = "GRPC_SECRET_STORAGE_BACKEND_ADDR"
 //	and the `provider` is enabled on this server.
 //
 // To run this test, execute:
-// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run TestNewStorageBackendClient -v -count 1
+// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run "^TestNewStorageBackendClient$" -v -count 1
 func TestNewStorageBackendClient(t *testing.T) {
 	srvAddr := os.Getenv(secretStorageBackendAddrEnv)
 	if srvAddr == "" {
@@ -43,7 +43,7 @@ func TestNewStorageBackendClient(t *testing.T) {
 //	and there is just one `provider` enabled on this server.
 //
 // To run this test, execute:
-// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run TestNewStorageBackendClient_WithDefaultProvider -v -count 1
+// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run "^TestNewStorageBackendClient_WithDefaultProvider$" -v -count 1
 func TestNewStorageBackendClient_WithDefaultProvider(t *testing.T) {
 	srvAddr := os.Getenv(secretStorageBackendAddrEnv)
 	if srvAddr == "" {

--- a/pkg/hub/api/grpc/storage_backend/client_test.go
+++ b/pkg/hub/api/grpc/storage_backend/client_test.go
@@ -14,14 +14,12 @@ import (
 
 // #nosec G101
 const secretStorageBackendAddrEnv = "GRPC_SECRET_STORAGE_BACKEND_ADDR"
+const typeInstanceIDEnv = "TYPEINSTANCE_ID"
 
 // This test illustrates how to use gRPC Go client against real gRPC Storage Backend server.
 //
 // NOTE: Before running this test, make sure that the server is running under the `srvAddr` address
 //	and the `provider` is enabled on this server.
-//
-// To run this test, execute:
-// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run "^TestNewStorageBackendClient$" -v -count 1
 func TestNewStorageBackendClient(t *testing.T) {
 	srvAddr := os.Getenv(secretStorageBackendAddrEnv)
 	if srvAddr == "" {
@@ -30,7 +28,6 @@ func TestNewStorageBackendClient(t *testing.T) {
 
 	value := []byte(`{"key": true}`)
 	typeInstanceID := "id"
-
 	provider := "dotenv"
 	reqContext := []byte(fmt.Sprintf(`{"provider":"%s"}`, provider))
 
@@ -44,14 +41,22 @@ func TestNewStorageBackendClient(t *testing.T) {
 //
 // To run this test, execute:
 // GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run "^TestNewStorageBackendClient_WithDefaultProvider$" -v -count 1
+//
+// You can run this test with custom TypeInstance ID, by setting TYPEINSTANCE_ID env variable during test run.
+// This might be helpful while running this test against server with different default provider configured.
 func TestNewStorageBackendClient_WithDefaultProvider(t *testing.T) {
 	srvAddr := os.Getenv(secretStorageBackendAddrEnv)
 	if srvAddr == "" {
-		srvAddr = ":50051"
+		t.Skipf("skipping storage backend gRPC client test as the env %s is not provided", secretStorageBackendAddrEnv)
+	}
+
+	typeInstanceID := os.Getenv(typeInstanceIDEnv)
+	if typeInstanceID == "" {
+		// fallback to default
+		typeInstanceID = "id"
 	}
 
 	value := []byte(`{"key": true}`)
-	typeInstanceID := "id"
 
 	executeSecretStorageBackendTestScenario(t, srvAddr, typeInstanceID, value, nil)
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Support default provider for secret store backend 
- Create Helm chart for Secret Storage Backend
    - Store additional environments in secret 
- Use the latest Teller (instead of my fork)

## Notes

As agreed, the Helm chart has been placed inside `deploy/kubernetes/charts`. The consequence is that it will be equally versioned as our other Helm charts.
This chart is not installed by default and will be installed with Capact Action (PR coming soon).

## Testing

1. Check out this branch.
1. Run any Kubernetes cluster (it doesn't to be Capact, but ensure the `capact-system` namespace exists). You can run such with `capact env create kind`, and then execute `kubectl create ns capact-system`.

### Dotenv

Install the Helm chart:

```bash
helm install dotenv -n capact-system ./deploy/kubernetes/charts/secret-storage-backend --set=global.containerRegistry.path="ghcr.io/capactio/pr" --set=global.containerRegistry.overrideTag="PR-653" --set=supportedProviders={dotenv} --wait
```

Do the port forwarding:

```bash
kubectl -n capact-system port-forward svc/dotenv-secret-storage-backend 50051:50051
```

Run both scenarios of the smoke test (with and without the request context):

```bash
GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -v -count 1
```

### AWS

Create AWS security credentials with `SecretsManagerReadWrite` policy and export the environment variables:
    
```bash
export AWS_ACCESS_KEY_ID="{accessKey}"
export AWS_SECRET_ACCESS_KEY="{secretKey}"
```

Create file:

```bash
cat > /tmp/aws-values.yaml << ENDOFFILE
global:
  containerRegistry:
    path: ghcr.io/capactio/pr
    overrideTag: "PR-653"
supportedProviders:
  - "aws_secretsmanager"
additionalEnvs:
  AWS_DEFAULT_REGION: "eu-west-1"
  AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
  AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
ENDOFFILE
```

Install the Helm chart:

```bash
helm install aws -n capact-system ./deploy/kubernetes/charts/secret-storage-backend -f /tmp/aws-values.yaml --wait
```

Do the port forwarding:

```bash
kubectl -n capact-system port-forward svc/aws-secret-storage-backend 50051:50051
```

Export env variable with custom, unique TypeInstance ID, which will be used for the test:
```
export TYPEINSTANCE_ID="bc387c6c-2580-46e8-aa1f-0e8f630951d" # this one has not been used during last 7 days... yet 😄 
```

Run the smoke test without the request context:

```bash
GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./pkg/hub/api/grpc/storage_backend -run "^TestNewStorageBackendClient_WithDefaultProvider$" -v -count 1
```

### Cleanup

Run:

```bash
helm del -n capact-system dotenv aws
```

## Related issue(s)

See https://github.com/capactio/capact/issues/647
