### PR TITLE
Fix fetching context from neo4j db

### DIFF
--- a/hub-js/graphql/local/schema.graphql
+++ b/hub-js/graphql/local/schema.graphql
@@ -123,7 +123,7 @@ type TypeInstanceResourceVersionSpec {
                 abstract: backendRef.abstract,
                 fetchInput: {
                    typeInstance: { resourceVersion: rev.resourceVersion, id: ti.id },
-                   backend: { context: backendCtx.context, id: backendRef.id}
+                   backend: { context: apoc.convert.fromJsonMap(backendCtx.context), id: backendRef.id}
                 }
               } AS value
               RETURN value

--- a/hub-js/src/local/resolver/mutation/delete-type-instance.ts
+++ b/hub-js/src/local/resolver/mutation/delete-type-instance.ts
@@ -58,7 +58,7 @@ export async function deleteTypeInstance(
 
             // NOTE: Need to be preserved with 'WITH' statement, otherwise we won't be able
             // to access node's properties after 'DETACH DELETE' statement.
-            WITH *, {id: ti.id, backend: { id: backendRef.id, context: specBackend.context, abstract: backendRef.abstract}} as out
+            WITH *, {id: ti.id, backend: { id: backendRef.id, context: apoc.convert.fromJsonMap(specBackend.context), abstract: backendRef.abstract}} as out
             DETACH DELETE ti, metadata, spec, tirs, specBackend
 
             WITH *

--- a/hub-js/src/local/resolver/mutation/lock-type-instances.ts
+++ b/hub-js/src/local/resolver/mutation/lock-type-instances.ts
@@ -180,7 +180,7 @@ export async function getTypeInstanceStoredExternally(
 
            WITH {
                 typeInstanceId: ti.id,
-                backend: { context: backendCtx.context, id: backendRef.id, abstract: backendRef.abstract}
+                backend: { context: apoc.convert.fromJsonMap(backendCtx.context), id: backendRef.id, abstract: backendRef.abstract}
               } AS value
            RETURN value
         `,


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix fetching context from neo4j db

Context is save in db with:
```
apoc.convert.fromJsonMap(this.context)
```
so we always need to fetch it as:
```
context: apoc.convert.fromJsonMap(specBackend.context)
```

but in a few places we forgot about this mapping.

This will be done in https://github.com/capactio/capact/pull/657
