### PR TITLE
Fix Helm Implementation generation for empty objects and arrays in Capact CLI

### DIFF
--- a/internal/cli/manifestgen/testdata/cap.implementation.helm.test-generated-schema.yaml
+++ b/internal/cli/manifestgen/testdata/cap.implementation.helm.test-generated-schema.yaml
@@ -99,12 +99,12 @@ spec:
                               repo: "https://charts.bitnami.com/bitnami"
                               version: "11.2.3"
                             values: # TODO(ContentDeveloper): Adjust the input values to use parameters from the Interface
-                              affinity: {}
-                              args: <@ additionalinput.args | default(None) | tojson @>
+                              affinity: <@ additionalinput.affinity | default({}) | tojson @>
+                              args: <@ additionalinput.args | default([]) | tojson @>
                               certificates:
-                                args: <@ additionalinput.certificates.args | default(None) | tojson @>
-                                command: <@ additionalinput.certificates.command | default(None) | tojson @>
-                                customCAs: <@ additionalinput.certificates.customCAs | default(None) | tojson @>
+                                args: <@ additionalinput.certificates.args | default([]) | tojson @>
+                                command: <@ additionalinput.certificates.command | default([]) | tojson @>
+                                customCAs: <@ additionalinput.certificates.customCAs | default([]) | tojson @>
                                 customCertificate:
                                   certificateLocation: <@ additionalinput.certificates.customCertificate.certificateLocation | default("/etc/ssl/certs/ssl-cert-snakeoil.pem") @>
                                   certificateSecret: <@ additionalinput.certificates.customCertificate.certificateSecret | default("") | tojson @>
@@ -113,63 +113,63 @@ spec:
                                     key: <@ additionalinput.certificates.customCertificate.chainSecret.key | default("") | tojson @>
                                     name: <@ additionalinput.certificates.customCertificate.chainSecret.name | default("") | tojson @>
                                   keyLocation: <@ additionalinput.certificates.customCertificate.keyLocation | default("/etc/ssl/private/ssl-cert-snakeoil.key") @>
-                                extraEnvVars: <@ additionalinput.certificates.extraEnvVars | default(None) | tojson @>
+                                extraEnvVars: <@ additionalinput.certificates.extraEnvVars | default([]) | tojson @>
                                 extraEnvVarsCM: <@ additionalinput.certificates.extraEnvVarsCM | default("") | tojson @>
                                 extraEnvVarsSecret: <@ additionalinput.certificates.extraEnvVarsSecret | default("") | tojson @>
                                 image:
                                   pullPolicy: <@ additionalinput.certificates.image.pullPolicy | default("IfNotPresent") @>
-                                  pullSecrets: <@ additionalinput.certificates.image.pullSecrets | default(None) | tojson @>
+                                  pullSecrets: <@ additionalinput.certificates.image.pullSecrets | default([]) | tojson @>
                                   registry: <@ additionalinput.certificates.image.registry | default("docker.io") @>
                                   repository: <@ additionalinput.certificates.image.repository | default("bitnami/bitnami-shell") @>
                                   tag: <@ additionalinput.certificates.image.tag | default("10-debian-10-r151") @>
-                              command: <@ additionalinput.command | default(None) | tojson @>
-                              commonAnnotations: {}
-                              commonLabels: {}
+                              command: <@ additionalinput.command | default([]) | tojson @>
+                              commonAnnotations: <@ additionalinput.commonAnnotations | default({}) | tojson @>
+                              commonLabels: <@ additionalinput.commonLabels | default({}) | tojson @>
                               containerSecurityContext:
                                 enabled: <@ additionalinput.containerSecurityContext.enabled | default(true) | tojson @>
                                 runAsUser: <@ additionalinput.containerSecurityContext.runAsUser | default(1001) @>
-                              customLivenessProbe: {}
-                              customReadinessProbe: {}
+                              customLivenessProbe: <@ additionalinput.customLivenessProbe | default({}) | tojson @>
+                              customReadinessProbe: <@ additionalinput.customReadinessProbe | default({}) | tojson @>
                               dokuwikiEmail: <@ additionalinput.dokuwikiEmail | default("user@example.com") @>
                               dokuwikiFullName: <@ additionalinput.dokuwikiFullName | default("User Name") @>
                               dokuwikiPassword: <@ additionalinput.dokuwikiPassword | default("") | tojson @>
                               dokuwikiUsername: <@ additionalinput.dokuwikiUsername | default("user") @>
                               dokuwikiWikiName: <@ additionalinput.dokuwikiWikiName | default("My Wiki") @>
                               existingSecret: <@ additionalinput.existingSecret | default("") | tojson @>
-                              extraDeploy: <@ additionalinput.extraDeploy | default(None) | tojson @>
-                              extraEnvVars: <@ additionalinput.extraEnvVars | default(None) | tojson @>
+                              extraDeploy: <@ additionalinput.extraDeploy | default([]) | tojson @>
+                              extraEnvVars: <@ additionalinput.extraEnvVars | default([]) | tojson @>
                               extraEnvVarsCM: <@ additionalinput.extraEnvVarsCM | default("") | tojson @>
                               extraEnvVarsSecret: <@ additionalinput.extraEnvVarsSecret | default("") | tojson @>
