### PR TITLE
Add "safe-to-evict" autoscaler annotations for components with `emptyDir` mounted

### DIFF
--- a/deploy/kubernetes/charts/monitoring/values.yaml
+++ b/deploy/kubernetes/charts/monitoring/values.yaml
@@ -9,6 +9,9 @@ kube-prometheus-stack:
     ## Settings affecting prometheusSpec
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     prometheusSpec:
+      podMetadata:
+        annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       serviceMonitorSelector:
         matchLabels:
           capact.io/scrape-metrics: "true"
@@ -69,6 +72,9 @@ kube-prometheus-stack:
 
   alertmanager:
     alertmanagerSpec:
+      podMetadata:
+        annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       resources:
         requests:
           cpu: 5m

--- a/deploy/kubernetes/charts/neo4j/values.yaml
+++ b/deploy/kubernetes/charts/neo4j/values.yaml
@@ -23,3 +23,5 @@ neo4j:
     timeoutSeconds: 3
     periodSeconds: 10
 
+  podAnnotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add "safe-to-evict" autoscaler annotations for components with `emptyDir` mounted

Prometheus, Alertmanager and Neo4j have `emptyDir` mounted which prevent them to scale down clusters that use Cluster Autoscaler, e.g. our long-running one on GCP:

![Screenshot 2022-03-17 at 10 48 28](https://user-images.githubusercontent.com/7155799/158782781-8a325438-fad3-4b45-95c4-f80e608914ed.png)

Since GKE 1.22 we wouldn't need such annotations on the pods:
https://cloud.google.com/kubernetes-engine/docs/release-notes#October_27_2021

## Related links
- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
- https://github.com/kubernetes/autoscaler/issues/966

