### PR TITLE
Improve readability of context schema

### DIFF
--- a/hub-js/src/local/storage/backend-schema.ts
+++ b/hub-js/src/local/storage/backend-schema.ts
@@ -3,7 +3,7 @@ import { JSONSchemaType } from "ajv";
 export interface StorageTypeInstanceSpec {
   url: string;
   acceptValue: boolean;
-  contextSchema: string | null;
+  contextSchema: object | null;
 }
 
 export const StorageTypeInstanceSpecSchema: JSONSchemaType<StorageTypeInstanceSpec> =
@@ -18,7 +18,7 @@ export const StorageTypeInstanceSpecSchema: JSONSchemaType<StorageTypeInstanceSp
         format: "uri",
       },
       acceptValue: { type: "boolean" },
-      contextSchema: { type: "string", nullable: true },
+      contextSchema: { type: "object", nullable: true },
     },
     required: ["url", "acceptValue"],
     additionalProperties: true,

--- a/hub-js/src/local/storage/service.ts
+++ b/hub-js/src/local/storage/service.ts
@@ -422,7 +422,7 @@ export default class DelegatedStorageService {
     }
 
     throw new Error(
-      this.ajv.errorsText(validate.errors, { dataVar: "spec.value" })
+      this.ajv.errorsText(validate.errors, { dataVar: "spec/value" })
     );
   }
 

--- a/hub-js/src/local/storage/service.ts
+++ b/hub-js/src/local/storage/service.ts
@@ -379,22 +379,16 @@ export default class DelegatedStorageService {
         url: spec.url,
       });
 
-      let contextSchema;
-      if (spec.contextSchema) {
-        const out = DelegatedStorageService.parseToObject(spec.contextSchema);
-        if (out.error) {
-          throw Error(
-            `failed to process the TypeInstance's backend "${id}": invalid spec.context: ${out.error.message}`
-          );
-        }
-        contextSchema = out.parsed as JSONSchemaType<unknown>;
-      }
       const channel = createChannel(spec.url);
       const client: StorageClient = createClient(
         StorageBackendDefinition,
         channel
       );
 