-                              extraVolumeMounts: <@ additionalinput.extraVolumeMounts | default(None) | tojson @>
-                              extraVolumes: <@ additionalinput.extraVolumes | default(None) | tojson @>
+                              extraVolumeMounts: <@ additionalinput.extraVolumeMounts | default([]) | tojson @>
+                              extraVolumes: <@ additionalinput.extraVolumes | default([]) | tojson @>
                               fullnameOverride: <@ additionalinput.fullnameOverride | default("") | tojson @>
                               global:
-                                imagePullSecrets: <@ additionalinput.global.imagePullSecrets | default(None) | tojson @>
+                                imagePullSecrets: <@ additionalinput.global.imagePullSecrets | default([]) | tojson @>
                                 imageRegistry: <@ additionalinput.global.imageRegistry | default("") | tojson @>
                                 storageClass: <@ additionalinput.global.storageClass | default("") | tojson @>
                               hostAliases: <@ additionalinput.hostAliases | default([{"hostnames":["status.localhost"],"ip":"127.0.0.1"}]) @>
                               image:
                                 debug: <@ additionalinput.image.debug | default(false) | tojson @>
                                 pullPolicy: <@ additionalinput.image.pullPolicy | default("IfNotPresent") @>
-                                pullSecrets: <@ additionalinput.image.pullSecrets | default(None) | tojson @>
+                                pullSecrets: <@ additionalinput.image.pullSecrets | default([]) | tojson @>
                                 registry: <@ additionalinput.image.registry | default("docker.io") @>
                                 repository: <@ additionalinput.image.repository | default("bitnami/dokuwiki") @>
                                 tag: <@ additionalinput.image.tag | default("20200729.0.0-debian-10-r319") @>
                               ingress:
-                                annotations: {}
+                                annotations: <@ additionalinput.ingress.annotations | default({}) | tojson @>
                                 apiVersion: <@ additionalinput.ingress.apiVersion | default("") | tojson @>
                                 certManager: <@ additionalinput.ingress.certManager | default(false) | tojson @>
                                 enabled: <@ additionalinput.ingress.enabled | default(false) | tojson @>
-                                extraHosts: <@ additionalinput.ingress.extraHosts | default(None) | tojson @>
-                                extraPaths: <@ additionalinput.ingress.extraPaths | default(None) | tojson @>
-                                extraTls: <@ additionalinput.ingress.extraTls | default(None) | tojson @>
+                                extraHosts: <@ additionalinput.ingress.extraHosts | default([]) | tojson @>
+                                extraPaths: <@ additionalinput.ingress.extraPaths | default([]) | tojson @>
+                                extraTls: <@ additionalinput.ingress.extraTls | default([]) | tojson @>
                                 hostname: <@ additionalinput.ingress.hostname | default("dokuwiki.local") @>
                                 path: <@ additionalinput.ingress.path | default("/") @>
                                 pathType: <@ additionalinput.ingress.pathType | default("ImplementationSpecific") @>
-                                secrets: <@ additionalinput.ingress.secrets | default(None) | tojson @>
+                                secrets: <@ additionalinput.ingress.secrets | default([]) | tojson @>
                                 tls: <@ additionalinput.ingress.tls | default(false) | tojson @>
                               kubeVersion: <@ additionalinput.kubeVersion | default("") | tojson @>
-                              lifecycleHooks: {}
+                              lifecycleHooks: <@ additionalinput.lifecycleHooks | default({}) | tojson @>
                               livenessProbe:
                                 enabled: <@ additionalinput.livenessProbe.enabled | default(true) | tojson @>
                                 failureThreshold: <@ additionalinput.livenessProbe.failureThreshold | default(6) @>
@@ -181,20 +181,20 @@ spec:
                                 enabled: <@ additionalinput.metrics.enabled | default(false) | tojson @>
                                 image:
                                   pullPolicy: <@ additionalinput.metrics.image.pullPolicy | default("IfNotPresent") @>
-                                  pullSecrets: <@ additionalinput.metrics.image.pullSecrets | default(None) | tojson @>
+                                  pullSecrets: <@ additionalinput.metrics.image.pullSecrets | default([]) | tojson @>
                                   registry: <@ additionalinput.metrics.image.registry | default("docker.io") @>
                                   repository: <@ additionalinput.metrics.image.repository | default("bitnami/apache-exporter") @>
                                   tag: <@ additionalinput.metrics.image.tag | default("0.10.0-debian-10-r5") @>
                                 podAnnotations:
                                   prometheus.io/port: <@ additionalinput.metrics.podAnnotations["prometheus.io/port"] | default("9117") @>
                                   prometheus.io/scrape: <@ additionalinput.metrics.podAnnotations["prometheus.io/scrape"] | default("true") @>
-                                resources: {}
+                                resources: <@ additionalinput.metrics.resources | default({}) | tojson @>
                               nameOverride: <@ additionalinput.nameOverride | default("") | tojson @>
                               nodeAffinityPreset:
                                 key: <@ additionalinput.nodeAffinityPreset.key | default("") | tojson @>
                                 type: <@ additionalinput.nodeAffinityPreset.type | default("") | tojson @>
