### PR TITLE
Implement Helm release storage backend

### DIFF
--- a/cmd/helm-storage-backend/main.go
+++ b/cmd/helm-storage-backend/main.go
@@ -74,7 +74,8 @@ func main() {
 	var handler storage_backend.StorageBackendServer
 	switch cfg.Mode {
 	case HelmReleaseMode:
-		handler = helm_storage_backend.NewReleaseHandler(logger, helmCfgFlags)
+		handler, err = helm_storage_backend.NewReleaseHandler(logger, helmCfgFlags)
+		exitOnError(err, "while creating Helm Release backend storage")
 	case HelmTemplateMode:
 		handler = helm_storage_backend.NewTemplateHandler(logger, helmCfgFlags)
 	default:

--- a/internal/helm-storage-backend/common.go
+++ b/internal/helm-storage-backend/common.go
@@ -1,3 +1,0 @@
-package helmstoragebackend
-
-const defaultHelmDriver = "secrets"

--- a/internal/helm-storage-backend/common.go
+++ b/internal/helm-storage-backend/common.go
@@ -1,0 +1,3 @@
+package helmstoragebackend
+
+const defaultHelmDriver = "secrets"

--- a/internal/helm-storage-backend/helm.go
+++ b/internal/helm-storage-backend/helm.go
@@ -10,6 +10,7 @@ import (
 
 type actionConfigurationProducerFn func(flags *genericclioptions.ConfigFlags, driver string, ns string) (*action.Configuration, error)
 
+// ActionConfigurationProducer returns Configuration with a given input settings.
 func ActionConfigurationProducer(flags *genericclioptions.ConfigFlags, driver, ns string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	helmCfg := &genericclioptions.ConfigFlags{

--- a/internal/helm-storage-backend/helm.go
+++ b/internal/helm-storage-backend/helm.go
@@ -8,8 +8,9 @@ import (
 	"capact.io/capact/internal/ptr"
 )
 
-// NewHelmGet create a new Helm release get client.
-func NewHelmGet(flags *genericclioptions.ConfigFlags, driver, ns string) (*action.Get, error) {
+type actionConfigurationProducerFn func(flags *genericclioptions.ConfigFlags, driver string, ns string) (*action.Configuration, error)
+
+func ActionConfigurationProducer(flags *genericclioptions.ConfigFlags, driver, ns string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	helmCfg := &genericclioptions.ConfigFlags{
 		APIServer:   flags.APIServer,
@@ -28,5 +29,5 @@ func NewHelmGet(flags *genericclioptions.ConfigFlags, driver, ns string) (*actio
 		return nil, errors.Wrap(err, "while initializing Helm configuration")
 	}
 
-	return action.NewGet(actionConfig), nil
+	return actionConfig, nil
 }

--- a/internal/helm-storage-backend/helm.go
+++ b/internal/helm-storage-backend/helm.go
@@ -8,6 +8,8 @@ import (
 	"capact.io/capact/internal/ptr"
 )
 
+const defaultHelmDriver = "secrets"
+
 type actionConfigurationProducerFn func(flags *genericclioptions.ConfigFlags, driver string, ns string) (*action.Configuration, error)
 
 // ActionConfigurationProducer returns Configuration with a given input settings.

--- a/internal/helm-storage-backend/helm.go
+++ b/internal/helm-storage-backend/helm.go
@@ -1,0 +1,32 @@
+package helmstoragebackend
+
+import (
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/action"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"capact.io/capact/internal/ptr"
+)
+
+// NewHelmGet create a new Helm release get client.
+func NewHelmGet(flags *genericclioptions.ConfigFlags, driver, ns string) (*action.Get, error) {
+	actionConfig := new(action.Configuration)
+	helmCfg := &genericclioptions.ConfigFlags{
+		APIServer:   flags.APIServer,
+		Insecure:    flags.Insecure,
+		CAFile:      flags.CAFile,
+		BearerToken: flags.BearerToken,
+		Namespace:   ptr.String(ns),
+	}
+
+	debugLog := func(format string, v ...interface{}) {
+		// noop
+	}
+
+	err := actionConfig.Init(helmCfg, ns, driver, debugLog)
+	if err != nil {
+		return nil, errors.Wrap(err, "while initializing Helm configuration")
+	}
+
+	return action.NewGet(actionConfig), nil
+}

--- a/internal/helm-storage-backend/release_test.go
+++ b/internal/helm-storage-backend/release_test.go
@@ -63,7 +63,7 @@ func TestRelease_GetValue_Success(t *testing.T) {
 			// given
 			const (
 				releaseName      = "test-get-release"
-				releaseNamespace = "test-namespace"
+				releaseNamespace = "test-get-namespace"
 				chartLocation    = "http://example.com/charts"
 			)
 			expHelmRelease := fixHelmRelease(releaseName, releaseNamespace)
@@ -192,7 +192,7 @@ func TestRelease_OnCreate_Success(t *testing.T) {
 	// given
 	const (
 		releaseName      = "test-create-release"
-		releaseNamespace = "test-namespace"
+		releaseNamespace = "test-create-namespace"
 		releaseDriver    = "configmap"
 		chartLocation    = "http://example.com/charts"
 	)
@@ -295,7 +295,7 @@ func TestRelease_OnUpdate_Success(t *testing.T) {
 	// given
 	const (
 		releaseName      = "test-update-release"
-		releaseNamespace = "test-namespace"
+		releaseNamespace = "test-update-namespace"
 		releaseDriver    = "configmap"
 		chartLocation    = "http://example.com/charts"
 	)

--- a/internal/helm-storage-backend/release_test.go
+++ b/internal/helm-storage-backend/release_test.go
@@ -1,0 +1,235 @@
+package helmstoragebackend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"capact.io/capact/internal/logger"
+	"capact.io/capact/internal/ptr"
+	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
+)
+
+func TestRelease_GetValue_Success(t *testing.T) {
+	tests := []struct {
+		name string
+
+		givenDriver          *string
+		givenTypeInstanceID  *string
+		givenResourceVersion int
+		expectedDriver       string
+	}{
+		{
+			name:                "should use default driver and return the latest release",
+			givenTypeInstanceID: ptr.String("123"),
+			givenDriver:         nil,
+			expectedDriver:      "secrets",
+		},
+		{
+			name:                "should use configmap driver and return the latest release",
+			givenTypeInstanceID: ptr.String("123"),
+			givenDriver:         ptr.String("configmaps"),
+			expectedDriver:      "configmaps",
+		},
+		{
+			name:                 "should ignore resourceVersion and return the latest release",
+			givenTypeInstanceID:  ptr.String("123"),
+			givenResourceVersion: 42, // should be ignored
+			expectedDriver:       "secrets",
+		},
+		{
+			name:           "should return the latest release even if TypeInstance's id and revision are not specified",
+			expectedDriver: "secrets",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// given
+			const (
+				releaseName      = "test-release"
+				releaseNamespace = "test-namespace"
+				chartLocation    = "http://example.com/charts"
+			)
+			expHelmRelease := fixHelmRelease(releaseName, releaseNamespace)
+			expFlags := &genericclioptions.ConfigFlags{ClusterName: ptr.String("testing")}
+			mockConfigurationProducer := mockConfigurationProducer(t, expHelmRelease, expFlags, test.expectedDriver)
+
+			givenReq := &pb.GetValueRequest{
+				TypeInstanceId: ptr.StringPtrToString(test.givenTypeInstanceID),
+				Context: mustMarshal(t, ReleaseContext{
+					Name:          releaseName,
+					Namespace:     releaseNamespace,
+					ChartLocation: chartLocation,
+					Driver:        test.givenDriver,
+				}),
+			}
+
+			expResponse := &pb.GetValueResponse{
+				Value: mustMarshal(t, ReleaseDetails{
+					Name:      expHelmRelease.Name,
+					Namespace: expHelmRelease.Namespace,
+					Chart: ChartDetails{
+						Name:    expHelmRelease.Chart.Metadata.Name,
+						Version: expHelmRelease.Chart.Metadata.Version,
+						Repo:    chartLocation,
+					},
+				}),
+			}
+
+			svc, err := NewReleaseHandler(logger.Noop(), expFlags)
+			svc.actionConfigurationProducer = mockConfigurationProducer
+			require.NoError(t, err)
+
+			// when
+			outVal, gotErr := svc.GetValue(context.Background(), givenReq)
+
+			// then
+			assert.NoError(t, gotErr)
+			assert.Equal(t, outVal, expResponse)
+		})
+	}
+}
+
+func TestRelease_GetValue_Failures(t *testing.T) {
+	// globally given
+	const (
+		releaseName      = "test-release"
+		releaseNamespace = "test-namespace"
+	)
+	tests := []struct {
+		name string
+
+		request       *pb.GetValueRequest
+		internalError error
+
+		expErrMsg string
+	}{
+		{
+			name: "should return not found error if release name is wrong",
+			request: &pb.GetValueRequest{
+				TypeInstanceId: "123",
+				Context: mustMarshal(t, ReleaseContext{
+					Name:          "other-release",
+					Namespace:     releaseNamespace,
+					ChartLocation: "http://example.com/charts",
+				}),
+			},
+			expErrMsg: "rpc error: code = NotFound desc = Helm release 'test-namespace/other-release' for TypeInstance '123' was not found",
+		},
+		{
+			name: "should return not found error if release namespace is wrong",
+			request: &pb.GetValueRequest{
+				TypeInstanceId: "123",
+				Context: mustMarshal(t, ReleaseContext{
+					Name:          releaseName,
+					Namespace:     "other-ns",
+					ChartLocation: "http://example.com/charts",
+				}),
+			},
+			expErrMsg: "rpc error: code = NotFound desc = Helm release 'other-ns/test-release' for TypeInstance '123' was not found",
+		},
+		{
+			name: "should return internal error",
+			request: &pb.GetValueRequest{
+				TypeInstanceId: "123",
+				Context: mustMarshal(t, ReleaseContext{
+					Name:          releaseName,
+					Namespace:     "other-ns",
+					ChartLocation: "http://example.com/charts",
+				}),
+			},
+			internalError: errors.New("internal error"),
+			expErrMsg:     "rpc error: code = Internal desc = while creating Helm get release client: internal error",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// given
+			expHelmRelease := fixHelmRelease(releaseName, releaseNamespace)
+			expFlags := &genericclioptions.ConfigFlags{ClusterName: ptr.String("testing")}
+
+			mockConfigurationProducer := func(inputFlags *genericclioptions.ConfigFlags, inputDriver, inputNs string) (*action.Configuration, error) {
+				if test.internalError != nil {
+					return nil, test.internalError
+				}
+				producer := mockConfigurationProducer(t, expHelmRelease, expFlags, "secrets")
+				return producer(inputFlags, inputDriver, inputNs)
+			}
+
+			svc, err := NewReleaseHandler(logger.Noop(), expFlags)
+			svc.actionConfigurationProducer = mockConfigurationProducer
+			require.NoError(t, err)
+
+			// when
+			outVal, gotErr := svc.GetValue(context.Background(), test.request)
+
+			// then
+			assert.EqualError(t, gotErr, test.expErrMsg)
+			assert.Nil(t, outVal)
+		})
+	}
+}
+
+func mockConfigurationProducer(t *testing.T, expHelmRelease *release.Release, expFlags *genericclioptions.ConfigFlags, expDriver string) actionConfigurationProducerFn {
+	t.Helper()
+	inMemoryDriver := driver.NewMemory()
+	err := inMemoryDriver.Create("1", expHelmRelease)
+	require.NoError(t, err)
+
+	return func(inputFlags *genericclioptions.ConfigFlags, inputDriver, inputNs string) (*action.Configuration, error) {
+		assert.Equal(t, expFlags, inputFlags)
+		assert.Equal(t, expDriver, inputDriver)
+
+		inMemoryDriver.SetNamespace(inputNs)
+		return &action.Configuration{
+			Releases:   storage.Init(inMemoryDriver),
+			KubeClient: &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
+		}, nil
+	}
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func fixHelmRelease(name, ns string) *release.Release {
+	now := time.Now()
+	return &release.Release{
+		Name:      name,
+		Namespace: ns,
+		Info: &release.Info{
+			FirstDeployed: now,
+			LastDeployed:  now,
+			Description:   "Named Release Stub",
+		},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{
+				Name:    fmt.Sprintf("%s-chart", name),
+				Version: "0.1.0",
+			},
+		},
+	}
+}

--- a/internal/helm-storage-backend/showcase_test.go
+++ b/internal/helm-storage-backend/showcase_test.go
@@ -1,0 +1,96 @@
+package helmstoragebackend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	pb "capact.io/capact/pkg/hub/api/grpc/storage_backend"
+)
+
+// To run this test, execute:
+// GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./internal/helm-storage-backend/... -run "^TestShowcase$" -v -count 1
+func TestShowcase(t *testing.T) {
+	srvAddr := os.Getenv("GRPC_SECRET_STORAGE_BACKEND_ADDR")
+	if srvAddr == "" {
+		t.Skip()
+	}
+
+	conn, err := grpc.Dial(srvAddr, grpc.WithInsecure())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := pb.NewStorageBackendClient(conn)
+
+	// ===== GET =====
+	out, err := client.GetValue(ctx, &pb.GetValueRequest{
+		TypeInstanceId: "42",
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "example-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+
+	require.NoError(t, err)
+
+	details := &ReleaseDetails{}
+	require.NoError(t, json.Unmarshal(out.Value, details))
+
+	fmt.Printf("GetValue for valid release")
+	fmt.Printf("\t\t Name: %s\n", details.Name)
+	fmt.Printf("\t\t Namespace: %s\n", details.Namespace)
+	fmt.Printf("\t\t Chart.Name: %s\n", details.Chart.Name)
+	fmt.Printf("\t\t Chart.Version: %s\n", details.Chart.Version)
+	fmt.Printf("\t\t Chart.Repo: %s\n", details.Chart.Repo)
+
+	_, err = client.GetValue(ctx, &pb.GetValueRequest{
+		TypeInstanceId: "42",
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "fake-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+
+	fmt.Printf("GetValue err if release doesn't exist: %v\n", err)
+
+	// ===== UPDATE =====
+	_, err = client.OnUpdate(ctx, &pb.OnUpdateRequest{
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "example-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+	fmt.Printf("OnUpdate err if release exists: %v\n", err)
+
+	_, err = client.OnUpdate(ctx, &pb.OnUpdateRequest{
+		TypeInstanceId: "42",
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "fake-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+	fmt.Printf("OnUpdate err if release doesn't exist: %v\n", err)
+
+	// ===== CREATE =====
+	_, err = client.OnCreate(ctx, &pb.OnCreateRequest{
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "example-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+	fmt.Printf("OnCreate err if release exists: %v\n", err)
+
+	_, err = client.OnCreate(ctx, &pb.OnCreateRequest{
+		TypeInstanceId: "42",
+		Context: mustMarshal(t, ReleaseContext{
+			Name:          "fake-release",
+			Namespace:     "default",
+			ChartLocation: "https://charts.bitnami.com/bitnami",
+		})})
+	fmt.Printf("OnCreate err if release doesn't exist: %v\n", err)
+}

--- a/pkg/runner/cloudsql/create.go
+++ b/pkg/runner/cloudsql/create.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"capact.io/capact/pkg/runner"
@@ -174,7 +175,7 @@ func (a *createAction) createAdditionalOutputFile(path string, args *OutputArgs,
 		return errors.Wrap(err, "failed to load template")
 	}
 
-	fd, err := os.Create(path)
+	fd, err := os.Create(filepath.Clean(path))
 	if err != nil {
 		return errors.Wrap(err, "cannot open output file to write")
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Implement Helm release storage backend

Related PR: https://github.com/capactio/hub-manifests/pull/62. In backend, we have an assumption that the data is validated by Local Hub, so we receive a valid context with all required fields.

## Testing

**Setup**
1. Create k8s cluster. For example, run:
    ```bash
    k3d cluster create test
    ```
2. Install PostgreSQL Helm chart:
    ```bash
    RUNNER_CONTEXT_PATH=cmd/helm-runner/example-input/context.yaml \
     RUNNER_ARGS_PATH=cmd/helm-runner/example-input/install-args.yaml \
     RUNNER_LOGGER_DEV_MODE=true \
     RUNNER_COMMAND="install" \
     go run cmd/helm-runner/main.go
    ```
**Testing**
1. Run server:
    ```bash
    APP_LOGGER_DEV_MODE=true APP_MODE="release" go run ./cmd/helm-storage-backend/main.go
    ```
4. Run showcase test:
    ```bash
    GRPC_SECRET_STORAGE_BACKEND_ADDR=":50051" go test ./internal/helm-storage-backend/... -run "^TestShowcase$" -v -count 1
    ```

There is also unit test coverage. 
## Related issue(s)

Fix: https://github.com/capactio/capact/issues/671