+      let contextSchema;
+      if (spec.contextSchema) {
+        contextSchema = spec.contextSchema as JSONSchemaType<unknown>;
+      }
       const storageSpec = {
         backendId: id,
         contextSchema,

--- a/internal/cli/testing/storage_backend.go
+++ b/internal/cli/testing/storage_backend.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"encoding/json"
 
 	"capact.io/capact/internal/logger"
 	"capact.io/capact/internal/ptr"
@@ -43,9 +44,9 @@ const testStorageTypeContextSchema = `
 `
 
 type typeInstanceValue struct {
-	URL           string `json:"url"`
-	AcceptValue   bool   `json:"acceptValue"`
-	ContextSchema string `json:"contextSchema"`
+	URL           string      `json:"url"`
+	AcceptValue   bool        `json:"acceptValue"`
+	ContextSchema interface{} `json:"contextSchema"`
 }
 
 // StorageBackendRegister provides functionality to produce and upload test storage backend TypeInstance.
@@ -79,6 +80,11 @@ func NewStorageBackendRegister() (*StorageBackendRegister, error) {
 
 // RegisterTypeInstances produces and uploads TypeInstances which describe Test storage backend.
 func (i *StorageBackendRegister) RegisterTypeInstances(ctx context.Context) error {
+	var contextSchema interface{}
+	err := json.Unmarshal([]byte(testStorageTypeContextSchema), &contextSchema)
+	if err != nil {
+		return errors.Wrap(err, "while unmarshaling contextSchema")
+	}
 	in := &hublocalgraphql.CreateTypeInstanceInput{
 		CreatedBy: ptr.String("populator/test-storage-backend-registration"),
 		TypeRef: &hublocalgraphql.TypeInstanceTypeReferenceInput{
@@ -88,7 +94,7 @@ func (i *StorageBackendRegister) RegisterTypeInstances(ctx context.Context) erro
 		Value: typeInstanceValue{
 			URL:           i.cfg.TestStorageBackendURL,
 			AcceptValue:   true,
-			ContextSchema: testStorageTypeContextSchema,
+			ContextSchema: contextSchema,
 		},
 	}
 

--- a/test/local-hub/external_storage_backend_test.go
+++ b/test/local-hub/external_storage_backend_test.go
@@ -415,7 +415,7 @@ func TestExternalStorage(t *testing.T) {
 func registerExternalDotenvStorage(ctx context.Context, t *testing.T, cli *local.Client, srvAddr string) (gqllocalapi.CreateTypeInstanceOutput, func(t *testing.T)) {
 	t.Helper()
 
-	ti, err := cli.CreateTypeInstances(ctx, fixExternalDotenvStorage(srvAddr))
+	ti, err := cli.CreateTypeInstances(ctx, fixExternalDotenvStorage(t, srvAddr))
 	require.NoError(t, err)
 	require.Len(t, ti, 1)
 	dotenvHubStorage := ti[0]
@@ -426,7 +426,14 @@ func registerExternalDotenvStorage(ctx context.Context, t *testing.T, cli *local
 	}
 }
 
-func fixExternalDotenvStorage(addr string) *gqllocalapi.CreateTypeInstancesInput {
+func unmarshalContextSchema(t *testing.T, schema string) interface{} {
+	var contextSchema interface{}
+	err := json.Unmarshal([]byte(schema), &contextSchema)
+	require.NoError(t, err)
+	return contextSchema
+}
+
+func fixExternalDotenvStorage(t *testing.T, addr string) *gqllocalapi.CreateTypeInstancesInput {
 	return &gqllocalapi.CreateTypeInstancesInput{
 		TypeInstances: []*gqllocalapi.CreateTypeInstanceInput{
 			{
@@ -438,7 +445,7 @@ func fixExternalDotenvStorage(addr string) *gqllocalapi.CreateTypeInstancesInput
 				Value: storageSpec{
 					URL:         ptr.String(addr),
 					AcceptValue: ptr.Bool(true),
-					ContextSchema: ptr.String(heredoc.Doc(`
+					ContextSchema: unmarshalContextSchema(t, heredoc.Doc(`
 				      {
 				      	"$id": "#/properties/contextSchema",
 				      	"type": "object",

--- a/test/local-hub/input_validation_test.go
+++ b/test/local-hub/input_validation_test.go
@@ -22,9 +22,9 @@ const (
 )
 
 type storageSpec struct {
-	URL           *string `json:"url,omitempty"`
-	AcceptValue   *bool   `json:"acceptValue,omitempty"`
-	ContextSchema *string `json:"contextSchema,omitempty"`
+	URL           *string     `json:"url,omitempty"`
+	AcceptValue   *bool       `json:"acceptValue,omitempty"`
+	ContextSchema interface{} `json:"contextSchema,omitempty"`
 }
 
 func TestExternalStorageInputValidation(t *testing.T) {
@@ -72,7 +72,7 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			storageSpec: storageSpec{
 				URL:         ptr.String("http://localhost:5000/fake"),
 				AcceptValue: ptr.Bool(false),
-				ContextSchema: ptr.String(heredoc.Doc(`
+				ContextSchema: unmarshalContextSchema(t, heredoc.Doc(`
 					   {
 					   	"$id": "#/properties/contextSchema",
 					   	"type": "object",
@@ -96,7 +96,7 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			storageSpec: storageSpec{
 				URL:         ptr.String("http://localhost:5000/fake"),
 				AcceptValue: ptr.Bool(false),
-				ContextSchema: ptr.String(heredoc.Doc(`
+				ContextSchema: unmarshalContextSchema(t, heredoc.Doc(`
 					   {
 					   	"$id": "#/properties/contextSchema",
 					   	"type": "object",
@@ -180,7 +180,7 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			storageSpec: storageSpec{
 				URL:         ptr.String("http://localhost:5000/fake"),
 				AcceptValue: ptr.Bool(false),
-				ContextSchema: ptr.String(heredoc.Doc(`
+				ContextSchema: []byte(heredoc.Doc(`
 					   yaml: true`)),
 			},
 			value: map[string]interface{}{
@@ -189,8 +189,8 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			expErrMsg: heredoc.Doc(`
               while executing mutation to create TypeInstance: All attempts fail:
               #1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-              	* Error: failed to process the TypeInstance's backend "MOCKED_ID": invalid spec.context: Unexpected token y in JSON at position 0
-              	* Error: rollback externally stored values: failed to process the TypeInstance's backend "MOCKED_ID": invalid spec.context: Unexpected token y in JSON at position 0`),
+                * Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object
+                * Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object`),
 		},
 	}
 	for tn, tc := range tests {

--- a/test/local-hub/input_validation_test.go
+++ b/test/local-hub/input_validation_test.go
@@ -147,8 +147,8 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			expErrMsg: heredoc.Doc(`
               while executing mutation to create TypeInstance: All attempts fail:
               #1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'url'
-              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'url'`),
+              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'url'
+              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'url'`),
 		},
 		"Should reject usage of backend without AcceptValue field": {
 			storageSpec: storageSpec{
@@ -160,8 +160,8 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			expErrMsg: heredoc.Doc(`
               while executing mutation to create TypeInstance: All attempts fail:
               #1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'acceptValue'
-              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'acceptValue'`),
+              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'acceptValue'
+              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'acceptValue'`),
 		},
 		"Should reject usage of backend without URL and AcceptValue fields": {
 			storageSpec: map[string]interface{}{
@@ -173,8 +173,8 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			expErrMsg: heredoc.Doc(`
               while executing mutation to create TypeInstance: All attempts fail:
               #1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'url', spec.value must have required property 'acceptValue'
-              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value must have required property 'url', spec.value must have required property 'acceptValue'`),
+              	* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'url', spec/value must have required property 'acceptValue'
+              	* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value must have required property 'url', spec/value must have required property 'acceptValue'`),
 		},
 		"Should reject usage of backend with wrong context schema": {
 			storageSpec: storageSpec{
@@ -189,8 +189,8 @@ func TestExternalStorageInputValidation(t *testing.T) {
 			expErrMsg: heredoc.Doc(`
 			while executing mutation to create TypeInstance: All attempts fail:
 			#1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-				* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object
-				* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object`),
+				* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value/contextSchema must be object
+				* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec/value/contextSchema must be object`),
 		},
 	}
 	for tn, tc := range tests {

--- a/test/local-hub/input_validation_test.go
+++ b/test/local-hub/input_validation_test.go
@@ -187,10 +187,10 @@ func TestExternalStorageInputValidation(t *testing.T) {
 				"name": "Luke Skywalker",
 			},
 			expErrMsg: heredoc.Doc(`
-              while executing mutation to create TypeInstance: All attempts fail:
-              #1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
-                * Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object
-                * Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object`),
+			while executing mutation to create TypeInstance: All attempts fail:
+			#1: graphql: failed to create TypeInstance: failed to create the TypeInstances: 2 error occurred:
+				* Error: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object
+				* Error: rollback externally stored values: failed to resolve the TypeInstance's backend "MOCKED_ID": spec.value/contextSchema must be object`),
 		},
 	}
 	for tn, tc := range tests {


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- changes the type of `contextSchema` from `string` to object for in `hub-js`
- fixes tests in `hub-js`
- correction of the creation of the test storage TypeInstance

## Testing

**Using test backend storage TypeInstance:**
1. Checkout this PR
2. Create cluster using `DISABLE_MONITORING_INSTALLATION=true USE_TEST_SETUP=true make dev-cluster`
3. Change manifests source to my branch:
```
kubectl set env deploy/capact-hub-public -n capact-system -c hub-public-populator MANIFESTS_SOURCES="github.com/mkuziemko/hub-manifests?ref=fix_context_schema"
```
4. Create a test storage TypeInstance where the `contextSchema` is an object:
```
cat > /tmp/storage-ti.yaml << ENDOFFILE
typeInstances:
- alias: "helm-storage"
  typeRef:
    path: cap.type.capactio.capact.validation.storage
    revision: 0.1.0
  value:
    acceptValue: true
    url: capact-test-storage-backend.capact-system:50051
    contextSchema: {
      "\$schema": "http://json-schema.org/draft-07/schema",
      "type": "object",
      "required": [
        "provider"
      ],
      "properties": {
        "provider": {
          "\$id": "#/properties/context/properties/provider",
          "type": "string",
          "enum": [
            "aws_secretsmanager",
            "dotenv"
          ]
        }
      },
      "additionalProperties": false
    }
ENDOFFILE
```
```
export STORAGE_TI=$(capact ti create -f /tmp/storage-ti.yaml -ojson | jq -r '.[] | select(.alias == "helm-storage") | .id')
``` 
5. Create a download TypeInstance that uses this test storage backend:
```
cat > /tmp/download-ti.yaml << ENDOFFILE
typeInstances:
- alias: "download"
  typeRef:
    path: cap.type.capactio.capact.validation.download
    revision: 0.1.0
  value:
    key: "true"
  backend:
    context:
      provider: dotenv
    id: $STORAGE_TI
ENDOFFILE
export DOWNLOAD_TI=$(capact ti create -f /tmp/download-ti.yaml -ojson | jq -r '.[] | select(.alias == "download") | .id')
```
6. Try one more time but in this case with an incorrect provider - it should correct read the contextSchema object and reject the request:
```
cat > /tmp/download-ti.yaml << ENDOFFILE
typeInstances:
- alias: "download"
  typeRef:
    path: cap.type.capactio.capact.validation.download
    revision: 0.1.0
  value:
    key: "true"
  backend:
    context:
      provider: test
    id: $STORAGE_TI
ENDOFFILE
export DOWNLOAD_TI=$(capact ti create -f /tmp/download-ti.yaml -ojson | jq -r '.[] | select(.alias == "download") | .id')
```
Error output message:
```
Error: while executing mutation to create TypeInstances: All attempts fail:
#1: graphql: failed to create the TypeInstances: 2 error occurred:
	* Error: External backend "2cc59261-41d4-4cd2-a96c-164bca9378b9": invalid input: context/provider must be equal to one of the allowed values
	* Error: rollback externally stored values: External backend "2cc59261-41d4-4cd2-a96c-164bca9378b9": invalid input: context/provider must be equal to one of the allowed values
```

**Install Mattermost using the Helm storage:**
7. Create Helm storage input params:
```
cat > /tmp/helm-storage-input-params.yaml << ENDOFFILE
input-parameters: {}
 # Optional input parameters:
 # version: 0.6.0-bf8d006
ENDOFFILE
```
8. Follow the instruction for installation of the Helm storage from [here](https://capact.io/docs/next/feature/storage-backends/helm#installation) and update the policy
9. Follow the instruction for installation of the Mattermost from [here](https://capact.io/docs/example/mattermost-installation/)

## Related issue(s)
- https://github.com/capactio/capact/issues/687
