### PR TITLE
Fetch value on update only if truly needed by external backend

### DIFF
--- a/hub-js/src/local/resolver/mutation/update-type-instances.ts
+++ b/hub-js/src/local/resolver/mutation/update-type-instances.ts
@@ -228,7 +228,10 @@ async function storeValueExternally(
   }
   // 1. Based on our contract, if user didn't provide value, we need to fetch the old one and put it
   // to the new revision.
-  if (!args.value) {
+  const requiresInputValue = await delegatedStorage.IsValueAllowedByBackend(
+    fetchInput.backend.id
+  );
+  if (!args.value && requiresInputValue) {
     logger.debug("Fetching previous value from external storage", fetchInput);
     const resp = await delegatedStorage.Get(fetchInput);
     args.value = resp[id];

--- a/hub-js/src/local/storage/service.ts
+++ b/hub-js/src/local/storage/service.ts
@@ -375,6 +375,11 @@ export default class DelegatedStorageService {
     }
   }
 
+  async IsValueAllowedByBackend(id: string): Promise<boolean> {
+    const backend = await this.getBackendContainer(id);
+    return backend.validateSpec.acceptValue;
+  }
+
   private async storageInstanceDetailsFetcher(
     id: string
   ): Promise<StorageTypeInstanceSpec> {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fetch value on update only if truly needed by external backend

This resolves the problem with the TypeInstance update for "dynamic" backend, where only `context` is allowed. In such cases we got error:
```
Error: while executing mutation to update TypeInstances: All attempts fail:
#1: graphql: failed to update TypeInstances: 1 error occurred:
	* Error: External backend "37341a40-abf9-4abd-aae1-4f2d50ea1bd6": input value not allowed
```

to resolve it, we need to check whether backend really need this value or not.

## Related issue(s)

Detected on https://github.com/capactio/capact/pull/699
Fix https://github.com/capactio/capact/issues/704