### PR TITLE
Add Helm chart for Helm backend storage

### DIFF
--- a/deploy/kubernetes/charts/helm-storage-backend/.helmignore
+++ b/deploy/kubernetes/charts/helm-storage-backend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/kubernetes/charts/helm-storage-backend/Chart.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: helm-storage-backend
+description: A Helm chart for Helm Storage Backend for Capact Local Hub
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.6.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helm-storage-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm-storage-backend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm-storage-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm-storage-backend.labels" -}}
+helm.sh/chart: {{ include "helm-storage-backend.chart" . }}
+{{ include "helm-storage-backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm-storage-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm-storage-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm-storage-backend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helm-storage-backend.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/_helpers.tpl
@@ -49,14 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "helm-storage-backend.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "helm-storage-backend.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "helm-storage-backend.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm-storage-backend.fullname" . }}
+  labels:
+    {{- include "helm-storage-backend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "helm-storage-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helm-storage-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helm-storage-backend.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        {{- if .Values.helmReleaseBackend.enabled }}
+        - name: release
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: release-grpc
+              containerPort: 50051
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: APP_GRPC_ADDR
+              value: ":50051"
+            - name: APP_HEALTHZ_ADDR
+              value: ":8082"
+            - name: APP_LOGGER_DEV_MODE
+              value: "true"
+            - name: APP_MODE
+              value: "release"
+        {{- end }}
+        {{- if .Values.helmTemplateBackend.enabled }}
+        - name: template
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.image.name }}:{{ .Values.global.containerRegistry.overrideTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: template-grpc
+              containerPort: 50052
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8083
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8083
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: APP_GRPC_ADDR
+              value: ":50052"
+            - name: APP_HEALTHZ_ADDR
+              value: ":8083"
+            - name: APP_LOGGER_DEV_MODE
+              value: "true"
+            - name: APP_MODE
+              value: "template"
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "helm-storage-backend.serviceAccountName" . }}
+      serviceAccountName: {{ include "helm-storage-backend.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/hpa.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "hub.fullname" . }}
+  name: {{ include "helm-storage-backend.fullname" . }}
   labels:
-    {{- include "hub.labels" . | nindent 4 }}
+    {{- include "helm-storage-backend.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "hub.fullname" . }}
+    name: {{ include "helm-storage-backend.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/hpa.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hub.fullname" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hub.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/role.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm-storage-backend.fullname" . }}
+  labels:
+  {{- include "helm-storage-backend.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - "get"
+      - "list"

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/rolebinding.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm-storage-backend.fullname" . }}
+  labels:
+  {{- include "helm-storage-backend.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "helm-storage-backend.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "helm-storage-backend.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/service.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/service.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.helmReleaseBackend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm-storage-backend.fullname" . }}-release
+  labels:
+    {{- include "helm-storage-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.helmReleaseBackend.service.type }}
+  ports:
+    - port: {{ .Values.helmReleaseBackend.service.port }}
+      targetPort: release-grpc
+      protocol: TCP
+      name: release-grpc
+  selector:
+    {{- include "helm-storage-backend.selectorLabels" . | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.helmTemplateBackend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm-storage-backend.fullname" . }}-template
+  labels:
+    {{- include "helm-storage-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.helmTemplateBackend.service.type }}
+  ports:
+    - port: {{ .Values.helmTemplateBackend.service.port }}
+      targetPort: template-grpc
+      protocol: TCP
+      name: template-grpc
+  selector:
+    {{- include "helm-storage-backend.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/serviceaccount.yaml
@@ -1,12 +1,6 @@
-{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "helm-storage-backend.serviceAccountName" . }}
+  name: {{ include "helm-storage-backend.fullname" . }}
   labels:
     {{- include "helm-storage-backend.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helm-storage-backend.serviceAccountName" . }}
+  labels:
+    {{- include "helm-storage-backend.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/helm-storage-backend/values.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/values.yaml
@@ -25,15 +25,6 @@ replicaCount: 1
 
 imagePullSecrets: []
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
-
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/deploy/kubernetes/charts/helm-storage-backend/values.yaml
+++ b/deploy/kubernetes/charts/helm-storage-backend/values.yaml
@@ -1,0 +1,69 @@
+# Default values for helm-storage-backend.
+global:
+  containerRegistry:
+    path: ghcr.io/capactio
+    # Overrides the image tag for all Capact components and extensions. Default is the appVersion.
+    overrideTag: "latest"
+
+image:
+  name: helm-storage-backend
+  pullPolicy: IfNotPresent
+
+helmReleaseBackend:
+  enabled: true
+  service:
+    port: 50051
+    type: ClusterIP
+
+helmTemplateBackend:
+  enabled: true
+  service:
+    port: 50052
+    type: ClusterIP
+
+replicaCount: 1
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 32Mi
+  requests:
+    cpu: 30m
+    memory: 16Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/hack/release-charts.sh
+++ b/hack/release-charts.sh
@@ -27,6 +27,7 @@ readonly charts=(
   "neo4j"
   "capact"
   "secret-storage-backend"
+  "helm-storage-backend"
 )
 
 # shellcheck source=./hack/lib/utilities.sh


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add Helm chart for Helm backend storage

## Testing

```bash
# Install chart (ofc you can use different name of the helm release)
helm install capact ./deploy/kubernetes/charts/helm-storage-backend --set=global.containerRegistry.path="ghcr.io/capactio/pr" --set=global.containerRegistry.overrideTag="PR-669" --wait

# Get logs
k logs capact-helm-storage-backend-{random} release -f
k logs capact-helm-storage-backend-{random} template -f

# Port forward
kubectl port-forward svc/capact-helm-storage-backend-release 3000:50051
# in second terminal:
kubectl port-forward svc/capact-helm-storage-backend-template 3001:50052
```

Now, you can do some gRPC calls via Insomnia to `localhost:3000` and `localhost:3001` and observe logs to see that proper backends are called.

![Screenshot 2022-03-16 at 16 28 42](https://user-images.githubusercontent.com/7155799/158626915-da5c6ca6-e0e0-4678-8a67-ac10bc58a92e.png)

## Related issue(s)

#670 