-                                values: <@ additionalinput.nodeAffinityPreset.values | default(None) | tojson @>
-                              nodeSelector: {}
+                                values: <@ additionalinput.nodeAffinityPreset.values | default([]) | tojson @>
+                              nodeSelector: <@ additionalinput.nodeSelector | default({}) | tojson @>
                               persistence:
                                 accessMode: <@ additionalinput.persistence.accessMode | default("ReadWriteOnce") @>
                                 enabled: <@ additionalinput.persistence.enabled | default(true) | tojson @>
@@ -202,9 +202,9 @@ spec:
                                 size: <@ additionalinput.persistence.size | default("8Gi") @>
                                 storageClass: <@ additionalinput.persistence.storageClass | default("") | tojson @>
                               podAffinityPreset: <@ additionalinput.podAffinityPreset | default("") | tojson @>
-                              podAnnotations: {}
+                              podAnnotations: <@ additionalinput.podAnnotations | default({}) | tojson @>
                               podAntiAffinityPreset: <@ additionalinput.podAntiAffinityPreset | default("soft") @>
-                              podLabels: {}
+                              podLabels: <@ additionalinput.podLabels | default({}) | tojson @>
                               podSecurityContext:
                                 enabled: <@ additionalinput.podSecurityContext.enabled | default(true) | tojson @>
                                 fsGroup: <@ additionalinput.podSecurityContext.fsGroup | default(1001) @>
@@ -228,19 +228,19 @@ spec:
                                   https: <@ additionalinput.service.nodePorts.https | default("") | tojson @>
                                 port: <@ additionalinput.service.port | default(80) @>
                                 type: <@ additionalinput.service.type | default("LoadBalancer") @>
-                              sidecars: <@ additionalinput.sidecars | default(None) | tojson @>
-                              tolerations: <@ additionalinput.tolerations | default(None) | tojson @>
+                              sidecars: <@ additionalinput.sidecars | default([]) | tojson @>
+                              tolerations: <@ additionalinput.tolerations | default([]) | tojson @>
                               volumePermissions:
                                 enabled: <@ additionalinput.volumePermissions.enabled | default(false) | tojson @>
                                 image:
                                   pullPolicy: <@ additionalinput.volumePermissions.image.pullPolicy | default("Always") @>
-                                  pullSecrets: <@ additionalinput.volumePermissions.image.pullSecrets | default(None) | tojson @>
+                                  pullSecrets: <@ additionalinput.volumePermissions.image.pullSecrets | default([]) | tojson @>
                                   registry: <@ additionalinput.volumePermissions.image.registry | default("docker.io") @>
                                   repository: <@ additionalinput.volumePermissions.image.repository | default("bitnami/bitnami-shell") @>
                                   tag: <@ additionalinput.volumePermissions.image.tag | default("10-debian-10-r151") @>
                                 resources:
-                                  limits: {}
-                                  requests: {}
+                                  limits: <@ additionalinput.volumePermissions.resources.limits | default({}) | tojson @>
+                                  requests: <@ additionalinput.volumePermissions.resources.requests | default({}) | tojson @>
                               
                             output:
                               goTemplate: |

--- a/internal/cli/manifestgen/testdata/cap.implementation.helm.test.yaml
+++ b/internal/cli/manifestgen/testdata/cap.implementation.helm.test.yaml
@@ -108,26 +108,26 @@ spec:
                                 logTimezone: <@ additionalinput.audit.logTimezone | default("") | tojson @>
                                 pgAuditLog: <@ additionalinput.audit.pgAuditLog | default("") | tojson @>
                                 pgAuditLogCatalog: <@ additionalinput.audit.pgAuditLogCatalog | default("off") @>
-                              commonAnnotations: {}
+                              commonAnnotations: <@ additionalinput.commonAnnotations | default({}) | tojson @>
                               configurationConfigMap: <@ additionalinput.configurationConfigMap | default("") | tojson @>
                               containerSecurityContext:
                                 enabled: <@ additionalinput.containerSecurityContext.enabled | default(true) | tojson @>
                                 runAsUser: <@ additionalinput.containerSecurityContext.runAsUser | default(1001) @>
-                              customLivenessProbe: {}
-                              customReadinessProbe: {}
-                              customStartupProbe: {}
+                              customLivenessProbe: <@ additionalinput.customLivenessProbe | default({}) | tojson @>
+                              customReadinessProbe: <@ additionalinput.customReadinessProbe | default({}) | tojson @>
+                              customStartupProbe: <@ additionalinput.customStartupProbe | default({}) | tojson @>
                               diagnosticMode:
                                 args: <@ additionalinput.diagnosticMode.args | default(["infinity"]) @>
                                 command: <@ additionalinput.diagnosticMode.command | default(["sleep"]) @>
                                 enabled: <@ additionalinput.diagnosticMode.enabled | default(false) | tojson @>
                               existingSecret: <@ additionalinput.existingSecret | default("") | tojson @>
                               extendedConfConfigMap: <@ additionalinput.extendedConfConfigMap | default("") | tojson @>
