### PR TITLE
Bootstrap Helm storage backend Go app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint ignore=DL3061
 # syntax = docker/dockerfile:1-experimental
 
 FROM golang:1.16.3-alpine as builder

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: generate build-all-images test-unit test-lint ## Default: generate all, bui
 # Building #
 ############
 
-APPS = gateway k8s-engine hub-js argo-runner helm-runner cloudsql-runner populator terraform-runner argo-actions gitlab-api-runner secret-storage-backend
+APPS = gateway k8s-engine hub-js argo-runner helm-runner cloudsql-runner populator terraform-runner argo-actions gitlab-api-runner secret-storage-backend helm-storage-backend
 TESTS = e2e
 INFRA = json-go-gen graphql-schema-linter jinja2 merger
 

--- a/cmd/helm-storage-backend/README.md
+++ b/cmd/helm-storage-backend/README.md
@@ -10,7 +10,11 @@ Helm Storage Backend is a service which handles Helm-related storage logic. It w
 
 ## Usage
 
+There are two separate modes of running the Helm storage backend.
+
 ### Helm Release storage backend
+
+This mode exposes functionality which fetches metadata for a given Helm release from a Kubernetes cluster.
 
 To run the server, execute:
 
@@ -21,6 +25,8 @@ To run the server, execute:
 The server listens to gRPC calls according to the [Storage Backend Protocol Buffers schema](../../hub-js/proto/storage_backend.proto). To perform such calls, you can use e.g. [Insomnia](https://insomnia.rest/) tool.
 
 ### Helm Templating storage backend
+
+This mode exposes functionality which renders a given Go template against an installed Helm release.
 
 To run the server, execute:
 

--- a/cmd/helm-storage-backend/README.md
+++ b/cmd/helm-storage-backend/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Helm Storage Backend is a service which handles Helm-related storage logic. It works in two modes. Each of them exposes the same Storage Backend gRPC server, but with a different set of features.
+Helm Storage Backend is a service which handles Helm-related storage logic. It works in different modes. Each of them exposes the same Storage Backend gRPC server with a different set of features.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ Helm Storage Backend is a service which handles Helm-related storage logic. It w
 
 ## Usage
 
-There are two separate modes of running the Helm storage backend.
+There are different modes of running the Helm storage backend.
 
 ### Helm Release storage backend
 

--- a/cmd/helm-storage-backend/README.md
+++ b/cmd/helm-storage-backend/README.md
@@ -1,0 +1,45 @@
+# Helm Storage Backend
+
+## Overview
+
+Helm Storage Backend is a service which handles Helm-related storage logic. It works in two modes. Each of them exposes the same Storage Backend gRPC server, but with a different set of features.
+
+## Prerequisites
+
+- [Go](https://golang.org)
+
+## Usage
+
+### Helm Release storage backend
+
+To run the server, execute:
+
+ ```bash
+ APP_LOGGER_DEV_MODE=true APP_MODE="release" go run ./cmd/helm-storage-backend/main.go
+ ```
+
+The server listens to gRPC calls according to the [Storage Backend Protocol Buffers schema](../../hub-js/proto/storage_backend.proto). To perform such calls, you can use e.g. [Insomnia](https://insomnia.rest/) tool.
+
+### Helm Templating storage backend
+
+To run the server, execute:
+
+ ```bash
+ APP_LOGGER_DEV_MODE=true APP_MODE="template" go run ./cmd/helm-storage-backend/main.go
+ ```
+
+The server listens to gRPC calls according to the [Storage Backend Protocol Buffers schema](../../hub-js/proto/storage_backend.proto). To perform such calls, you can use e.g. [Insomnia](https://insomnia.rest/) tool.
+
+## Configuration
+
+| Name                | Required | Default          | Description                                        |
+|---------------------|----------|------------------|----------------------------------------------------|
+| APP_MODE            | yes      |                  | One of the service modes: `release` or `template`. |
+| KUBECONFIG          | no       | `~/.kube/config` | Path to kubeconfig file                            |
+| APP_GRPC_ADDR       | no       | `:50051`         | TCP address the gRPC server binds to.              |
+| APP_HEALTHZ_ADDR    | no       | `:8082`          | TCP address the health probes endpoint binds to.   |
+| APP_LOGGER_DEV_MODE | no       | `false`          | Enable development mode logging.                   |
+
+## Development
+
+To read more about development, see the [Development guide](https://capact.io/community/development/development-guide).

--- a/cmd/helm-storage-backend/main.go
+++ b/cmd/helm-storage-backend/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+
+	helm_storage_backend "capact.io/capact/internal/helm-storage-backend"
+
+	"capact.io/capact/internal/healthz"
+	"capact.io/capact/internal/logger"
+	"capact.io/capact/pkg/hub/api/grpc/storage_backend"
+	"github.com/vrischmann/envconfig"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+)
+
+// Mode describes the selected handler for the Helm storage backend gRPC server.
+type Mode string
+
+const (
+	// HelmReleaseMode describes the Helm release functionality of the Helm storage backend.
+	HelmReleaseMode = "release"
+	// HelmTemplateMode describes the Helm templating functionality of the Helm storage backend.
+	HelmTemplateMode = "template"
+)
+
+// Config holds application related configuration.
+type Config struct {
+	// GRPCAddr is the TCP address the gRPC server binds to.
+	GRPCAddr string `envconfig:"default=:50051"`
+
+	// HealthzAddr is the TCP address the health probes endpoint binds to.
+	HealthzAddr string `envconfig:"default=:8082"`
+
+	// Mode describes the selected handler for the Helm storage backend gRPC server.
+	Mode Mode
+
+	Logger logger.Config
+}
+
+const appName = "helm-storage"
+
+func main() {
+	var cfg Config
+	err := envconfig.InitWithPrefix(&cfg, "APP")
+	exitOnError(err, "while loading configuration")
+
+	ctx := signals.SetupSignalHandler()
+
+	// setup logger
+	unnamedLogger, err := logger.New(cfg.Logger)
+	exitOnError(err, "while creating zap logger")
+
+	logger := unnamedLogger.Named(appName).Named(string(cfg.Mode))
+
+	// k8s
+
+	k8sCfg, err := config.GetConfig()
+	exitOnError(err, "while getting K8s config")
+
+	helmCfgFlags := helmCfgFlagsForK8sCfg(k8sCfg)
+
+	// setup servers
+	parallelServers := new(errgroup.Group)
+
+	// create handler
+	var handler storage_backend.StorageBackendServer
+	switch cfg.Mode {
+	case HelmReleaseMode:
+		handler = helm_storage_backend.NewReleaseHandler(logger, helmCfgFlags)
+	case HelmTemplateMode:
+		handler = helm_storage_backend.NewTemplateHandler(logger, helmCfgFlags)
+	default:
+		exitOnError(fmt.Errorf("invalid mode %q", cfg.Mode), "while loading storage backend handler")
+	}
+
+	healthzServer := healthz.NewHTTPServer(logger, cfg.HealthzAddr, fmt.Sprintf("%s-%s", appName, cfg.Mode))
+
+	parallelServers.Go(func() error { return healthzServer.Start(ctx) })
+
+	listenCfg := net.ListenConfig{}
+	listener, err := listenCfg.Listen(ctx, "tcp", cfg.GRPCAddr)
+	exitOnError(err, "while listening")
+
+	srv := grpc.NewServer()
+	storage_backend.RegisterStorageBackendServer(srv, handler)
+
+	go func() {
+		<-ctx.Done()
+		logger.Info("Stopping server gracefully")
+		srv.GracefulStop()
+	}()
+
+	parallelServers.Go(func() error {
+		logger.Info("Starting TCP server", zap.String("addr", cfg.GRPCAddr))
+		return srv.Serve(listener)
+	})
+
+	err = parallelServers.Wait()
+	exitOnError(err, "while waiting for servers to finish gracefully")
+}
+
+func exitOnError(err error, context string) {
+	if err != nil {
+		log.Fatalf("%s: %v", context, err)
+	}
+}
+
+func helmCfgFlagsForK8sCfg(k8sCfg *rest.Config) *genericclioptions.ConfigFlags {
+	return &genericclioptions.ConfigFlags{
+		APIServer:   &k8sCfg.Host,
+		Insecure:    &k8sCfg.Insecure,
+		CAFile:      &k8sCfg.CAFile,
+		BearerToken: &k8sCfg.BearerToken,
+	}
+}

--- a/cmd/secret-storage-backend/main.go
+++ b/cmd/secret-storage-backend/main.go
@@ -58,7 +58,6 @@ func main() {
 	exitOnError(err, "while loading providers")
 
 	handler := secret_storage_backend.NewHandler(logger, providers)
-	exitOnError(err, "while creating new handler")
 
 	listenCfg := net.ListenConfig{}
 	listener, err := listenCfg.Listen(ctx, "tcp", cfg.GRPCAddr)

--- a/hack/ci/setup-env.sh
+++ b/hack/ci/setup-env.sh
@@ -36,7 +36,7 @@ fi
 
 # TODO: Read components to build in automated way, e.g. from directory structure
 cat <<EOT >>"$GITHUB_ENV"
-APPS=name=matrix::{"include":[{"APP":"gateway"},{"APP":"k8s-engine"},{"APP":"hub-js"},{"APP":"argo-runner"},{"APP":"helm-runner"},{"APP":"populator"},{"APP":"terraform-runner"},{"APP":"argo-actions"},{"APP":"gitlab-api-runner"},{"APP":"secret-storage-backend"}]}
+APPS=name=matrix::{"include":[{"APP":"gateway"},{"APP":"k8s-engine"},{"APP":"hub-js"},{"APP":"argo-runner"},{"APP":"helm-runner"},{"APP":"populator"},{"APP":"terraform-runner"},{"APP":"argo-actions"},{"APP":"gitlab-api-runner"},{"APP":"secret-storage-backend"},{"APP":"helm-storage-backend"}]}
 TESTS=name=matrix::{"include":[{"TEST":"e2e"}]}
 INFRAS=name=matrix::{"include":[{"INFRA":"json-go-gen"},{"INFRA":"graphql-schema-linter"},{"INFRA":"jinja2"},{"INFRA":"merger"}]}
 EOT

--- a/internal/cli/credstore/keychain_darwin.go
+++ b/internal/cli/credstore/keychain_darwin.go
@@ -12,6 +12,7 @@ import (
 // Keychain is a simple adapter to Zalando go-keyring.
 type Keychain struct{}
 
+// Get returns an Item matching the key.
 func (k Keychain) Get(key string) (keyring.Item, error) {
 	data, err := zkeyring.Get(serviceName, key)
 	if err != nil {
@@ -23,6 +24,7 @@ func (k Keychain) Get(key string) (keyring.Item, error) {
 	}, nil
 }
 
+// Set stores an Item on the keyring.
 func (k Keychain) Set(item keyring.Item) error {
 	err := zkeyring.Set(serviceName, item.Key, string(item.Data))
 	if err != nil {
@@ -31,6 +33,7 @@ func (k Keychain) Set(item keyring.Item) error {
 	return nil
 }
 
+// Remove removes the item with matching key.
 func (k Keychain) Remove(key string) error {
 	err := zkeyring.Delete(serviceName, key)
 	if err != nil {

--- a/internal/healthz/healthz_server.go
+++ b/internal/healthz/healthz_server.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewHTTPServer returns new HTTP server with preconfigured `/healthz` endpoint.
-func NewHTTPServer(log *zap.Logger, healthzAddr, appName string) httputil.StartableServer {
+func NewHTTPServer(namedLogger *zap.Logger, healthzAddr, appName string) httputil.StartableServer {
 	router := mux.NewRouter()
 	router.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		if _, err := fmt.Fprintf(w, "%s - OK", appName); err != nil {
@@ -20,7 +20,7 @@ func NewHTTPServer(log *zap.Logger, healthzAddr, appName string) httputil.Starta
 	})
 
 	return httputil.NewStartableServer(
-		log.Named(appName).With(zap.String("server", "healthz")),
+		namedLogger.With(zap.String("server", "healthz")),
 		healthzAddr,
 		router,
 	)

--- a/internal/helm-storage-backend/release.go
+++ b/internal/helm-storage-backend/release.go
@@ -1,6 +1,8 @@
 package helmstoragebackend
 
 import (
+	"context"
+
 	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
 	"go.uber.org/zap"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -20,4 +22,12 @@ func NewReleaseHandler(log *zap.Logger, helmCfgFlags *genericclioptions.ConfigFl
 	return &ReleaseHandler{
 		log: log,
 	}
+}
+
+// GetValue returns a value for a given TypeInstance.
+func (h *ReleaseHandler) GetValue(_ context.Context, _ *pb.GetValueRequest) (*pb.GetValueResponse, error) {
+	h.log.Info("Getting value")
+	return &pb.GetValueResponse{
+		Value: []byte(`{"handler": "release"}`),
+	}, nil
 }

--- a/internal/helm-storage-backend/release.go
+++ b/internal/helm-storage-backend/release.go
@@ -1,0 +1,23 @@
+package helmstoragebackend
+
+import (
+	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
+	"go.uber.org/zap"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var _ pb.StorageBackendServer = &ReleaseHandler{}
+
+// ReleaseHandler handles incoming requests to the Helm release storage backend gRPC server.
+type ReleaseHandler struct {
+	pb.UnimplementedStorageBackendServer
+
+	log *zap.Logger
+}
+
+// NewReleaseHandler returns new ReleaseHandler.
+func NewReleaseHandler(log *zap.Logger, helmCfgFlags *genericclioptions.ConfigFlags) *ReleaseHandler {
+	return &ReleaseHandler{
+		log: log,
+	}
+}

--- a/internal/helm-storage-backend/template.go
+++ b/internal/helm-storage-backend/template.go
@@ -1,0 +1,23 @@
+package helmstoragebackend
+
+import (
+	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
+	"go.uber.org/zap"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var _ pb.StorageBackendServer = &TemplateHandler{}
+
+// TemplateHandler handles incoming requests to the Helm template storage backend gRPC server.
+type TemplateHandler struct {
+	pb.UnimplementedStorageBackendServer
+
+	log *zap.Logger
+}
+
+// NewTemplateHandler returns new TemplateHandler.
+func NewTemplateHandler(log *zap.Logger, helmCfgFlags *genericclioptions.ConfigFlags) *TemplateHandler {
+	return &TemplateHandler{
+		log: log,
+	}
+}

--- a/internal/helm-storage-backend/template.go
+++ b/internal/helm-storage-backend/template.go
@@ -1,6 +1,8 @@
 package helmstoragebackend
 
 import (
+	"context"
+
 	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
 	"go.uber.org/zap"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -20,4 +22,12 @@ func NewTemplateHandler(log *zap.Logger, helmCfgFlags *genericclioptions.ConfigF
 	return &TemplateHandler{
 		log: log,
 	}
+}
+
+// GetValue returns a value for a given TypeInstance.
+func (h *TemplateHandler) GetValue(_ context.Context, _ *pb.GetValueRequest) (*pb.GetValueResponse, error) {
+	h.log.Info("Getting value")
+	return &pb.GetValueResponse{
+		Value: []byte(`{"handler": "template"}`),
+	}, nil
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Bootstrap Helm storage backend Go app for both Release and Templating gRPC servers

**Additional:**
- Add missing Go comments for macOS-only source code (to avoid lint errors on macOS)
- Fix duplicated logger name on healthz endpoints
- Make new Hadolint not failing on syntax comment in Dockerfile

## Testing

No testing required, as the services are not yet implemented. But you can run them anyway if you want - just follow the README.md inside `cmd/helm-storage-backend/` directory 🙂 

You can also run some gRPC calls from Insomnia, but unfortunately the response won't be that useful - that's why I added logging to the sample `GetValue` method.
![Screenshot 2022-03-16 at 15 56 58](https://user-images.githubusercontent.com/7155799/158619638-7aae9ca5-7699-40e7-9b4f-fb1792595005.png)

## Related issue(s)

#670 