### PR TITLE
Remove no longer needed Hadolint ignore for syntax comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# hadolint ignore=DL3061
 # syntax = docker/dockerfile:1-experimental
 
 FROM golang:1.16.3-alpine as builder


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Remove no longer needed Hadolint ignore for syntax comment

[Hadolint 2.9.2](https://github.com/hadolint/hadolint/releases/tag/v2.9.2) has been just released ([see DockerHub](https://hub.docker.com/r/hadolint/hadolint/tags)) with a fix for https://github.com/hadolint/hadolint/issues/795, which required us to ignore syntax comment in our Dockerfile.

## Related issue(s)

https://github.com/hadolint/hadolint/issues/795