-                              extraDeploy: <@ additionalinput.extraDeploy | default(None) | tojson @>
-                              extraEnv: <@ additionalinput.extraEnv | default(None) | tojson @>
+                              extraDeploy: <@ additionalinput.extraDeploy | default([]) | tojson @>
+                              extraEnv: <@ additionalinput.extraEnv | default([]) | tojson @>
                               extraEnvVarsCM: <@ additionalinput.extraEnvVarsCM | default("") | tojson @>
                               fullnameOverride: <@ additionalinput.fullnameOverride | default("") | tojson @>
                               global:
-                                imagePullSecrets: <@ additionalinput.global.imagePullSecrets | default(None) | tojson @>
+                                imagePullSecrets: <@ additionalinput.global.imagePullSecrets | default([]) | tojson @>
                                 imageRegistry: <@ additionalinput.global.imageRegistry | default("") | tojson @>
                                 postgresql:
                                   existingSecret: <@ additionalinput.global.postgresql.existingSecret | default("") | tojson @>
@@ -140,12 +140,12 @@ spec:
                               image:
                                 debug: <@ additionalinput.image.debug | default(false) | tojson @>
                                 pullPolicy: <@ additionalinput.image.pullPolicy | default("IfNotPresent") @>
-                                pullSecrets: <@ additionalinput.image.pullSecrets | default(None) | tojson @>
+                                pullSecrets: <@ additionalinput.image.pullSecrets | default([]) | tojson @>
                                 registry: <@ additionalinput.image.registry | default("docker.io") @>
                                 repository: <@ additionalinput.image.repository | default("bitnami/postgresql") @>
                                 tag: <@ additionalinput.image.tag | default("11.13.0-debian-10-r0") @>
                               initdbPassword: <@ additionalinput.initdbPassword | default("") | tojson @>
-                              initdbScripts: {}
+                              initdbScripts: <@ additionalinput.initdbScripts | default({}) | tojson @>
                               initdbScriptsConfigMap: <@ additionalinput.initdbScriptsConfigMap | default("") | tojson @>
                               initdbScriptsSecret: <@ additionalinput.initdbScriptsSecret | default("") | tojson @>
                               initdbUser: <@ additionalinput.initdbUser | default("") | tojson @>
@@ -163,7 +163,7 @@ spec:
                                 suffix: <@ additionalinput.ldap.suffix | default("") | tojson @>
                                 tls: <@ additionalinput.ldap.tls | default("") | tojson @>
                                 url: <@ additionalinput.ldap.url | default("") | tojson @>
-                              lifecycleHooks: {}
+                              lifecycleHooks: <@ additionalinput.lifecycleHooks | default({}) | tojson @>
                               livenessProbe:
                                 enabled: <@ additionalinput.livenessProbe.enabled | default(true) | tojson @>
                                 failureThreshold: <@ additionalinput.livenessProbe.failureThreshold | default(6) @>
@@ -172,12 +172,12 @@ spec:
                                 successThreshold: <@ additionalinput.livenessProbe.successThreshold | default(1) @>
                                 timeoutSeconds: <@ additionalinput.livenessProbe.timeoutSeconds | default(5) @>
                               metrics:
-                                customMetrics: {}
+                                customMetrics: <@ additionalinput.metrics.customMetrics | default({}) | tojson @>
                                 enabled: <@ additionalinput.metrics.enabled | default(false) | tojson @>
-                                extraEnvVars: <@ additionalinput.metrics.extraEnvVars | default(None) | tojson @>
+                                extraEnvVars: <@ additionalinput.metrics.extraEnvVars | default([]) | tojson @>
                                 image:
                                   pullPolicy: <@ additionalinput.metrics.image.pullPolicy | default("IfNotPresent") @>
-                                  pullSecrets: <@ additionalinput.metrics.image.pullSecrets | default(None) | tojson @>
+                                  pullSecrets: <@ additionalinput.metrics.image.pullSecrets | default([]) | tojson @>
                                   registry: <@ additionalinput.metrics.image.registry | default("docker.io") @>
                                   repository: <@ additionalinput.metrics.image.repository | default("bitnami/postgres-exporter") @>
                                   tag: <@ additionalinput.metrics.image.tag | default("0.10.0-debian-10-r27") @>
@@ -189,10 +189,10 @@ spec:
                                   successThreshold: <@ additionalinput.metrics.livenessProbe.successThreshold | default(1) @>
                                   timeoutSeconds: <@ additionalinput.metrics.livenessProbe.timeoutSeconds | default(5) @>
                                 prometheusRule:
-                                  additionalLabels: {}
+                                  additionalLabels: <@ additionalinput.metrics.prometheusRule.additionalLabels | default({}) | tojson @>
                                   enabled: <@ additionalinput.metrics.prometheusRule.enabled | default(false) | tojson @>
                                   namespace: <@ additionalinput.metrics.prometheusRule.namespace | default("") | tojson @>
-                                  rules: <@ additionalinput.metrics.prometheusRule.rules | default(None) | tojson @>
+                                  rules: <@ additionalinput.metrics.prometheusRule.rules | default([]) | tojson @>
                                 readinessProbe:
                                   enabled: <@ additionalinput.metrics.readinessProbe.enabled | default(true) | tojson @>
                                   failureThreshold: <@ additionalinput.metrics.readinessProbe.failureThreshold | default(6) @>
@@ -200,7 +200,7 @@ spec:
                                   periodSeconds: <@ additionalinput.metrics.readinessProbe.periodSeconds | default(10) @>
                                   successThreshold: <@ additionalinput.metrics.readinessProbe.successThreshold | default(1) @>
                                   timeoutSeconds: <@ additionalinput.metrics.readinessProbe.timeoutSeconds | default(5) @>
-                                resources: {}
+                                resources: <@ additionalinput.metrics.resources | default({}) | tojson @>
                                 securityContext:
                                   enabled: <@ additionalinput.metrics.securityContext.enabled | default(false) | tojson @>
                                   runAsUser: <@ additionalinput.metrics.securityContext.runAsUser | default(1001) @>
@@ -211,34 +211,34 @@ spec:
                                   loadBalancerIP: <@ additionalinput.metrics.service.loadBalancerIP | default("") | tojson @>
                                   type: <@ additionalinput.metrics.service.type | default("ClusterIP") @>
                                 serviceMonitor:
-                                  additionalLabels: {}
+                                  additionalLabels: <@ additionalinput.metrics.serviceMonitor.additionalLabels | default({}) | tojson @>
                                   enabled: <@ additionalinput.metrics.serviceMonitor.enabled | default(false) | tojson @>
                                   interval: <@ additionalinput.metrics.serviceMonitor.interval | default("") | tojson @>
-                                  metricRelabelings: <@ additionalinput.metrics.serviceMonitor.metricRelabelings | default(None) | tojson @>
+                                  metricRelabelings: <@ additionalinput.metrics.serviceMonitor.metricRelabelings | default([]) | tojson @>
                                   namespace: <@ additionalinput.metrics.serviceMonitor.namespace | default("") | tojson @>
-                                  relabelings: <@ additionalinput.metrics.serviceMonitor.relabelings | default(None) | tojson @>
+                                  relabelings: <@ additionalinput.metrics.serviceMonitor.relabelings | default([]) | tojson @>
                                   scrapeTimeout: <@ additionalinput.metrics.serviceMonitor.scrapeTimeout | default("") | tojson @>
                               nameOverride: <@ additionalinput.nameOverride | default("") | tojson @>
                               networkPolicy:
                                 allowExternal: <@ additionalinput.networkPolicy.allowExternal | default(true) | tojson @>
                                 enabled: <@ additionalinput.networkPolicy.enabled | default(false) | tojson @>
-                                explicitNamespacesSelector: {}
+                                explicitNamespacesSelector: <@ additionalinput.networkPolicy.explicitNamespacesSelector | default({}) | tojson @>
                               persistence:
                                 accessModes: <@ additionalinput.persistence.accessModes | default(["ReadWriteOnce"]) @>
-                                annotations: {}
+                                annotations: <@ additionalinput.persistence.annotations | default({}) | tojson @>
                                 enabled: <@ additionalinput.persistence.enabled | default(true) | tojson @>
                                 existingClaim: <@ additionalinput.persistence.existingClaim | default("") | tojson @>
                                 mountPath: <@ additionalinput.persistence.mountPath | default("/bitnami/postgresql") @>
-                                selector: {}
+                                selector: <@ additionalinput.persistence.selector | default({}) | tojson @>
                                 size: <@ additionalinput.persistence.size | default("8Gi") @>
                                 storageClass: <@ additionalinput.persistence.storageClass | default("") | tojson @>
                                 subPath: <@ additionalinput.persistence.subPath | default("") | tojson @>
                               pgHbaConfiguration: <@ additionalinput.pgHbaConfiguration | default("") | tojson @>
-                              postgresqlConfiguration: {}
+                              postgresqlConfiguration: <@ additionalinput.postgresqlConfiguration | default({}) | tojson @>
                               postgresqlDataDir: <@ additionalinput.postgresqlDataDir | default("/bitnami/postgresql/data") @>
                               postgresqlDatabase: <@ additionalinput.postgresqlDatabase | default("") | tojson @>
                               postgresqlDbUserConnectionLimit: <@ additionalinput.postgresqlDbUserConnectionLimit | default("") | tojson @>
-                              postgresqlExtendedConf: {}
+                              postgresqlExtendedConf: <@ additionalinput.postgresqlExtendedConf | default({}) | tojson @>
                               postgresqlInitdbArgs: <@ additionalinput.postgresqlInitdbArgs | default("") | tojson @>
                               postgresqlInitdbWalDir: <@ additionalinput.postgresqlInitdbWalDir | default("") | tojson @>
                               postgresqlMaxConnections: <@ additionalinput.postgresqlMaxConnections | default("") | tojson @>
@@ -253,28 +253,28 @@ spec:
                               postgresqlTcpKeepalivesInterval: <@ additionalinput.postgresqlTcpKeepalivesInterval | default("") | tojson @>
                               postgresqlUsername: <@ additionalinput.postgresqlUsername | default("postgres") @>
                               primary:
-                                affinity: {}
-                                annotations: {}
-                                extraInitContainers: <@ additionalinput.primary.extraInitContainers | default(None) | tojson @>
-                                extraVolumeMounts: <@ additionalinput.primary.extraVolumeMounts | default(None) | tojson @>
-                                extraVolumes: <@ additionalinput.primary.extraVolumes | default(None) | tojson @>
-                                labels: {}
+                                affinity: <@ additionalinput.primary.affinity | default({}) | tojson @>
+                                annotations: <@ additionalinput.primary.annotations | default({}) | tojson @>
+                                extraInitContainers: <@ additionalinput.primary.extraInitContainers | default([]) | tojson @>
+                                extraVolumeMounts: <@ additionalinput.primary.extraVolumeMounts | default([]) | tojson @>
+                                extraVolumes: <@ additionalinput.primary.extraVolumes | default([]) | tojson @>
+                                labels: <@ additionalinput.primary.labels | default({}) | tojson @>
                                 nodeAffinityPreset:
                                   key: <@ additionalinput.primary.nodeAffinityPreset.key | default("") | tojson @>
                                   type: <@ additionalinput.primary.nodeAffinityPreset.type | default("") | tojson @>
-                                  values: <@ additionalinput.primary.nodeAffinityPreset.values | default(None) | tojson @>
-                                nodeSelector: {}
+                                  values: <@ additionalinput.primary.nodeAffinityPreset.values | default([]) | tojson @>
+                                nodeSelector: <@ additionalinput.primary.nodeSelector | default({}) | tojson @>
                                 podAffinityPreset: <@ additionalinput.primary.podAffinityPreset | default("") | tojson @>
-                                podAnnotations: {}
+                                podAnnotations: <@ additionalinput.primary.podAnnotations | default({}) | tojson @>
                                 podAntiAffinityPreset: <@ additionalinput.primary.podAntiAffinityPreset | default("soft") @>
-                                podLabels: {}
+                                podLabels: <@ additionalinput.primary.podLabels | default({}) | tojson @>
                                 priorityClassName: <@ additionalinput.primary.priorityClassName | default("") | tojson @>
                                 service:
                                   clusterIP: <@ additionalinput.primary.service.clusterIP | default("") | tojson @>
                                   nodePort: <@ additionalinput.primary.service.nodePort | default("") | tojson @>
                                   type: <@ additionalinput.primary.service.type | default("") | tojson @>
-                                sidecars: <@ additionalinput.primary.sidecars | default(None) | tojson @>
-                                tolerations: <@ additionalinput.primary.tolerations | default(None) | tojson @>
+                                sidecars: <@ additionalinput.primary.sidecars | default([]) | tojson @>
+                                tolerations: <@ additionalinput.primary.tolerations | default([]) | tojson @>
                               primaryAsStandBy:
                                 enabled: <@ additionalinput.primaryAsStandBy.enabled | default(false) | tojson @>
                                 primaryHost: <@ additionalinput.primaryAsStandBy.primaryHost | default("") | tojson @>
@@ -284,31 +284,31 @@ spec:
                               rbac:
                                 create: <@ additionalinput.rbac.create | default(false) | tojson @>
                               readReplicas:
-                                affinity: {}
-                                annotations: {}
-                                extraInitContainers: <@ additionalinput.readReplicas.extraInitContainers | default(None) | tojson @>
-                                extraVolumeMounts: <@ additionalinput.readReplicas.extraVolumeMounts | default(None) | tojson @>
-                                extraVolumes: <@ additionalinput.readReplicas.extraVolumes | default(None) | tojson @>
-                                labels: {}
+                                affinity: <@ additionalinput.readReplicas.affinity | default({}) | tojson @>
+                                annotations: <@ additionalinput.readReplicas.annotations | default({}) | tojson @>
+                                extraInitContainers: <@ additionalinput.readReplicas.extraInitContainers | default([]) | tojson @>
+                                extraVolumeMounts: <@ additionalinput.readReplicas.extraVolumeMounts | default([]) | tojson @>
+                                extraVolumes: <@ additionalinput.readReplicas.extraVolumes | default([]) | tojson @>
+                                labels: <@ additionalinput.readReplicas.labels | default({}) | tojson @>
                                 nodeAffinityPreset:
                                   key: <@ additionalinput.readReplicas.nodeAffinityPreset.key | default("") | tojson @>
                                   type: <@ additionalinput.readReplicas.nodeAffinityPreset.type | default("") | tojson @>
-                                  values: <@ additionalinput.readReplicas.nodeAffinityPreset.values | default(None) | tojson @>
-                                nodeSelector: {}
+                                  values: <@ additionalinput.readReplicas.nodeAffinityPreset.values | default([]) | tojson @>
+                                nodeSelector: <@ additionalinput.readReplicas.nodeSelector | default({}) | tojson @>
                                 persistence:
                                   enabled: <@ additionalinput.readReplicas.persistence.enabled | default(true) | tojson @>
                                 podAffinityPreset: <@ additionalinput.readReplicas.podAffinityPreset | default("") | tojson @>
-                                podAnnotations: {}
+                                podAnnotations: <@ additionalinput.readReplicas.podAnnotations | default({}) | tojson @>
                                 podAntiAffinityPreset: <@ additionalinput.readReplicas.podAntiAffinityPreset | default("soft") @>
-                                podLabels: {}
+                                podLabels: <@ additionalinput.readReplicas.podLabels | default({}) | tojson @>
                                 priorityClassName: <@ additionalinput.readReplicas.priorityClassName | default("") | tojson @>
-                                resources: {}
+                                resources: <@ additionalinput.readReplicas.resources | default({}) | tojson @>
                                 service:
                                   clusterIP: <@ additionalinput.readReplicas.service.clusterIP | default("") | tojson @>
                                   nodePort: <@ additionalinput.readReplicas.service.nodePort | default("") | tojson @>
                                   type: <@ additionalinput.readReplicas.service.type | default("") | tojson @>
-                                sidecars: <@ additionalinput.readReplicas.sidecars | default(None) | tojson @>
-                                tolerations: <@ additionalinput.readReplicas.tolerations | default(None) | tojson @>
+                                sidecars: <@ additionalinput.readReplicas.sidecars | default([]) | tojson @>
+                                tolerations: <@ additionalinput.readReplicas.tolerations | default([]) | tojson @>
                               readinessProbe:
                                 enabled: <@ additionalinput.readinessProbe.enabled | default(true) | tojson @>
                                 failureThreshold: <@ additionalinput.readinessProbe.failureThreshold | default(6) @>
@@ -335,10 +335,10 @@ spec:
                                 enabled: <@ additionalinput.securityContext.enabled | default(true) | tojson @>
                                 fsGroup: <@ additionalinput.securityContext.fsGroup | default(1001) @>
                               service:
-                                annotations: {}
+                                annotations: <@ additionalinput.service.annotations | default({}) | tojson @>
                                 clusterIP: <@ additionalinput.service.clusterIP | default("") | tojson @>
                                 loadBalancerIP: <@ additionalinput.service.loadBalancerIP | default("") | tojson @>
-                                loadBalancerSourceRanges: <@ additionalinput.service.loadBalancerSourceRanges | default(None) | tojson @>
+                                loadBalancerSourceRanges: <@ additionalinput.service.loadBalancerSourceRanges | default([]) | tojson @>
                                 nodePort: <@ additionalinput.service.nodePort | default("") | tojson @>
                                 port: <@ additionalinput.service.port | default(5432) @>
                                 type: <@ additionalinput.service.type | default("ClusterIP") @>
@@ -375,7 +375,7 @@ spec:
                                 enabled: <@ additionalinput.volumePermissions.enabled | default(false) | tojson @>
                                 image:
                                   pullPolicy: <@ additionalinput.volumePermissions.image.pullPolicy | default("Always") @>
-                                  pullSecrets: <@ additionalinput.volumePermissions.image.pullSecrets | default(None) | tojson @>
+                                  pullSecrets: <@ additionalinput.volumePermissions.image.pullSecrets | default([]) | tojson @>
                                   registry: <@ additionalinput.volumePermissions.image.registry | default("docker.io") @>
                                   repository: <@ additionalinput.volumePermissions.image.repository | default("bitnami/bitnami-shell") @>
                                   tag: <@ additionalinput.volumePermissions.image.tag | default("10-debian-10-r159") @>

--- a/internal/cli/manifestgen/testdata/cap.type.helm.test-generated-schema-input-parameters.yaml
+++ b/internal/cli/manifestgen/testdata/cap.type.helm.test-generated-schema-input-parameters.yaml
@@ -20,6 +20,7 @@ spec:
         "properties": {
           "affinity": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "Affinity",
             "$id": "#/properties/affinity"
@@ -85,6 +86,7 @@ spec:
                         "$id": "#/properties/certificates/properties/customCertificate/properties/chainSecret/properties/name"
                       }
                     },
+                    "additionalProperties": true,
                     "type": "object",
                     "title": "ChainSecret",
                     "$id": "#/properties/certificates/properties/customCertificate/properties/chainSecret"
@@ -96,6 +98,7 @@ spec:
                     "$id": "#/properties/certificates/properties/customCertificate/properties/keyLocation"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "CustomCertificate",
                 "$id": "#/properties/certificates/properties/customCertificate"
@@ -151,11 +154,13 @@ spec:
                     "$id": "#/properties/certificates/properties/image/properties/tag"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Image",
                 "$id": "#/properties/certificates/properties/image"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Certificates",
             "$id": "#/properties/certificates"
@@ -168,12 +173,14 @@ spec:
           },
           "commonAnnotations": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "CommonAnnotations",
             "$id": "#/properties/commonAnnotations"
           },
           "commonLabels": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "CommonLabels",
             "$id": "#/properties/commonLabels"
@@ -193,18 +200,21 @@ spec:
                 "$id": "#/properties/containerSecurityContext/properties/runAsUser"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "ContainerSecurityContext",
             "$id": "#/properties/containerSecurityContext"
           },
           "customLivenessProbe": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "CustomLivenessProbe",
             "$id": "#/properties/customLivenessProbe"
           },
           "customReadinessProbe": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "CustomReadinessProbe",
             "$id": "#/properties/customReadinessProbe"
@@ -308,6 +318,7 @@ spec:
                 "$id": "#/properties/global/properties/storageClass"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Global",
             "$id": "#/properties/global"
@@ -364,6 +375,7 @@ spec:
                 "$id": "#/properties/image/properties/tag"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Image",
             "$id": "#/properties/image"
@@ -372,6 +384,7 @@ spec:
             "properties": {
               "annotations": {
                 "properties": {},
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Annotations",
                 "$id": "#/properties/ingress/properties/annotations"
@@ -443,6 +456,7 @@ spec:
                 "$id": "#/properties/ingress/properties/tls"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Ingress",
             "$id": "#/properties/ingress"
@@ -455,6 +469,7 @@ spec:
           },
           "lifecycleHooks": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "LifecycleHooks",
             "$id": "#/properties/lifecycleHooks"
@@ -498,6 +513,7 @@ spec:
                 "$id": "#/properties/livenessProbe/properties/timeoutSeconds"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "LivenessProbe",
             "$id": "#/properties/livenessProbe"
@@ -543,6 +559,7 @@ spec:
                     "$id": "#/properties/metrics/properties/image/properties/tag"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Image",
                 "$id": "#/properties/metrics/properties/image"
@@ -562,17 +579,20 @@ spec:
                     "$id": "#/properties/metrics/properties/podAnnotations/properties/prometheus.io/scrape"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "PodAnnotations",
                 "$id": "#/properties/metrics/properties/podAnnotations"
               },
               "resources": {
                 "properties": {},
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Resources",
                 "$id": "#/properties/metrics/properties/resources"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Metrics",
             "$id": "#/properties/metrics"
@@ -604,12 +624,14 @@ spec:
                 "$id": "#/properties/nodeAffinityPreset/properties/values"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "NodeAffinityPreset",
             "$id": "#/properties/nodeAffinityPreset"
           },
           "nodeSelector": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "NodeSelector",
             "$id": "#/properties/nodeSelector"
@@ -647,6 +669,7 @@ spec:
                 "$id": "#/properties/persistence/properties/storageClass"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Persistence",
             "$id": "#/properties/persistence"
@@ -659,6 +682,7 @@ spec:
           },
           "podAnnotations": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "PodAnnotations",
             "$id": "#/properties/podAnnotations"
@@ -671,6 +695,7 @@ spec:
           },
           "podLabels": {
             "properties": {},
+            "additionalProperties": true,
             "type": "object",
             "title": "PodLabels",
             "$id": "#/properties/podLabels"
@@ -690,6 +715,7 @@ spec:
                 "$id": "#/properties/podSecurityContext/properties/fsGroup"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "PodSecurityContext",
             "$id": "#/properties/podSecurityContext"
@@ -733,6 +759,7 @@ spec:
                 "$id": "#/properties/readinessProbe/properties/timeoutSeconds"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "ReadinessProbe",
             "$id": "#/properties/readinessProbe"
@@ -754,11 +781,13 @@ spec:
                     "$id": "#/properties/resources/properties/requests/properties/memory"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Requests",
                 "$id": "#/properties/resources/properties/requests"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Resources",
             "$id": "#/properties/resources"
@@ -798,6 +827,7 @@ spec:
                     "$id": "#/properties/service/properties/nodePorts/properties/https"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "NodePorts",
                 "$id": "#/properties/service/properties/nodePorts"
@@ -815,6 +845,7 @@ spec:
                 "$id": "#/properties/service/properties/type"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "Service",
             "$id": "#/properties/service"
@@ -872,6 +903,7 @@ spec:
                     "$id": "#/properties/volumePermissions/properties/image/properties/tag"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Image",
                 "$id": "#/properties/volumePermissions/properties/image"
@@ -880,27 +912,32 @@ spec:
                 "properties": {
                   "limits": {
                     "properties": {},
+                    "additionalProperties": true,
                     "type": "object",
                     "title": "Limits",
                     "$id": "#/properties/volumePermissions/properties/resources/properties/limits"
                   },
                   "requests": {
                     "properties": {},
+                    "additionalProperties": true,
                     "type": "object",
                     "title": "Requests",
                     "$id": "#/properties/volumePermissions/properties/resources/properties/requests"
                   }
                 },
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Resources",
                 "$id": "#/properties/volumePermissions/properties/resources"
               }
             },
+            "additionalProperties": true,
             "type": "object",
             "title": "VolumePermissions",
             "$id": "#/properties/volumePermissions"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "$id": "#"
       }


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Fix Helm Implementation generation for empty objects and arrays in Capact CLI
- Allow additional properties for objects generated with

## Testing

To test this PR, check out this branch and run:

```
# with old CLI
capact manifest generate implementation helm cap.implementation.secret-storage-backend.install ./deploy/kubernetes/charts/secret-storage-backend -o /tmp/generated-old

# with new CLI, from this branch
go run ./cmd/cli/main.go manifest generate implementation helm cap.implementation.secret-storage-backend.install ./deploy/kubernetes/charts/secret-storage-backend -o /tmp/generated-new
```

You can compare the values with real manifests from https://github.com/capactio/hub-manifests/blob/main/manifests/implementation/aws/secrets-manager/storage/install.yaml

For more details, see the Steps to reproduce from #663.

## Related issue(s)

Resolves #663
