### PR TITLE
Fix storage backend ID for TypeInstance from nested workflow

### DIFF
--- a/pkg/hub/client/fake/fake.go
+++ b/pkg/hub/client/fake/fake.go
@@ -124,7 +124,8 @@ func (s *FileSystemClient) ListTypes(ctx context.Context, opts ...public.TypeOpt
 					Path: typeRev.Metadata.Path,
 				},
 				Spec: &hubpublicgraphql.TypeSpec{
-					JSONSchema: typeRev.Spec.JSONSchema,
+					JSONSchema:     typeRev.Spec.JSONSchema,
+					AdditionalRefs: typeRev.Spec.AdditionalRefs,
 				},
 			}},
 		})

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -348,7 +348,7 @@ func (r *dedicatedRenderer) RenderTemplateSteps(ctx context.Context, workflow *W
 
 					// 3.9 Add TypeInstances to the upload graph
 					inputArtifacts := r.tplInputArguments[step.Template]
-					typeInstancesBackends, err := r.policyEnforcedCli.ListTypeInstancesBackendsBasedOnPolicy(ctx, rootimpl.Rule, rootimpl.Revision)
+					typeInstancesBackends, err := r.policyEnforcedCli.ListTypeInstancesBackendsBasedOnPolicy(ctx, rule, implementation)
 					if err != nil {
 						return nil, errors.Wrap(err, "while resolving TypeInstance Backend based on Policy")
 					}

--- a/pkg/sdk/renderer/argo/dedicated_renderer.go
+++ b/pkg/sdk/renderer/argo/dedicated_renderer.go
@@ -982,6 +982,16 @@ func (r *dedicatedRenderer) addOutputTypeInstancesToGraph(step *WorkflowStep, pr
 				stepOutputBackendAlias = ptr.StringPtrToString(output.Backend)
 				name = addPrefix(prefix, output.From)
 				r.tryReplaceTypeInstanceName(output.Name, name)
+
+				for i := range mappings {
+					if mappings[i].Name == name {
+						mappings[name] = artefactNameWithBackend{
+							Name:    output.Name,
+							Backend: mappings[i].Backend,
+						}
+						delete(mappings, i)
+					}
+				}
 			} else {
 				// if the TypeInstance was not defined in capact-outputTypeInstances, then just prefix it
 				name = addPrefix(prefix, item.TypeInstanceName)
@@ -1041,7 +1051,7 @@ func (r *dedicatedRenderer) addOutputTypeInstancesToGraph(step *WorkflowStep, pr
 }
 
 func (*dedicatedRenderer) selectBackendAlias(upperStep, resolvedStep string) (*string, error) {
-	if upperStep != "" && resolvedStep != "" {
+	if upperStep != "" && resolvedStep != "" && upperStep != resolvedStep {
 		return nil, errors.Errorf("cannot override backend on capact-outputTypeInstances")
 	}
 	for _, alias := range []string{upperStep, resolvedStep} {

--- a/pkg/sdk/renderer/argo/fixtures_test.go
+++ b/pkg/sdk/renderer/argo/fixtures_test.go
@@ -6,6 +6,43 @@ import (
 	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 )
 
+func fixHelmStorageGlobalPolicy() policy.Policy {
+	return policy.Policy{
+		Interface: policy.InterfacePolicy{
+			Default: &policy.InterfaceDefault{
+				Inject: &policy.DefaultInject{
+					RequiredTypeInstances: []policy.RequiredTypeInstanceToInject{
+						{
+							TypeInstanceReference: policy.TypeInstanceReference{
+								ID:          "a35a0c04-6153-4fe9-8d49-9ec35a0e86e",
+								Description: ptr.String("Helm release"),
+							},
+						},
+						{
+							TypeInstanceReference: policy.TypeInstanceReference{
+								ID:          "b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2",
+								Description: ptr.String("Helm template"),
+							},
+						},
+					},
+				},
+			},
+			Rules: policy.InterfaceRulesList{
+				{
+					Interface: types.ManifestRefWithOptRevision{
+						Path: "cap.*",
+					},
+					OneOf: []policy.Rule{
+						{
+							ImplementationConstraints: policy.ImplementationConstraints{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func fixGCPGlobalPolicy() policy.Policy {
 	return policy.Policy{
 		Interface: policy.InterfacePolicy{

--- a/pkg/sdk/renderer/argo/renderer_test.go
+++ b/pkg/sdk/renderer/argo/renderer_test.go
@@ -204,6 +204,16 @@ func TestRenderHappyPathWithCustomPolicies(t *testing.T) {
 		policy                  policy.Policy
 	}{
 		{
+			name: "Mattermost workflow with storage backends",
+			ref: types.InterfaceRef{
+				Path: "cap.interface.productivity.mattermost.install",
+			},
+			userParameterCollection: types.ParametersCollection{
+				"input-parameters": `{"host":"mattermost.local"}`,
+			},
+			policy: fixHelmStorageGlobalPolicy(),
+		},
+		{
 			name: "Mattermost with CloudSQL PostgreSQL installation with GCP SA injected",
 			ref: types.InterfaceRef{
 				Path: "cap.interface.productivity.mattermost.install",

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -174,8 +174,8 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: inject-input-type-instances-2-0-step
-          template: inject-input-type-instances-2-0
+          name: inject-input-type-instances-3-0-step
+          template: inject-input-type-instances-3-0
       - - arguments: {}
           name: populate-input-parameters-step
           template: populate-input-parameters
@@ -258,7 +258,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-2-0
+      name: inject-input-type-instances-3-0
       outputs:
         artifacts:
         - globalName: gcp-sa

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_AWS_RDS_install.golden.yaml
@@ -427,8 +427,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-5-0-step
-          template: inject-input-type-instances-5-0
+          name: inject-input-type-instances-6-0-step
+          template: inject-input-type-instances-6-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -869,7 +869,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-5-0
+      name: inject-input-type-instances-6-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_PostgreSQL_installation_with_GCP_SA_injected.golden.yaml
@@ -423,8 +423,8 @@ args:
           name: postgresql
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-0-0-step
-          template: inject-input-type-instances-0-0
+          name: inject-input-type-instances-1-0-step
+          template: inject-input-type-instances-1-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -592,7 +592,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-0-0
+      name: inject-input-type-instances-1-0
       outputs:
         artifacts:
         - globalName: gcp-sa

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_CloudSQL_using_Terraform.golden.yaml
@@ -423,8 +423,8 @@ args:
           name: postgresql
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-4-0-step
-          template: inject-input-type-instances-4-0
+          name: inject-input-type-instances-5-0-step
+          template: inject-input-type-instances-5-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -653,7 +653,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-4-0
+      name: inject-input-type-instances-5-0
       outputs:
         artifacts:
         - globalName: gcp-sa

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_with_existing_DB_installation.golden.yaml
@@ -950,14 +950,14 @@ args:
       outputs: {}
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-1-1-step
-          template: inject-input-type-instances-1-1
+          name: inject-input-type-instances-2-1-step
+          template: inject-input-type-instances-2-1
       - - arguments: {}
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: inject-input-type-instances-1-0-step
-          template: inject-input-type-instances-1-0
+          name: inject-input-type-instances-2-0-step
+          template: inject-input-type-instances-2-0
       - - arguments: {}
           name: populate-input-parameters-step
           template: populate-input-parameters
@@ -1072,7 +1072,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-1-0
+      name: inject-input-type-instances-2-0
       outputs:
         artifacts:
         - globalName: postgresql
@@ -1122,7 +1122,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-1-1
+      name: inject-input-type-instances-2-1
       outputs:
         artifacts:
         - globalName: postgresql

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_workflow_with_storage_backends.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Mattermost_workflow_with_storage_backends.golden.yaml
@@ -1,0 +1,1583 @@
+args:
+  workflow:
+    arguments: {}
+    entrypoint: capact-root
+    templates:
+    - inputs:
+        artifacts:
+        - name: input-parameters
+        - name: postgresql
+          optional: true
+        - name: additional-parameters
+          optional: true
+      metadata: {}
+      name: mattermost-install
+      outputs:
+        artifacts:
+        - from: '{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}'
+          name: mattermost-config
+      steps:
+      - - arguments:
+            artifacts:
+            - name: input-parameters
+              raw:
+                data: |
+                  superuser:
+                    username: superuser
+                  defaultDBName: postgres
+          name: install-db
+          template: mattermost-install-install-db-postgres-install
+      - - arguments:
+            artifacts:
+            - from: '{{steps.install-db.outputs.artifacts.postgresql}}'
+              name: postgresql
+            - name: input-parameters
+              raw:
+                data: |
+                  name: mattermost
+          name: create-user
+          template: mattermost-install-create-user-main
+      - - arguments:
+            artifacts:
+            - name: template
+              raw:
+                data: |
+                  name: mattermost
+                  owner: "<@ name @>"
+            - from: '{{steps.create-user.outputs.artifacts.user}}'
+              name: input-parameters
+            - name: configuration
+              raw:
+                data: 'unpackValue: true'
+          name: render-create-db-args
+          template: mattermost-install-render-create-db-args-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.install-db.outputs.artifacts.postgresql}}'
+              name: postgresql
+            - from: '{{steps.render-create-db-args.outputs.artifacts.render}}'
+              name: input-parameters
+          name: create-db
+          template: mattermost-install-create-db-main
+      - - arguments:
+            artifacts:
+            - from: '{{inputs.artifacts.input-parameters}}'
+              name: input-parameters
+            - from: '{{inputs.artifacts.additional-parameters}}'
+              name: additional-parameters
+              optional: true
+            - from: '{{steps.install-db.outputs.artifacts.postgresql}}'
+              name: psql
+            - from: '{{steps.create-db.outputs.artifacts.database}}'
+              name: db
+            - from: '{{steps.create-user.outputs.artifacts.user}}'
+              name: user
+          name: prepare-parameters
+          template: prepare-parameters
+      - - arguments:
+            artifacts:
+            - name: template
+              raw:
+                data: "generateName: true\nchart:\n  name: \"mattermost-team-edition\"\n
+                  \ repo: \"https://helm.mattermost.com\"\n  version: \"4.0.0\"\nvalues:\n
+                  \ image:\n    repository: <@ additionalinput.image.repository |
+                  default('mattermost/mattermost-team-edition') @>\n    tag: <@ additionalinput.image.tag
+                  | default('5.29.0') @>\n    imagePullPolicy: <@ additionalinput.image.imagePullPolicy
+                  | default('IfNotPresent') @>\n  initContainerImage:\n    repository:
+                  <@ additionalinput.initContainerImage.repository | default('appropriate/curl')
+                  @>\n    tag: <@ additionalinput.initContainerImage.tag | default('latest')
+                  @>\n    imagePullPolicy: <@ additionalinput.initContainerImage.imagePullPolicy
+                  | default('IfNotPresent') @>\n  revisionHistoryLimit: <@ additionalinput.revisionHistoryLimit
+                  | default(1) @>\n  persistence:\n    data:\n      enabled: <@ additionalinput.persistence.data.enabled
+                  | default(true) | tojson @>\n      size: <@ additionalinput.persistence.data.size
+                  | default('10Gi') @>\n      accessMode: <@ additionalinput.persistence.data.accessMode
+                  | default('ReadWriteOnce') @>\n      storageClass: <@ additionalinput.persistence.data.storageClass
+                  | default('') @>\n    plugins:\n      enabled: <@ additionalinput.persistence.plugins.enabled
+                  | default(true) | tojson @>\n      size: <@ additionalinput.persistence.plugins.size
+                  | default('1Gi') @>\n      accessMode: <@ additionalinput.persistence.plugins.accessMode
+                  | default('ReadWriteOnce') @>\n      storageClass: <@ additionalinput.persistence.plugins.storageClass
+                  | default('') @>\n  service:\n    type: <@ additionalinput.service.type
+                  | default('ClusterIP') @>\n    externalPort: <@ additionalinput.service.externalPort
+                  | default(8065) @>\n    internalPort: <@ additionalinput.service.internalPort
+                  | default(8065) @>\n    annotations: <@ additionalinput.service.annotations
+                  | default({}) @>\n    loadBalancerSourceRanges: <@ additionalinput.service.loadBalancerSourceRanges
+                  | default([]) @>\n  ingress:\n    enabled: <@ additionalinput.ingress.enabled
+                  | default(true) | tojson @>\n    path: <@ additionalinput.ingress.path
+                  | default('/') @>\n    annotations:\n      \"cert-manager.io/cluster-issuer\":
+                  letsencrypt\n    hosts:\n      - <@ input.host @>\n    tls:\n      -
+                  hosts:\n          - <@ input.host @>\n        secretName: mattermost-team-edition-tls-<@
+                  random_word(length=5) @>\n  route:\n    enabled: <@ additionalinput.route.enabled
+                  | default(false) | tojson @>\n  externalDB:\n    enabled: true\n
+                  \   externalDriverType: \"postgres\"\n    externalConnectionString:
+                  \"postgres://<@ user.name @>:<@ user.password @>@<@ psql.host @>:<@
+                  psql.port @>/<@ db.name @>?sslmode=disable\"\n  mysql:\n    enabled:
+                  false\n  extraPodAnnotations: <@ additionalinput.extraPodAnnotations
+                  | default({}) @>\n  extraEnvVars: <@ additionalinput.extraEnvVars
+                  | default([]) @>\n  extraInitContainers: <@ additionalinput.extraInitContainers
+                  | default([]) @>\n  extraVolumes: <@ additionalinput.extraVolumes
+                  | default([]) @>\n  extraVolumeMounts: <@ additionalinput.extraVolumeMounts
+                  | default([]) @>\n  nodeSelector: <@ additionalinput.nodeSelector
+                  | default({}) @>\n  affinity: <@ additionalinput.affinity | default({})
+                  @>\n  affinity: <@ additionalinput.resources | default({}) @>\n
+                  \ tolerations: <@ additionalinput.tolerations | default([]) @>\n\n
+                  \ configJSON:\n    ServiceSettings:\n      SiteURL: \"https://<@
+                  input.host @>\"\n      LicenseFileLocation: \"<@ input.configJSON.ServiceSettings.LicenseFileLocation
+                  | default('') @>\"\n      ListenAddress: \"<@ input.configJSON.ServiceSettings.ListenAddress
+                  | default(':8065') @>\"\n      ConnectionSecurity: \"<@ input.configJSON.ServiceSettings.ConnectionSecurity
+                  | default('') @>\"\n      TLSCertFile: \"<@ input.configJSON.ServiceSettings.TLSCertFile
+                  | default('') @>\"\n      TLSKeyFile: \"<@ input.configJSON.ServiceSettings.TLSKeyFile
+                  | default('') @>\"\n      UseLetsEncrypt: <@ input.configJSON.ServiceSettings.UseLetsEncrypt
+                  | default(false) | tojson @>\n      LetsEncryptCertificateCacheFile:
+                  \"<@ input.configJSON.ServiceSettings.LetsEncryptCertificateCacheFile
+                  | default('./config/letsencrypt.cache') @>\"\n      Forward80To443:
+                  <@ input.configJSON.ServiceSettings.Forward80To443 | default(false)
+                  | tojson @>\n      ReadTimeout: <@ input.configJSON.ServiceSettings.ReadTimeout
+                  | default(300) @>\n      WriteTimeout: <@ input.configJSON.ServiceSettings.WriteTimeout
+                  | default(300) @>\n      MaximumLoginAttempts: <@ input.configJSON.ServiceSettings.MaximumLoginAttempts
+                  | default(10) @>\n      GoroutineHealthThreshold: <@ input.configJSON.ServiceSettings.GoroutineHealthThreshold
+                  | default(-1) @>\n      GoogleDeveloperKey: \"<@ input.configJSON.ServiceSettings.GoogleDeveloperKey
+                  | default('') @>\"\n      EnableOAuthServiceProvider: <@ input.configJSON.ServiceSettings.EnableOAuthServiceProvider
+                  | default(false) | tojson @>\n      EnableIncomingWebhooks: <@ input.configJSON.ServiceSettings.EnableIncomingWebhooks
+                  | default(true) | tojson @>\n      EnableOutgoingWebhooks: <@ input.configJSON.ServiceSettings.EnableOutgoingWebhooks
+                  | default(true) | tojson @>\n      EnableCommands: <@ input.configJSON.ServiceSettings.EnableCommands
+                  | default(true) | tojson @>\n      EnableOnlyAdminIntegrations:
+                  <@ input.configJSON.ServiceSettings.EnableOnlyAdminIntegrations
+                  | default(false) | tojson @>\n      EnablePostUsernameOverride:
+                  <@ input.configJSON.ServiceSettings.EnablePostUsernameOverride |
+                  default(false) | tojson @>\n      EnablePostIconOverride: <@ input.configJSON.ServiceSettings.EnablePostIconOverride
+                  | default(false) | tojson @>\n      EnableBotAccountCreation: <@
+                  input.configJSON.ServiceSettings.EnableBotAccountCreation | default(false)
+                  | tojson @>\n      EnableUserAccessTokens: <@ input.configJSON.ServiceSettings.EnableUserAccessTokens
+                  | default(false) | tojson @>\n      EnableLinkPreviews: <@ input.configJSON.ServiceSettings.EnableLinkPreviews
+                  | default(false) | tojson @>\n      EnableTesting: <@ input.configJSON.ServiceSettings.EnableTesting
+                  | default(false) | tojson @>\n      EnableDeveloper: <@ input.configJSON.ServiceSettings.EnableDeveloper
+                  | default(false) | tojson @>\n      EnableSecurityFixAlert: <@ input.configJSON.ServiceSettings.EnableSecurityFixAlert
+                  | default(true) | tojson @>\n      EnableInsecureOutgoingConnections:
+                  <@ input.configJSON.ServiceSettings.EnableInsecureOutgoingConnections
+                  | default(false) | tojson @>\n      EnableMultifactorAuthentication:
+                  <@ input.configJSON.ServiceSettings.EnableMultifactorAuthentication
+                  | default(false) | tojson @>\n      EnforceMultifactorAuthentication:
+                  <@ input.configJSON.ServiceSettings.EnforceMultifactorAuthentication
+                  | default(false) | tojson @>\n      AllowCorsFrom: \"<@ input.configJSON.ServiceSettings.AllowCorsFrom
+                  | default('') @>\"\n      SessionLengthWebInDays: <@ input.configJSON.ServiceSettings.SessionLengthWebInDays
+                  | default(30) @>\n      SessionLengthMobileInDays: <@ input.configJSON.ServiceSettings.SessionLengthMobileInDays
+                  | default(30) @>\n      SessionLengthSSOInDays: <@ input.configJSON.ServiceSettings.SessionLengthSSOInDays
+                  | default(30) @>\n      SessionCacheInMinutes: <@ input.configJSON.ServiceSettings.SessionCacheInMinutes
+                  | default(10) @>\n      WebsocketSecurePort: <@ input.configJSON.ServiceSettings.WebsocketSecurePort
+                  | default(443) @>\n      WebsocketPort: <@ input.configJSON.ServiceSettings.WebsocketPort
+                  | default(80) @>\n      WebserverMode: \"<@ input.configJSON.ServiceSettings.WebserverMode
+                  | default('gzip') @>\"\n      EnableCustomEmoji: <@ input.configJSON.ServiceSettings.EnableCustomEmoji
+                  | default(false) @>\n      RestrictCustomEmojiCreation: \"<@ input.configJSON.ServiceSettings.RestrictCustomEmojiCreation
+                  | default('all') @>\"\n      RestrictPostDelete: \"<@ input.configJSON.ServiceSettings.RestrictPostDelete
+                  | default('all') @>\"\n      AllowEditPost: \"<@ input.configJSON.ServiceSettings.AllowEditPost
+                  | default('always') @>\"\n      PostEditTimeLimit: <@ input.configJSON.ServiceSettings.PostEditTimeLimit
+                  | default(300) @>\n      TimeBetweenUserTypingUpdatesMilliseconds:
+                  <@ input.configJSON.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds
+                  | default(5000) @>\n      EnablePostSearch: <@ input.configJSON.ServiceSettings.EnablePostSearch
+                  | default(true) | tojson @>\n      EnableUserTypingMessages: <@
+                  input.configJSON.ServiceSettings.EnableUserTypingMessages | default(true)
+                  | tojson @>\n      EnableUserStatuses: <@ input.configJSON.ServiceSettings.EnableUserStatuses
+                  | default(true) | tojson @>\n      ClusterLogTimeoutMilliseconds:
+                  <@ input.configJSON.ServiceSettings.ClusterLogTimeoutMilliseconds
+                  | default(2000) @>\n    TeamSettings:\n      SiteName: \"<@ input.configJSON.TeamSettings.SiteName
+                  | default('Mattermost') @>\"\n      MaxUsersPerTeam: <@ input.configJSON.TeamSettings.MaxUsersPerTeam
+                  | default(50000) @>\n      EnableTeamCreation: <@ input.configJSON.TeamSettings.EnableTeamCreation
+                  | default(true) | tojson @>\n      EnableUserCreation: <@ input.configJSON.TeamSettings.EnableUserCreation
+                  | default(true) | tojson @>\n      EnableOpenServer: <@ input.configJSON.TeamSettings.EnableOpenServer
+                  | default(true) | tojson @>\n      RestrictCreationToDomains: \"<@
+                  input.configJSON.TeamSettings.RestrictCreationToDomains | default('')
+                  @>\"\n      EnableCustomBrand: <@ input.configJSON.TeamSettings.EnableCustomBrand
+                  | default(false) | tojson @>\n      CustomBrandText: \"<@ input.configJSON.TeamSettings.CustomBrandText
+                  | default('') @>\"\n      CustomDescriptionText: \"<@ input.configJSON.TeamSettings.CustomDescriptionText
+                  | default('') @>\"\n      RestrictDirectMessage: \"<@ input.configJSON.TeamSettings.RestrictDirectMessage
+                  | default('any') @>\"\n      RestrictTeamInvite: \"<@ input.configJSON.TeamSettings.RestrictTeamInvite
+                  | default('all') @>\"\n      RestrictPublicChannelManagement: \"<@
+                  input.configJSON.TeamSettings.RestrictPublicChannelManagement |
+                  default('all') @>\"\n      RestrictPrivateChannelManagement: \"<@
+                  input.configJSON.TeamSettings.RestrictPrivateChannelManagement |
+                  default('all') @>\"\n      RestrictPublicChannelCreation: \"<@ input.configJSON.TeamSettings.RestrictPublicChannelCreation
+                  | default('all') @>\"\n      RestrictPrivateChannelCreation: \"<@
+                  input.configJSON.TeamSettings.RestrictPrivateChannelCreation | default('all')
+                  @>\"\n      RestrictPublicChannelDeletion: \"<@ input.configJSON.TeamSettings.RestrictPublicChannelDeletion
+                  | default('all') @>\"\n      RestrictPrivateChannelDeletion: \"<@
+                  input.configJSON.TeamSettings.RestrictPrivateChannelDeletion | default('all')
+                  @>\"\n      RestrictPrivateChannelManageMembers: \"<@ input.configJSON.TeamSettings.RestrictPrivateChannelManageMembers
+                  | default('all') @>\"\n      UserStatusAwayTimeout: <@ input.configJSON.TeamSettings.UserStatusAwayTimeout
+                  | default(300) @>\n      MaxChannelsPerTeam: <@ input.configJSON.TeamSettings.MaxChannelsPerTeam
+                  | default(50000) @>\n      MaxNotificationsPerChannel: <@ input.configJSON.TeamSettings.MaxNotificationsPerChannel
+                  | default(1000) @>\n    SqlSettings:\n      DriverName: \"<@ input.configJSON.SqlSettings.DriverName
+                  | default('') @>\"\n      DataSource: \"<@ input.configJSON.SqlSettings.DataSource
+                  | default('') @>\"\n      DataSourceReplicas: <@ input.configJSON.SqlSettings.DataSourceReplicas
+                  | default([]) @>\n      DataSourceSearchReplicas: <@ input.configJSON.SqlSettings.DataSourceSearchReplicas
+                  | default([]) @>\n      MaxIdleConns: <@ input.configJSON.SqlSettings.MaxIdleConns
+                  | default(20) @>\n      MaxOpenConns: <@ input.configJSON.SqlSettings.MaxOpenConns
+                  | default(35) @>\n      Trace: <@ input.configJSON.SqlSettings.Trace
+                  | default(false) | tojson @>\n      AtRestEncryptKey: \"<@ input.configJSON.SqlSettings.AtRestEncryptKey
+                  | default('') @>\"\n      QueryTimeout: <@ input.configJSON.SqlSettings.QueryTimeout
+                  | default(30) @>\n    LogSettings:\n      EnableConsole: <@ input.configJSON.LogSettings.EnableConsole
+                  | default(true) | tojson @>\n      ConsoleLevel: \"<@ input.configJSON.LogSettings.ConsoleLevel
+                  | default('INFO') @>\"\n      EnableFile: <@ input.configJSON.LogSettings.EnableFile
+                  | default(true) | tojson @>\n      FileLevel: \"<@ input.configJSON.LogSettings.FileLevel
+                  | default('INFO') @>\"\n      FileFormat: \"<@ input.configJSON.LogSettings.FileFormat
+                  | default('') @>\"\n      FileLocation: \"<@ input.configJSON.LogSettings.FileLocation
+                  | default('') @>\"\n      EnableWebhookDebugging: <@ input.configJSON.LogSettings.EnableWebhookDebugging
+                  | default(true) | tojson @>\n      EnableDiagnostics: <@ input.configJSON.LogSettings.EnableDiagnostics
+                  | default(true) | tojson @>\n    PasswordSettings:\n      MinimumLength:
+                  <@ input.configJSON.PasswordSettings.MinimumLength | default(5)
+                  @>\n      Lowercase: <@ input.configJSON.PasswordSettings.Lowercase
+                  | default(false) | tojson @>\n      Number: <@ input.configJSON.PasswordSettings.Number
+                  | default(false) | tojson @>\n      Uppercase: <@ input.configJSON.PasswordSettings.Uppercase
+                  | default(false) | tojson @>\n      Symbol: <@ input.configJSON.PasswordSettings.Symbol
+                  | default(false) | tojson @>\n    FileSettings:\n      EnableFileAttachments:
+                  <@ input.configJSON.FileSettings.EnableFileAttachments | default(true)
+                  | tojson @>\n      MaxFileSize: <@ input.configJSON.FileSettings.MaxFileSize
+                  | default(52428800) @>\n      DriverName: \"<@ input.configJSON.FileSettings.DriverName
+                  | default('local') @>\"\n      Directory: \"<@ input.configJSON.FileSettings.Directory
+                  | default('./data/') @>\"\n      EnablePublicLink: <@ input.configJSON.FileSettings.EnablePublicLink
+                  | default(false) | tojson @>\n      PublicLinkSalt: \"<@ input.configJSON.FileSettings.PublicLinkSalt
+                  | default('') @>\"\n      ThumbnailWidth: <@ input.configJSON.FileSettings.ThumbnailWidth
+                  | default(120) @>\n      ThumbnailHeight: <@ input.configJSON.FileSettings.ThumbnailHeight
+                  | default(100) @>\n      PreviewWidth: <@ input.configJSON.FileSettings.PreviewWidth
+                  | default(1024) @>\n      PreviewHeight: <@ input.configJSON.FileSettings.PreviewHeight
+                  | default(0) @>\n      ProfileWidth: <@ input.configJSON.FileSettings.ProfileWidth
+                  | default(128) @>\n      ProfileHeight: <@ input.configJSON.FileSettings.ProfileHeight
+                  | default(128) @>\n      InitialFont: \"<@ input.configJSON.FileSettings.InitialFont
+                  | default('luximbi.ttf') @>\"\n      AmazonS3AccessKeyId: \"<@ input.configJSON.FileSettings.AmazonS3AccessKeyId
+                  | default('') @>\"\n      AmazonS3SecretAccessKey: \"<@ input.configJSON.FileSettings.AmazonS3SecretAccessKey
+                  | default('') @>\"\n      AmazonS3Bucket: \"<@ input.configJSON.FileSettings.AmazonS3Bucket
+                  | default('') @>\"\n      AmazonS3Region: \"<@ input.configJSON.FileSettings.AmazonS3Region
+                  | default('') @>\"\n      AmazonS3Endpoint: \"<@ input.configJSON.FileSettings.AmazonS3Endpoint
+                  | default('s3.amazonaws.com') @>\"\n      AmazonS3SSL: <@ input.configJSON.FileSettings.AmazonS3SSL
+                  | default(false) | tojson @>\n      AmazonS3SignV2: <@ input.configJSON.FileSettings.AmazonS3SignV2
+                  | default(false) | tojson @>\n    EmailSettings:\n      EnableSignUpWithEmail:
+                  <@ input.configJSON.EmailSettings.EnableSignUpWithEmail | default(true)
+                  | tojson @>\n      EnableSignInWithEmail: <@ input.configJSON.EmailSettings.EnableSignInWithEmail
+                  | default(true) | tojson @>\n      EnableSignInWithUsername: <@
+                  input.configJSON.EmailSettings.EnableSignInWithUsername | default(true)
+                  | tojson @>\n      SendEmailNotifications: <@ input.configJSON.EmailSettings.SendEmailNotifications
+                  | default(false) | tojson @>\n      RequireEmailVerification: <@
+                  input.configJSON.EmailSettings.RequireEmailVerification | default(false)
+                  | tojson @>\n      FeedbackName: \"<@ input.configJSON.EmailSettings.FeedbackName
+                  | default('') @>\"\n      FeedbackEmail: \"<@ input.configJSON.EmailSettings.FeedbackEmail
+                  | default('') @>\"\n      FeedbackOrganization: \"<@ input.configJSON.EmailSettings.FeedbackOrganization
+                  | default('') @>\"\n      SMTPUsername: \"<@ input.configJSON.EmailSettings.SMTPUsername
+                  | default('') @>\"\n      SMTPPassword: \"<@ input.configJSON.EmailSettings.SMTPPassword
+                  | default('') @>\"\n      EnableSMTPAuth: \"<@ input.configJSON.EmailSettings.EnableSMTPAuth
+                  | default('') @>\"\n      SMTPServer: \"<@ input.configJSON.EmailSettings.SMTPServer
+                  | default('') @>\"\n      SMTPPort: \"<@ input.configJSON.EmailSettings.SMTPPort
+                  | default('') @>\"\n      ConnectionSecurity: \"<@ input.configJSON.EmailSettings.ConnectionSecurity
+                  | default('') @>\"\n      InviteSalt: \"<@ input.configJSON.EmailSettings.InviteSalt
+                  | default('') @>\"\n      SendPushNotifications: <@ input.configJSON.EmailSettings.SendPushNotifications
+                  | default(true) | tojson @>\n      PushNotificationServer: \"<@
+                  input.configJSON.EmailSettings.PushNotificationServer | default('https://push-test.mattermost.com')
+                  @>\"\n      PushNotificationContents: \"<@ input.configJSON.EmailSettings.PushNotificationContents
+                  | default('generic') @>\"\n      EnableEmailBatching: <@ input.configJSON.EmailSettings.EnableEmailBatching
+                  | default(false) | tojson @>\n      EmailBatchingBufferSize: <@
+                  input.configJSON.EmailSettings.EmailBatchingBufferSize | default(256)
+                  @>\n      EmailBatchingInterval: <@ input.configJSON.EmailSettings.EmailBatchingInterval
+                  | default(30) @>\n      SkipServerCertificateVerification: <@ input.configJSON.EmailSettings.SkipServerCertificateVerification
+                  | default(false) | tojson @>\n    RateLimitSettings:\n      Enable:
+                  <@ input.configJSON.RateLimitSettings.Enable | default(false) |
+                  tojson @>\n      PerSec: <@ input.configJSON.RateLimitSettings.PerSec
+                  | default(10) @>\n      MaxBurst: <@ input.configJSON.RateLimitSettings.MaxBurst
+                  | default(100) @>\n      MemoryStoreSize: <@ input.configJSON.RateLimitSettings.MemoryStoreSize
+                  | default(10000) @>\n      VaryByRemoteAddr: <@ input.configJSON.RateLimitSettings.VaryByRemoteAddr
+                  | default(true) | tojson @>\n      VaryByHeader: \"<@ input.configJSON.RateLimitSettings.VaryByHeader
+                  | default('') @>\"\n    PrivacySettings:\n      ShowEmailAddress:
+                  <@ input.configJSON.PrivacySettings.ShowEmailAddress | default(true)
+                  | tojson @>\n      ShowFullName: <@ input.configJSON.PrivacySettings.ShowFullName
+                  | default(true) | tojson @>\n    SupportSettings:\n      TermsOfServiceLink:
+                  \"<@ input.configJSON.SupportSettings.TermsOfServiceLink | default('https://about.mattermost.com/default-terms/')
+                  @>\"\n      PrivacyPolicyLink: \"<@ input.configJSON.SupportSettings.PrivacyPolicyLink
+                  | default('https://about.mattermost.com/default-privacy-policy/')
+                  @>\"\n      AboutLink: \"<@ input.configJSON.SupportSettings.AboutLink
+                  | default('https://about.mattermost.com/default-about/') @>\"\n
+                  \     HelpLink: \"<@ input.configJSON.SupportSettings.HelpLink |
+                  default('https://about.mattermost.com/default-help/') @>\"\n      ReportAProblemLink:
+                  \"<@ input.configJSON.SupportSettings.ReportAProblemLink | default('https://about.mattermost.com/default-report-a-problem/')
+                  @>\"\n      SupportEmail: \"<@ input.configJSON.SupportSettings.SupportEmail
+                  | default('feedback@mattermost.com') @>\"\n    AnnouncementSettings:\n
+                  \     EnableBanner: <@ input.configJSON.AnnouncementSettings.EnableBanner
+                  | default(false) | tojson @>\n      BannerText: \"<@ input.configJSON.AnnouncementSettings.BannerText
+                  | default('') @>\"\n      BannerColor: \"<@ input.configJSON.AnnouncementSettings.BannerColor
+                  | default('#f2a93b') @>\"\n      BannerTextColor: \"<@ input.configJSON.AnnouncementSettings.BannerTextColor
+                  | default('#333333') @>\"\n      AllowBannerDismissal: <@ input.configJSON.AnnouncementSettings.AllowBannerDismissal
+                  | default(true) | tojson @>\n    GitLabSettings:\n      Enable:
+                  <@ input.configJSON.GitLabSettings.Enable | default(false) | tojson
+                  @>\n      Secret: \"<@ input.configJSON.GitLabSettings.Secret |
+                  default('') @>\"\n      Id: \"<@ input.configJSON.GitLabSettings.Id
+                  | default('') @>\"\n      Scope: \"<@ input.configJSON.GitLabSettings.Scope
+                  | default('') @>\"\n      AuthEndpoint: \"<@ input.configJSON.GitLabSettings.AuthEndpoint
+                  | default('') @>\"\n      TokenEndpoint: \"<@ input.configJSON.GitLabSettings.TokenEndpoint
+                  | default('') @>\"\n      UserApiEndpoint: \"<@ input.configJSON.GitLabSettings.UserApiEndpoint
+                  | default('') @>\"\n    LocalizationSettings:\n      DefaultServerLocale:
+                  \"<@ input.configJSON.LocalizationSettings.DefaultServerLocale |
+                  default('en') @>\"\n      DefaultClientLocale: \"<@ input.configJSON.LocalizationSettings.DefaultClientLocale
+                  | default('en') @>\"\n      AvailableLocales: \"<@ input.configJSON.LocalizationSettings.AvailableLocales
+                  | default('') @>\"\n    NativeAppSettings:\n      AppDownloadLink:
+                  \"<@ input.configJSON.NativeAppSettings.AppDownloadLink | default('https://about.mattermost.com/downloads/')
+                  @>\"\n      AndroidAppDownloadLink: \"<@ input.configJSON.NativeAppSettings.AndroidAppDownloadLink
+                  | default('https://about.mattermost.com/mattermost-android-app/')
+                  @>\"\n      IosAppDownloadLink: \"<@ input.configJSON.NativeAppSettings.IosAppDownloadLink
+                  | default('https://about.mattermost.com/mattermost-ios-app/') @>\"\n
+                  \   AnalyticsSettings:\n      MaxUsersForStatistics: <@ input.configJSON.AnalyticsSettings.MaxUsersForStatistics
+                  | default(2500) @>\n    WebrtcSettings:\n      Enable: <@ input.configJSON.WebrtcSettings.Enable
+                  | default(false) | tojson @>\n      GatewayWebsocketUrl: \"<@ input.configJSON.WebrtcSettings.GatewayWebsocketUrl
+                  | default('') @>\"\n      GatewayAdminUrl: \"<@ input.configJSON.WebrtcSettings.GatewayAdminUrl
+                  | default('') @>\"\n      GatewayAdminSecret: \"<@ input.configJSON.WebrtcSettings.GatewayAdminSecret
+                  | default('') @>\"\n      StunURI: \"<@ input.configJSON.WebrtcSettings.StunURI
+                  | default('') @>\"\n      TurnURI: \"<@ input.configJSON.WebrtcSettings.TurnURI
+                  | default('') @>\"\n      TurnUsername: \"<@ input.configJSON.WebrtcSettings.TurnUsername
+                  | default('') @>\"\n      TurnSharedKey: \"<@ input.configJSON.WebrtcSettings.TurnSharedKey
+                  | default('') @>\"\n    DisplaySettings:\n      CustomUrlSchemes:
+                  <@ input.configJSON.DisplaySettings.CustomUrlSchemes | default([])
+                  @>\n      ExperimentalTimezone: <@ input.configJSON.DisplaySettings.ExperimentalTimezone
+                  | default(true) | tojson @>\n    TimezoneSettings:\n      SupportedTimezonesPath:
+                  \"<@ input.configJSON.TimezoneSettings.SupportedTimezonesPath |
+                  default('timezones.json') @>\"\n    PluginSettings:\n      Enable:
+                  <@ input.configJSON.PluginSettings.Enable | default(true) @>\n      EnableUploads:
+                  <@ input.configJSON.PluginSettings.EnableUploads | default(true)
+                  | tojson @>\n      Directory: \"<@ input.configJSON.PluginSettings.Directory
+                  | default('./plugins') @>\"\n      ClientDirectory: \"<@ input.configJSON.PluginSettings.ClientDirectory
+                  | default('./client/plugins') @>\"\n      Plugins: <@ input.configJSON.PluginSettings.Plugins
+                  | default({}) @>\n      PluginStates: <@ input.configJSON.PluginSettings.PluginStates
+                  | default({}) @>\noutput:\n  helmRelease:\n    useHelmReleaseStorage:
+                  true\n  additional:\n    useHelmTemplateStorage: true  \n    goTemplate:
+                  |\n      host: \"{{ index .Values.ingress.hosts 0 }}\"\n      version:
+                  \"{{ .Values.image.tag }}\"\n"
+            - from: '{{steps.prepare-parameters.outputs.artifacts.merged}}'
+              name: input-parameters
+            - name: configuration
+              raw:
+                data: 'unpackValue: true'
+          name: create-helm-args
+          template: mattermost-install-create-helm-args-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-helm-args.outputs.artifacts.render}}'
+              name: input-parameters
+            - from: '{{workflow.outputs.artifacts.runner-context}}'
+              name: runner-context
+          name: helm-install
+          template: mattermost-install-helm-install-helm
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.additional}}'
+              name: ti-artifact
+            - from: '{{workflow.outputs.artifacts.helm-template-storage}}'
+              name: backend
+          name: resolve-ti-value
+          template: resolve-ti-art-value
+      - - arguments:
+            artifacts:
+            - from: '{{steps.install-db.outputs.artifacts.postgresql}}'
+              name: postgresql
+          name: output-postgresql
+          template: output-postgresql
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-user.outputs.artifacts.user}}'
+              name: database-user
+          name: output-database-user
+          template: output-database-user
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-db.outputs.artifacts.database}}'
+              name: database
+          name: output-database
+          template: output-database
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.helm-release}}'
+              name: mattermost-helm-release
+          name: output-mattermost-helm-release
+          template: output-mattermost-helm-release
+      - - arguments:
+            artifacts:
+            - from: '{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}'
+              name: mattermost-config
+          name: output-mattermost-config
+          template: output-mattermost-config
+    - inputs:
+        artifacts:
+        - name: input-parameters
+        - name: kubeconfig
+          optional: true
+      metadata: {}
+      name: mattermost-install-install-db-postgres-install
+      outputs:
+        artifacts:
+        - from: '{{steps.resolve-psql-value.outputs.artifacts.ti-artifact}}'
+          name: postgresql
+      steps:
+      - - arguments: {}
+          name: inject-input-type-instances-0-1-step
+          template: inject-input-type-instances-0-1
+      - - arguments:
+            artifacts:
+            - from: '{{inputs.artifacts.input-parameters}}'
+              name: input-parameters
+            - name: template
+              raw:
+                data: |
+                  generateName: true
+                  chart:
+                    name: "postgresql"
+                    repo: "https://charts.bitnami.com/bitnami"
+                    version: "10.2.6"
+                  values:
+                    volumePermissions:
+                      enabled: true
+                    global:
+                      postgresql:
+                        postgresqlDatabase: <@ defaultDBName | default('postgres') @>
+                        postgresqlPassword: <@ superuser.password | default(random_word(length=16)) @>
+                  output:
+                    helmRelease:
+                      useHelmReleaseStorage: true
+                    additional:
+                      useHelmTemplateStorage: true
+                      goTemplate: |
+                        host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
+                        port: {{ template "postgresql.port" . }}
+                        defaultDBName: '{{ template "postgresql.database" . }}'
+                        superuser:
+                          # It cannot be changed
+                          username: 'postgres'
+                          password: '{{ template "postgresql.password" . }}'
+            - name: configuration
+              raw:
+                data: 'unpackValue: true'
+          name: create-helm-args
+          template: mattermost-install-install-db-postgres-install-create-helm-args-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-helm-args.outputs.artifacts.render}}'
+              name: input-parameters
+            - from: '{{workflow.outputs.artifacts.runner-context}}'
+              name: runner-context
+            - from: '{{inputs.artifacts.kubeconfig}}'
+              name: kubeconfig
+              optional: true
+          name: helm-install
+          template: mattermost-install-install-db-postgres-install-helm-install-helm
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.additional}}'
+              name: ti-artifact
+            - from: '{{workflow.outputs.artifacts.helm-template-storage}}'
+              name: backend
+          name: resolve-psql-value
+          template: mattermost-install-install-db-resolve-ti-art-value
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.helm-release}}'
+              name: psql-helm-release
+          name: output-psql-helm-release
+          template: output-mattermost-install-install-db-psql-helm-release
+      - - arguments:
+            artifacts:
+            - from: '{{steps.resolve-psql-value.outputs.artifacts.ti-artifact}}'
+              name: postgresql
+          name: output-postgresql
+          template: output-mattermost-install-install-db-postgresql
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-install-db-postgres-install-create-helm-args-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - inputs:
+        artifacts:
+        - name: input-parameters
+        - name: runner-context
+        - name: kubeconfig
+          optional: true
+      metadata: {}
+      name: mattermost-install-install-db-postgres-install-helm-install-helm
+      outputs:
+        artifacts:
+        - from: '{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}'
+          name: helm-release
+        - from: '{{steps.helm-install.outputs.artifacts.additional}}'
+          name: additional
+      steps:
+      - - arguments: {}
+          name: inject-input-type-instances-0-2-step
+          template: inject-input-type-instances-0-2
+      - - arguments:
+            artifacts:
+            - from: '{{inputs.artifacts.input-parameters}}'
+              name: input-parameters
+            - from: '{{inputs.artifacts.runner-context}}'
+              name: runner-context
+            - from: '{{inputs.artifacts.kubeconfig}}'
+              name: kubeconfig
+          name: helm-install
+          template: mattermost-install-install-db-postgres-install-helm-install-helm-install
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.helm-release}}'
+              name: ti-artifact
+            - from: '{{workflow.outputs.artifacts.helm-release-storage}}'
+              name: backend
+          name: resolve-helm-rel-value
+          template: mattermost-install-install-db-postgres-install-helm-install-resolve-ti-art-value
+      - - arguments:
+            artifacts:
+            - from: '{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}'
+              name: helm-release
+          name: output-helm-release
+          template: output-mattermost-install-install-db-postgres-install-helm-install-helm-release
+    - container:
+        env:
+        - name: RUNNER_OPTIONAL_KUBECONFIG_TI
+          value: '{{inputs.artifacts.kubeconfig.path}}'
+        - name: RUNNER_CONTEXT_PATH
+          value: '{{inputs.artifacts.runner-context.path}}'
+        - name: RUNNER_ARGS_PATH
+          value: '{{inputs.artifacts.input-parameters.path}}'
+        - name: RUNNER_LOGGER_DEV_MODE
+          value: "true"
+        - name: RUNNER_COMMAND
+          value: install
+        - name: RUNNER_OUTPUT_HELM_RELEASE_FILE_PATH
+          value: '{{outputs.artifacts.helm-release.path}}'
+        - name: RUNNER_OUTPUT_ADDITIONAL_FILE_PATH
+          value: '{{outputs.artifacts.additional.path}}'
+        image: ghcr.io/capactio/helm-runner:2ada6f8
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      inputs:
+        artifacts:
+        - name: input-parameters
+          path: /runner-args
+        - name: runner-context
+          path: /runner-context
+        - name: kubeconfig
+          optional: true
+          path: /kubeconfig-ti
+      metadata: {}
+      name: mattermost-install-install-db-postgres-install-helm-install-helm-install
+      outputs:
+        artifacts:
+        - name: helm-release
+          path: /helm-release.yaml
+        - name: additional
+          optional: true
+          path: /additional.yaml
+      volumes:
+      - emptyDir: {}
+        name: tmp
+    - container:
+        env:
+        - name: APP_LOGGER_DEV_MODE
+          value: "true"
+        - name: APP_INPUT_TI_FILE_PATH
+          value: '{{inputs.artifacts.ti-artifact.path}}'
+        - name: APP_INPUT_BACKEND_TI_FILE_PATH
+          value: '{{inputs.artifacts.backend.path}}'
+        - name: APP_OUTPUT_FILE_PATH
+          value: '{{outputs.artifacts.ti-artifact.path}}'
+        image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/input-ti.yaml
+        - name: backend
+          path: /tmp/storage-backend.yaml
+      metadata: {}
+      name: mattermost-install-install-db-postgres-install-helm-install-resolve-ti-art-value
+      outputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/output.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: helm-release
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-install-db-postgres-install-helm-install-helm-release
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-install-db-postgres-install-helm-install-helm-release
+          name: helm-release
+          path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{a35a0c04-6153-4fe9-8d49-9ec35a0e86e,/helm-release-storage.yaml}'
+        - name: APP_LOCAL_HUB_ENDPOINT
+          value: http://capact-hub-local.capact-system/graphql
+        - name: APP_PUBLIC_HUB_ENDPOINT
+          value: http://capact-hub-public.capact-system/graphql
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-0-2
+      outputs:
+        artifacts:
+        - globalName: helm-release-storage
+          name: helm-release-storage
+          path: /helm-release-storage.yaml
+    - container:
+        env:
+        - name: APP_LOGGER_DEV_MODE
+          value: "true"
+        - name: APP_INPUT_TI_FILE_PATH
+          value: '{{inputs.artifacts.ti-artifact.path}}'
+        - name: APP_INPUT_BACKEND_TI_FILE_PATH
+          value: '{{inputs.artifacts.backend.path}}'
+        - name: APP_OUTPUT_FILE_PATH
+          value: '{{outputs.artifacts.ti-artifact.path}}'
+        image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/input-ti.yaml
+        - name: backend
+          path: /tmp/storage-backend.yaml
+      metadata: {}
+      name: mattermost-install-install-db-resolve-ti-art-value
+      outputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/output.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: psql-helm-release
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-install-db-psql-helm-release
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-install-db-psql-helm-release
+          name: psql-helm-release
+          path: /typeinstance
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: postgresql
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-install-db-postgresql
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-install-db-postgresql
+          name: postgresql
+          path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2,/helm-template-storage.yaml}'
+        - name: APP_LOCAL_HUB_ENDPOINT
+          value: http://capact-hub-local.capact-system/graphql
+        - name: APP_PUBLIC_HUB_ENDPOINT
+          value: http://capact-hub-public.capact-system/graphql
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-0-1
+      outputs:
+        artifacts:
+        - globalName: helm-template-storage
+          name: helm-template-storage
+          path: /helm-template-storage.yaml
+    - inputs:
+        artifacts:
+        - name: postgresql
+        - name: user-input
+      metadata: {}
+      name: mattermost-install-create-user-main
+      outputs:
+        artifacts:
+        - from: '{{steps.create-user.outputs.artifacts.user}}'
+          name: user
+      steps:
+      - - arguments:
+            artifacts:
+            - name: template
+              raw:
+                data: |
+                  set -e
+                  <% set password = input.password | default(random_word()) %>
+                  export PGPASSWORD=<@ superuser.password @>
+                  PSQL_CMD="psql -h <@host@> -U <@superuser.username@> <@defaultDBName@> -c"
+                  ${PSQL_CMD} "CREATE USER <@ input.name @> WITH PASSWORD '<@ password @>';"
+
+
+                  cat <<EOF > /user.yaml
+                  name: <@ input.name @>
+                  password: <@ password @>
+                  EOF
+                  sync
+            - from: '{{inputs.artifacts.user-input}}'
+              name: input-parameters
+            - name: configuration
+              raw:
+                data: 'prefix: input'
+          name: render-create-user-script
+          template: mattermost-install-create-user-main-render-create-user-script-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.render-create-user-script.outputs.artifacts.render}}'
+              name: template
+            - from: '{{inputs.artifacts.postgresql}}'
+              name: input-parameters
+            - name: configuration
+              raw:
+                data: ""
+          name: fill-db-config-in-user-script
+          template: mattermost-install-create-user-main-fill-db-config-in-user-script-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.fill-db-config-in-user-script.outputs.artifacts.render}}'
+              name: script
+          name: create-user
+          template: mattermost-install-create-user-create-psql-user
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-user.outputs.artifacts.user}}'
+              name: user
+          name: output-user
+          template: output-mattermost-install-create-user-user
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-create-user-main-render-create-user-script-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-create-user-main-fill-db-config-in-user-script-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - container:
+        args:
+        - sleep 1 && chmod +x /script.sh && /script.sh
+        command:
+        - bash
+        - -c
+        image: postgres:11
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: script
+          path: /script.sh
+      metadata: {}
+      name: mattermost-install-create-user-create-psql-user
+      outputs:
+        artifacts:
+        - name: user
+          path: /user.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: user
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-create-user-user
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-create-user-user
+          name: user
+          path: /typeinstance
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-render-create-db-args-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - inputs:
+        artifacts:
+        - name: postgresql
+        - name: database-input
+      metadata: {}
+      name: mattermost-install-create-db-main
+      outputs:
+        artifacts:
+        - from: '{{steps.create-db.outputs.artifacts.database}}'
+          name: database
+      steps:
+      - - arguments:
+            artifacts:
+            - name: template
+              raw:
+                data: |
+                  export PGPASSWORD=<@ superuser.password @>
+                  PSQL_CMD="psql -h <@host@> -U <@superuser.username@> <@defaultDBName@> -c"
+                  ${PSQL_CMD} "CREATE DATABASE <@name@>"
+                  ${PSQL_CMD} "GRANT ALL PRIVILEGES ON DATABASE <@name@> TO <@owner@>"
+
+                  cat <<EOF > /database.yml
+                  name: <@name@>
+                  owner: <@owner@>
+                  tablespace: ""
+                  EOF
+            - from: '{{inputs.artifacts.postgresql}}'
+              name: input-parameters
+          name: render-create-db-script
+          template: mattermost-install-create-db-main-render-create-db-script-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.render-create-db-script.outputs.artifacts.render}}'
+              name: template
+            - from: '{{inputs.artifacts.database-input}}'
+              name: input-parameters
+          name: fill-params-in-create-db-script
+          template: mattermost-install-create-db-main-fill-params-in-create-db-script-template
+      - - arguments:
+            artifacts:
+            - from: '{{steps.fill-params-in-create-db-script.outputs.artifacts.render}}'
+              name: script
+          name: create-db
+          template: mattermost-install-create-db-create-psql-db
+      - - arguments:
+            artifacts:
+            - from: '{{steps.create-db.outputs.artifacts.database}}'
+              name: database
+          name: output-database
+          template: output-mattermost-install-create-db-database
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-create-db-main-render-create-db-script-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-create-db-main-fill-params-in-create-db-script-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - container:
+        args:
+        - sleep 1 && chmod +x /script.sh && /script.sh
+        command:
+        - bash
+        - -c
+        image: postgres:11
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: script
+          path: /script.sh
+      metadata: {}
+      name: mattermost-install-create-db-create-psql-db
+      outputs:
+        artifacts:
+        - name: database
+          path: /database.yml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: database
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-create-db-database
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-create-db-database
+          name: database
+          path: /typeinstance
+    - container:
+        args:
+        - /template.yml
+        - /values.yml
+        - --format=yaml
+        - -o
+        - /render.yml
+        image: ghcr.io/capactio/jinja2:v2.11.2
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: template
+          path: /template.yml
+        - name: input-parameters
+          path: /values.yml
+      metadata: {}
+      name: mattermost-install-create-helm-args-template
+      outputs:
+        artifacts:
+        - name: render
+          path: /render.yml
+    - inputs:
+        artifacts:
+        - name: input-parameters
+        - name: runner-context
+        - name: kubeconfig
+          optional: true
+      metadata: {}
+      name: mattermost-install-helm-install-helm
+      outputs:
+        artifacts:
+        - from: '{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}'
+          name: helm-release
+        - from: '{{steps.helm-install.outputs.artifacts.additional}}'
+          name: additional
+      steps:
+      - - arguments: {}
+          name: inject-input-type-instances-0-3-step
+          template: inject-input-type-instances-0-3
+      - - arguments:
+            artifacts:
+            - from: '{{inputs.artifacts.input-parameters}}'
+              name: input-parameters
+            - from: '{{inputs.artifacts.runner-context}}'
+              name: runner-context
+            - from: '{{inputs.artifacts.kubeconfig}}'
+              name: kubeconfig
+          name: helm-install
+          template: mattermost-install-helm-install-helm-install
+      - - arguments:
+            artifacts:
+            - from: '{{steps.helm-install.outputs.artifacts.helm-release}}'
+              name: ti-artifact
+            - from: '{{workflow.outputs.artifacts.helm-release-storage}}'
+              name: backend
+          name: resolve-helm-rel-value
+          template: mattermost-install-helm-install-resolve-ti-art-value
+      - - arguments:
+            artifacts:
+            - from: '{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}'
+              name: helm-release
+          name: output-helm-release
+          template: output-mattermost-install-helm-install-helm-release
+    - container:
+        env:
+        - name: RUNNER_OPTIONAL_KUBECONFIG_TI
+          value: '{{inputs.artifacts.kubeconfig.path}}'
+        - name: RUNNER_CONTEXT_PATH
+          value: '{{inputs.artifacts.runner-context.path}}'
+        - name: RUNNER_ARGS_PATH
+          value: '{{inputs.artifacts.input-parameters.path}}'
+        - name: RUNNER_LOGGER_DEV_MODE
+          value: "true"
+        - name: RUNNER_COMMAND
+          value: install
+        - name: RUNNER_OUTPUT_HELM_RELEASE_FILE_PATH
+          value: '{{outputs.artifacts.helm-release.path}}'
+        - name: RUNNER_OUTPUT_ADDITIONAL_FILE_PATH
+          value: '{{outputs.artifacts.additional.path}}'
+        image: ghcr.io/capactio/helm-runner:2ada6f8
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      inputs:
+        artifacts:
+        - name: input-parameters
+          path: /runner-args
+        - name: runner-context
+          path: /runner-context
+        - name: kubeconfig
+          optional: true
+          path: /kubeconfig-ti
+      metadata: {}
+      name: mattermost-install-helm-install-helm-install
+      outputs:
+        artifacts:
+        - name: helm-release
+          path: /helm-release.yaml
+        - name: additional
+          optional: true
+          path: /additional.yaml
+      volumes:
+      - emptyDir: {}
+        name: tmp
+    - container:
+        env:
+        - name: APP_LOGGER_DEV_MODE
+          value: "true"
+        - name: APP_INPUT_TI_FILE_PATH
+          value: '{{inputs.artifacts.ti-artifact.path}}'
+        - name: APP_INPUT_BACKEND_TI_FILE_PATH
+          value: '{{inputs.artifacts.backend.path}}'
+        - name: APP_OUTPUT_FILE_PATH
+          value: '{{outputs.artifacts.ti-artifact.path}}'
+        image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/input-ti.yaml
+        - name: backend
+          path: /tmp/storage-backend.yaml
+      metadata: {}
+      name: mattermost-install-helm-install-resolve-ti-art-value
+      outputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/output.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: helm-release
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-install-helm-install-helm-release
+      outputs:
+        artifacts:
+        - globalName: mattermost-install-helm-install-helm-release
+          name: helm-release
+          path: /typeinstance
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{a35a0c04-6153-4fe9-8d49-9ec35a0e86e,/helm-release-storage.yaml}'
+        - name: APP_LOCAL_HUB_ENDPOINT
+          value: http://capact-hub-local.capact-system/graphql
+        - name: APP_PUBLIC_HUB_ENDPOINT
+          value: http://capact-hub-public.capact-system/graphql
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-0-3
+      outputs:
+        artifacts:
+        - globalName: helm-release-storage
+          name: helm-release-storage
+          path: /helm-release-storage.yaml
+    - container:
+        image: ghcr.io/capactio/infra/merger:2ada6f8
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: input-parameters
+          path: /yamls/input.yaml
+        - name: additional-parameters
+          optional: true
+          path: /yamls/additionalinput.yaml
+        - name: psql
+          path: /yamls/psql.yaml
+        - name: db
+          path: /yamls/db.yaml
+        - name: user
+          path: /yamls/user.yaml
+      metadata: {}
+      name: prepare-parameters
+      outputs:
+        artifacts:
+        - name: merged
+          path: /merged.yaml
+    - container:
+        env:
+        - name: APP_LOGGER_DEV_MODE
+          value: "true"
+        - name: APP_INPUT_TI_FILE_PATH
+          value: '{{inputs.artifacts.ti-artifact.path}}'
+        - name: APP_INPUT_BACKEND_TI_FILE_PATH
+          value: '{{inputs.artifacts.backend.path}}'
+        - name: APP_OUTPUT_FILE_PATH
+          value: '{{outputs.artifacts.ti-artifact.path}}'
+        image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/input-ti.yaml
+        - name: backend
+          path: /tmp/storage-backend.yaml
+      metadata: {}
+      name: resolve-ti-art-value
+      outputs:
+        artifacts:
+        - name: ti-artifact
+          path: /tmp/output.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: postgresql
+          path: /typeinstance
+      metadata: {}
+      name: output-postgresql
+      outputs:
+        artifacts:
+        - globalName: postgresql
+          name: postgresql
+          path: /typeinstance
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: database-user
+          path: /typeinstance
+      metadata: {}
+      name: output-database-user
+      outputs:
+        artifacts:
+        - globalName: database-user
+          name: database-user
+          path: /typeinstance
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: database
+          path: /typeinstance
+      metadata: {}
+      name: output-database
+      outputs:
+        artifacts:
+        - globalName: database
+          name: database
+          path: /typeinstance
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: mattermost-helm-release
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-helm-release
+      outputs:
+        artifacts:
+        - globalName: mattermost-helm-release
+          name: mattermost-helm-release
+          path: /typeinstance
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: mattermost-config
+          path: /typeinstance
+      metadata: {}
+      name: output-mattermost-config
+      outputs:
+        artifacts:
+        - globalName: mattermost-config
+          name: mattermost-config
+          path: /typeinstance
+    - inputs: {}
+      metadata: {}
+      name: capact-root
+      outputs: {}
+      steps:
+      - - arguments: {}
+          name: inject-runner-context-step
+          template: inject-runner-context
+      - - arguments: {}
+          name: inject-input-type-instances-0-0-step
+          template: inject-input-type-instances-0-0
+      - - arguments: {}
+          name: populate-input-parameters-step
+          template: populate-input-parameters
+      - - arguments:
+            artifacts:
+            - from: '{{steps.populate-input-parameters-step.outputs.artifacts.input-parameters}}'
+              name: input-parameters
+          name: start-entrypoint
+          template: mattermost-install
+      - - arguments:
+            artifacts:
+            - from: '{{workflow.outputs.artifacts.mattermost-config}}'
+              name: mattermost-config
+            - from: '{{workflow.outputs.artifacts.mattermost-install-install-db-postgresql}}'
+              name: mattermost-install-install-db-postgresql
+            - from: '{{workflow.outputs.artifacts.mattermost-install-install-db-postgres-install-helm-install-helm-release}}'
+              name: mattermost-install-install-db-postgres-install-helm-install-helm-release
+            - from: '{{workflow.outputs.artifacts.mattermost-install-create-user-user}}'
+              name: mattermost-install-create-user-user
+            - from: '{{workflow.outputs.artifacts.mattermost-install-create-db-database}}'
+              name: mattermost-install-create-db-database
+            - from: '{{workflow.outputs.artifacts.mattermost-install-helm-install-helm-release}}'
+              name: mattermost-install-helm-install-helm-release
+            - name: payload
+              raw:
+                data: |
+                  typeInstances:
+                  - alias: mattermost-config
+                    attributes: []
+                    backend:
+                      context: null
+                      id: b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.productivity.mattermost.config
+                      revision: 0.1.0
+                    value: null
+                  - alias: mattermost-install-install-db-postgresql
+                    attributes: []
+                    backend:
+                      context: null
+                      id: b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.database.postgresql.config
+                      revision: 0.1.0
+                    value: null
+                  - alias: mattermost-install-install-db-postgres-install-helm-install-helm-release
+                    attributes: []
+                    backend:
+                      context: null
+                      id: a35a0c04-6153-4fe9-8d49-9ec35a0e86e
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.helm.chart.release
+                      revision: 0.1.0
+                    value: null
+                  - alias: mattermost-install-create-user-user
+                    attributes: []
+                    backend: null
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.database.postgresql.user
+                      revision: 0.1.0
+                    value: null
+                  - alias: mattermost-install-create-db-database
+                    attributes: []
+                    backend: null
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.database.postgresql.database
+                      revision: 0.1.0
+                    value: null
+                  - alias: mattermost-install-helm-install-helm-release
+                    attributes: []
+                    backend:
+                      context: null
+                      id: a35a0c04-6153-4fe9-8d49-9ec35a0e86e
+                    createdBy: owner
+                    typeRef:
+                      path: cap.type.helm.chart.release
+                      revision: 0.1.0
+                    value: null
+                  usesRelations:
+                  - from: mattermost-config
+                    to: mattermost-install-helm-install-helm-release
+                  - from: mattermost-config
+                    to: mattermost-install-install-db-postgresql
+                  - from: mattermost-config
+                    to: mattermost-install-create-db-database
+                  - from: mattermost-config
+                    to: mattermost-install-create-user-user
+                  - from: mattermost-install-install-db-postgresql
+                    to: mattermost-install-install-db-postgres-install-helm-install-helm-release
+                  - from: mattermost-install-create-user-user
+                    to: mattermost-install-install-db-postgresql
+                  - from: mattermost-install-create-db-database
+                    to: mattermost-install-install-db-postgresql
+          name: upload-output-type-instances-step
+          template: upload-output-type-instances
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /input
+          name: user-secret-volume
+      inputs: {}
+      metadata: {}
+      name: populate-input-parameters
+      outputs:
+        artifacts:
+        - name: input-parameters
+          path: /input/input-parameters
+      volumes:
+      - name: user-secret-volume
+        secret:
+          items:
+          - key: parameter-input-parameters
+            path: input-parameters
+          optional: false
+          secretName: user-input
+    - container:
+        env:
+        - name: APP_ACTION
+          value: DownloadAction
+        - name: APP_DOWNLOAD_CONFIG
+          value: '{b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2,/helm-template-storage.yaml}'
+        - name: APP_LOCAL_HUB_ENDPOINT
+          value: http://capact-hub-local.capact-system/graphql
+        - name: APP_PUBLIC_HUB_ENDPOINT
+          value: http://capact-hub-public.capact-system/graphql
+        image: alpine:3.7
+        name: ""
+        resources: {}
+      inputs: {}
+      metadata: {}
+      name: inject-input-type-instances-0-0
+      outputs:
+        artifacts:
+        - globalName: helm-template-storage
+          name: helm-template-storage
+          path: /helm-template-storage.yaml
+    - container:
+        args:
+        - sleep 1
+        command:
+        - sh
+        - -c
+        image: alpine:3.7
+        name: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /input
+          name: runner-context
+          readOnly: true
+      inputs: {}
+      metadata: {}
+      name: inject-runner-context
+      outputs:
+        artifacts:
+        - globalName: runner-context
+          name: runner-context
+          path: /input/context.yaml
+      volumes:
+      - name: runner-context
+        secret:
+          items:
+          - key: key
+            path: context.yaml
+          optional: false
+          secretName: secret
+    - container:
+        env:
+        - name: APP_ACTION
+          value: UploadAction
+        - name: APP_UPLOAD_CONFIG_PAYLOAD_FILEPATH
+          value: /upload/payload
+        - name: APP_UPLOAD_CONFIG_TYPE_INSTANCES_DIR
+          value: /upload/typeInstances
+        - name: APP_LOCAL_HUB_ENDPOINT
+          value: http://capact-hub-local.capact-system/graphql
+        - name: APP_PUBLIC_HUB_ENDPOINT
+          value: http://capact-hub-public.capact-system/graphql
+        image: alpine:3.7
+        imagePullPolicy: IfNotPresent
+        name: ""
+        resources: {}
+      inputs:
+        artifacts:
+        - name: mattermost-config
+          path: /upload/typeInstances/mattermost-config
+        - name: mattermost-install-install-db-postgresql
+          path: /upload/typeInstances/mattermost-install-install-db-postgresql
+        - name: mattermost-install-install-db-postgres-install-helm-install-helm-release
+          path: /upload/typeInstances/mattermost-install-install-db-postgres-install-helm-install-helm-release
+        - name: mattermost-install-create-user-user
+          path: /upload/typeInstances/mattermost-install-create-user-user
+        - name: mattermost-install-create-db-database
+          path: /upload/typeInstances/mattermost-install-create-db-database
+        - name: mattermost-install-helm-install-helm-release
+          path: /upload/typeInstances/mattermost-install-helm-install-helm-release
+        - name: payload
+          path: /upload/payload
+      metadata: {}
+      name: upload-output-type-instances
+      outputs: {}
+runnerInterface: cap.interface.runner.argo.run

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/RDS_installation_with_AWS_SA_and_additional_parameters_injected.golden.yaml
@@ -451,8 +451,8 @@ args:
           name: inject-runner-context-step
           template: inject-runner-context
       - - arguments: {}
-          name: inject-input-type-instances-3-0-step
-          template: inject-input-type-instances-3-0
+          name: inject-input-type-instances-4-0-step
+          template: inject-input-type-instances-4-0
       - - arguments: {}
           name: populate-input-parameters-step
           template: populate-input-parameters
@@ -563,7 +563,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-3-0
+      name: inject-input-type-instances-4-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_ManifestRef.golden.yaml
@@ -118,8 +118,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-7-0-step
-          template: inject-input-type-instances-7-0
+          name: inject-input-type-instances-8-0-step
+          template: inject-input-type-instances-8-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -560,7 +560,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-7-0
+      name: inject-input-type-instances-8-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
+++ b/pkg/sdk/renderer/argo/testdata/TestRenderHappyPathWithCustomPolicies/Workflow_policy_injects_additional_input_-_reference_by_alias.golden.yaml
@@ -118,8 +118,8 @@ args:
           name: rds-instance
       steps:
       - - arguments: {}
-          name: inject-input-type-instances-8-0-step
-          template: inject-input-type-instances-8-0
+          name: inject-input-type-instances-9-0-step
+          template: inject-input-type-instances-9-0
       - - arguments:
             artifacts:
             - from: '{{inputs.artifacts.input-parameters}}'
@@ -560,7 +560,7 @@ args:
         resources: {}
       inputs: {}
       metadata: {}
-      name: inject-input-type-instances-8-0
+      name: inject-input-type-instances-9-0
       outputs:
         artifacts:
         - globalName: aws-credentials

--- a/pkg/sdk/renderer/argo/testdata/hub/implementation/bitnami/postgresql/install-v2.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/implementation/bitnami/postgresql/install-v2.yaml
@@ -1,0 +1,165 @@
+---
+metadata:
+  attributes: []
+  description: Action which installs PostgreSQL database via Helm chart
+  displayName: Install PostgreSQL database
+  documentationURL: https://github.com/bitnami/charts
+  iconURL: https://bitnami.com
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+  name: install
+  path: cap.implementation.bitnami.postgresql.install
+  prefix: cap.implementation.bitnami.postgresql
+  supportURL: https://bitnami.com
+revision: 0.2.0
+spec:
+  additionalInput:
+    typeInstances:
+      - kubeconfig:
+        typeRef:
+          path: cap.type.containerization.kubernetes.kubeconfig
+          revision: 0.1.0
+        verbs: [ "get" ]
+  outputTypeInstanceRelations:
+    - typeInstanceName: postgresql
+      uses: [psql-helm-release]
+  appVersion: "10,11,12,13"
+  implements:
+    - path: cap.interface.database.postgresql.install
+      revision: 0.1.0
+  imports:
+    - alias: helm
+      appVersion:
+      interfaceGroupPath: cap.interface.runner.helm
+      methods:
+        - name: install
+          revision: 0.2.0
+    - alias: jinja2
+      appVersion:
+      interfaceGroupPath: cap.interface.templating.jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - alias: argo
+      appVersion:
+      interfaceGroupPath: cap.interface.runner.argo
+      methods:
+        - name: run
+          revision: 0.1.0
+  requires:
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.type.helm.template.storage
+            revision: 0.1.0
+          alias: helm-template-storage
+          valueConstraints: {}
+      prefix: cap.core.type.hub.storage
+  
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: postgres-install
+        templates:
+          - name: postgres-install
+            inputs:
+              artifacts:
+                - name: input-parameters # Entrypoint template gets the user parameters in 'input-parameters' artifacts.
+                - name: kubeconfig
+                  optional: true
+            outputs:
+              artifacts:
+                - name: postgresql
+                  from: "{{steps.resolve-psql-value.outputs.artifacts.ti-artifact}}"
+            steps:
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "postgresql"
+                              repo: "https://charts.bitnami.com/bitnami"
+                              version: "10.2.6"
+                            values:
+                              volumePermissions:
+                                enabled: true
+                              global:
+                                postgresql:
+                                  postgresqlDatabase: <@ defaultDBName | default('postgres') @>
+                                  postgresqlPassword: <@ superuser.password | default(random_word(length=16)) @>
+                            output:
+                              helmRelease:
+                                useHelmReleaseStorage: true
+                              additional:
+                                useHelmTemplateStorage: true
+                                goTemplate: |
+                                  host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
+                                  port: {{ template "postgresql.port" . }}
+                                  defaultDBName: '{{ template "postgresql.database" . }}'
+                                  superuser:
+                                    # It cannot be changed
+                                    username: 'postgres'
+                                    password: '{{ template "postgresql.password" . }}'
+                      - name: configuration
+                        raw:
+                          data: "unpackValue: true"
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: psql-helm-release
+                      from: helm-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.create-helm-args.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+                      - name: kubeconfig
+                        from: "{{inputs.artifacts.kubeconfig}}"
+                        optional: true
+
+              - - name: resolve-psql-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: postgresql
+                      from: ti-artifact
+                      backend: helm-template-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-template-storage}}"
+
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/input-ti.yaml
+                - name: backend
+                  path: /tmp/storage-backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/output.yaml
+            container:
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"

--- a/pkg/sdk/renderer/argo/testdata/hub/implementation/mattermost/mattermost-team-edition/install-v2.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/implementation/mattermost/mattermost-team-edition/install-v2.yaml
@@ -1,0 +1,535 @@
+ocfVersion: 0.0.1
+revision: 0.2.0
+kind: Implementation
+metadata:
+  path: cap.implementation.mattermost.mattermost-team-edition.install
+  prefix: cap.implementation.mattermost.mattermost-team-edition
+  name: install
+  displayName: Install Mattermost Team Edition
+  description: Action which installs Mattermost Team Edition via Helm chart
+  documentationURL: https://docs.mattermost.com/
+  supportURL: https://docs.mattermost.com/
+  license:
+    name: "Apache 2.0"
+  attributes: []
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  appVersion: "10,11,12,13"
+
+  outputTypeInstanceRelations:
+    - typeInstanceName: mattermost-config
+      uses:
+        - mattermost-helm-release
+        - postgresql
+        - database
+        - database-user
+
+  additionalInput:
+    typeInstances:
+     - name: postgresql
+       typeRef:
+          path: cap.type.database.postgresql.config
+          revision: 0.1.0
+       verbs: ["GET"]
+
+  implements:
+    - path: cap.interface.productivity.mattermost.install
+      revision: 0.1.0
+
+  requires:
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.core.type.platform.kubernetes
+            revision: 0.1.0
+          valueConstraints:
+      prefix: cap.core.type.platform
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.type.helm.template.storage
+            revision: 0.1.0
+          alias: helm-template-storage
+          valueConstraints: {}
+      prefix: cap.core.type.hub.storage
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.helm
+      alias: helm
+      methods:
+        - name: install
+          revision: 0.2.0
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.database.postgresql
+      alias: postgresql
+      methods:
+        - name: install
+          revision: 0.2.0
+        - name: create-db
+          revision: 0.1.0
+        - name: create-user
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: mattermost-install
+        templates:
+          - name: mattermost-install
+            inputs:
+              artifacts:
+                - name: input-parameters
+                - name: postgresql
+                  optional: true
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts:
+                - name: mattermost-config
+                  from: "{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}"
+            steps:
+              # Install DB
+              - - name: install-db
+                  capact-when: postgresql == nil
+                  capact-action: postgresql.install
+                  capact-outputTypeInstances:
+                    - name: postgresql
+                      from: postgresql
+                      backend: helm-template-storage
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        raw:
+                          data: |
+                            superuser:
+                              username: superuser
+                            defaultDBName: postgres
+
+              - - name: create-user
+                  capact-action: postgresql.create-user
+                  capact-outputTypeInstances:
+                    - name: database-user
+                      from: user
+                  arguments:
+                    artifacts:
+                      - name: postgresql
+                        from: "{{steps.install-db.outputs.artifacts.postgresql}}"
+                      - name: input-parameters
+                        raw:
+                          data: |
+                            name: mattermost
+
+              - - name: render-create-db-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        raw:
+                          data: |
+                            name: mattermost
+                            owner: "<@ name @>"
+                      - name: input-parameters
+                        from: "{{steps.create-user.outputs.artifacts.user}}"
+                      - name: configuration
+                        raw:
+                          data: "unpackValue: true"
+
+              - - name: create-db
+                  capact-action: postgresql.create-db
+                  capact-outputTypeInstances:
+                    - name: database
+                      from: database
+                  arguments:
+                    artifacts:
+                      - name: postgresql
+                        from: "{{steps.install-db.outputs.artifacts.postgresql}}"
+                      - name: input-parameters
+                        from: "{{steps.render-create-db-args.outputs.artifacts.render}}"
+
+              - - name: prepare-parameters
+                  template: prepare-parameters
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: additional-parameters
+                        from: "{{inputs.artifacts.additional-parameters}}"
+                        optional: true
+                      - name: psql
+                        from: "{{steps.install-db.outputs.artifacts.postgresql}}"
+                      - name: db
+                        from: "{{steps.create-db.outputs.artifacts.database}}"
+                      - name: user
+                        from: "{{steps.create-user.outputs.artifacts.user}}"
+
+              # Install Mattermost
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "mattermost-team-edition"
+                              repo: "https://helm.mattermost.com"
+                              version: "4.0.0"
+                            values:
+                              image:
+                                repository: <@ additionalinput.image.repository | default('mattermost/mattermost-team-edition') @>
+                                tag: <@ additionalinput.image.tag | default('5.29.0') @>
+                                imagePullPolicy: <@ additionalinput.image.imagePullPolicy | default('IfNotPresent') @>
+                              initContainerImage:
+                                repository: <@ additionalinput.initContainerImage.repository | default('appropriate/curl') @>
+                                tag: <@ additionalinput.initContainerImage.tag | default('latest') @>
+                                imagePullPolicy: <@ additionalinput.initContainerImage.imagePullPolicy | default('IfNotPresent') @>
+                              revisionHistoryLimit: <@ additionalinput.revisionHistoryLimit | default(1) @>
+                              persistence:
+                                data:
+                                  enabled: <@ additionalinput.persistence.data.enabled | default(true) | tojson @>
+                                  size: <@ additionalinput.persistence.data.size | default('10Gi') @>
+                                  accessMode: <@ additionalinput.persistence.data.accessMode | default('ReadWriteOnce') @>
+                                  storageClass: <@ additionalinput.persistence.data.storageClass | default('') @>
+                                plugins:
+                                  enabled: <@ additionalinput.persistence.plugins.enabled | default(true) | tojson @>
+                                  size: <@ additionalinput.persistence.plugins.size | default('1Gi') @>
+                                  accessMode: <@ additionalinput.persistence.plugins.accessMode | default('ReadWriteOnce') @>
+                                  storageClass: <@ additionalinput.persistence.plugins.storageClass | default('') @>
+                              service:
+                                type: <@ additionalinput.service.type | default('ClusterIP') @>
+                                externalPort: <@ additionalinput.service.externalPort | default(8065) @>
+                                internalPort: <@ additionalinput.service.internalPort | default(8065) @>
+                                annotations: <@ additionalinput.service.annotations | default({}) @>
+                                loadBalancerSourceRanges: <@ additionalinput.service.loadBalancerSourceRanges | default([]) @>
+                              ingress:
+                                enabled: <@ additionalinput.ingress.enabled | default(true) | tojson @>
+                                path: <@ additionalinput.ingress.path | default('/') @>
+                                annotations:
+                                  "cert-manager.io/cluster-issuer": letsencrypt
+                                hosts:
+                                  - <@ input.host @>
+                                tls:
+                                  - hosts:
+                                      - <@ input.host @>
+                                    secretName: mattermost-team-edition-tls-<@ random_word(length=5) @>
+                              route:
+                                enabled: <@ additionalinput.route.enabled | default(false) | tojson @>
+                              externalDB:
+                                enabled: true
+                                externalDriverType: "postgres"
+                                externalConnectionString: "postgres://<@ user.name @>:<@ user.password @>@<@ psql.host @>:<@ psql.port @>/<@ db.name @>?sslmode=disable"
+                              mysql:
+                                enabled: false
+                              extraPodAnnotations: <@ additionalinput.extraPodAnnotations | default({}) @>
+                              extraEnvVars: <@ additionalinput.extraEnvVars | default([]) @>
+                              extraInitContainers: <@ additionalinput.extraInitContainers | default([]) @>
+                              extraVolumes: <@ additionalinput.extraVolumes | default([]) @>
+                              extraVolumeMounts: <@ additionalinput.extraVolumeMounts | default([]) @>
+                              nodeSelector: <@ additionalinput.nodeSelector | default({}) @>
+                              affinity: <@ additionalinput.affinity | default({}) @>
+                              affinity: <@ additionalinput.resources | default({}) @>
+                              tolerations: <@ additionalinput.tolerations | default([]) @>
+
+                              configJSON:
+                                ServiceSettings:
+                                  SiteURL: "https://<@ input.host @>"
+                                  LicenseFileLocation: "<@ input.configJSON.ServiceSettings.LicenseFileLocation | default('') @>"
+                                  ListenAddress: "<@ input.configJSON.ServiceSettings.ListenAddress | default(':8065') @>"
+                                  ConnectionSecurity: "<@ input.configJSON.ServiceSettings.ConnectionSecurity | default('') @>"
+                                  TLSCertFile: "<@ input.configJSON.ServiceSettings.TLSCertFile | default('') @>"
+                                  TLSKeyFile: "<@ input.configJSON.ServiceSettings.TLSKeyFile | default('') @>"
+                                  UseLetsEncrypt: <@ input.configJSON.ServiceSettings.UseLetsEncrypt | default(false) | tojson @>
+                                  LetsEncryptCertificateCacheFile: "<@ input.configJSON.ServiceSettings.LetsEncryptCertificateCacheFile | default('./config/letsencrypt.cache') @>"
+                                  Forward80To443: <@ input.configJSON.ServiceSettings.Forward80To443 | default(false) | tojson @>
+                                  ReadTimeout: <@ input.configJSON.ServiceSettings.ReadTimeout | default(300) @>
+                                  WriteTimeout: <@ input.configJSON.ServiceSettings.WriteTimeout | default(300) @>
+                                  MaximumLoginAttempts: <@ input.configJSON.ServiceSettings.MaximumLoginAttempts | default(10) @>
+                                  GoroutineHealthThreshold: <@ input.configJSON.ServiceSettings.GoroutineHealthThreshold | default(-1) @>
+                                  GoogleDeveloperKey: "<@ input.configJSON.ServiceSettings.GoogleDeveloperKey | default('') @>"
+                                  EnableOAuthServiceProvider: <@ input.configJSON.ServiceSettings.EnableOAuthServiceProvider | default(false) | tojson @>
+                                  EnableIncomingWebhooks: <@ input.configJSON.ServiceSettings.EnableIncomingWebhooks | default(true) | tojson @>
+                                  EnableOutgoingWebhooks: <@ input.configJSON.ServiceSettings.EnableOutgoingWebhooks | default(true) | tojson @>
+                                  EnableCommands: <@ input.configJSON.ServiceSettings.EnableCommands | default(true) | tojson @>
+                                  EnableOnlyAdminIntegrations: <@ input.configJSON.ServiceSettings.EnableOnlyAdminIntegrations | default(false) | tojson @>
+                                  EnablePostUsernameOverride: <@ input.configJSON.ServiceSettings.EnablePostUsernameOverride | default(false) | tojson @>
+                                  EnablePostIconOverride: <@ input.configJSON.ServiceSettings.EnablePostIconOverride | default(false) | tojson @>
+                                  EnableBotAccountCreation: <@ input.configJSON.ServiceSettings.EnableBotAccountCreation | default(false) | tojson @>
+                                  EnableUserAccessTokens: <@ input.configJSON.ServiceSettings.EnableUserAccessTokens | default(false) | tojson @>
+                                  EnableLinkPreviews: <@ input.configJSON.ServiceSettings.EnableLinkPreviews | default(false) | tojson @>
+                                  EnableTesting: <@ input.configJSON.ServiceSettings.EnableTesting | default(false) | tojson @>
+                                  EnableDeveloper: <@ input.configJSON.ServiceSettings.EnableDeveloper | default(false) | tojson @>
+                                  EnableSecurityFixAlert: <@ input.configJSON.ServiceSettings.EnableSecurityFixAlert | default(true) | tojson @>
+                                  EnableInsecureOutgoingConnections: <@ input.configJSON.ServiceSettings.EnableInsecureOutgoingConnections | default(false) | tojson @>
+                                  EnableMultifactorAuthentication: <@ input.configJSON.ServiceSettings.EnableMultifactorAuthentication | default(false) | tojson @>
+                                  EnforceMultifactorAuthentication: <@ input.configJSON.ServiceSettings.EnforceMultifactorAuthentication | default(false) | tojson @>
+                                  AllowCorsFrom: "<@ input.configJSON.ServiceSettings.AllowCorsFrom | default('') @>"
+                                  SessionLengthWebInDays: <@ input.configJSON.ServiceSettings.SessionLengthWebInDays | default(30) @>
+                                  SessionLengthMobileInDays: <@ input.configJSON.ServiceSettings.SessionLengthMobileInDays | default(30) @>
+                                  SessionLengthSSOInDays: <@ input.configJSON.ServiceSettings.SessionLengthSSOInDays | default(30) @>
+                                  SessionCacheInMinutes: <@ input.configJSON.ServiceSettings.SessionCacheInMinutes | default(10) @>
+                                  WebsocketSecurePort: <@ input.configJSON.ServiceSettings.WebsocketSecurePort | default(443) @>
+                                  WebsocketPort: <@ input.configJSON.ServiceSettings.WebsocketPort | default(80) @>
+                                  WebserverMode: "<@ input.configJSON.ServiceSettings.WebserverMode | default('gzip') @>"
+                                  EnableCustomEmoji: <@ input.configJSON.ServiceSettings.EnableCustomEmoji | default(false) @>
+                                  RestrictCustomEmojiCreation: "<@ input.configJSON.ServiceSettings.RestrictCustomEmojiCreation | default('all') @>"
+                                  RestrictPostDelete: "<@ input.configJSON.ServiceSettings.RestrictPostDelete | default('all') @>"
+                                  AllowEditPost: "<@ input.configJSON.ServiceSettings.AllowEditPost | default('always') @>"
+                                  PostEditTimeLimit: <@ input.configJSON.ServiceSettings.PostEditTimeLimit | default(300) @>
+                                  TimeBetweenUserTypingUpdatesMilliseconds: <@ input.configJSON.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds | default(5000) @>
+                                  EnablePostSearch: <@ input.configJSON.ServiceSettings.EnablePostSearch | default(true) | tojson @>
+                                  EnableUserTypingMessages: <@ input.configJSON.ServiceSettings.EnableUserTypingMessages | default(true) | tojson @>
+                                  EnableUserStatuses: <@ input.configJSON.ServiceSettings.EnableUserStatuses | default(true) | tojson @>
+                                  ClusterLogTimeoutMilliseconds: <@ input.configJSON.ServiceSettings.ClusterLogTimeoutMilliseconds | default(2000) @>
+                                TeamSettings:
+                                  SiteName: "<@ input.configJSON.TeamSettings.SiteName | default('Mattermost') @>"
+                                  MaxUsersPerTeam: <@ input.configJSON.TeamSettings.MaxUsersPerTeam | default(50000) @>
+                                  EnableTeamCreation: <@ input.configJSON.TeamSettings.EnableTeamCreation | default(true) | tojson @>
+                                  EnableUserCreation: <@ input.configJSON.TeamSettings.EnableUserCreation | default(true) | tojson @>
+                                  EnableOpenServer: <@ input.configJSON.TeamSettings.EnableOpenServer | default(true) | tojson @>
+                                  RestrictCreationToDomains: "<@ input.configJSON.TeamSettings.RestrictCreationToDomains | default('') @>"
+                                  EnableCustomBrand: <@ input.configJSON.TeamSettings.EnableCustomBrand | default(false) | tojson @>
+                                  CustomBrandText: "<@ input.configJSON.TeamSettings.CustomBrandText | default('') @>"
+                                  CustomDescriptionText: "<@ input.configJSON.TeamSettings.CustomDescriptionText | default('') @>"
+                                  RestrictDirectMessage: "<@ input.configJSON.TeamSettings.RestrictDirectMessage | default('any') @>"
+                                  RestrictTeamInvite: "<@ input.configJSON.TeamSettings.RestrictTeamInvite | default('all') @>"
+                                  RestrictPublicChannelManagement: "<@ input.configJSON.TeamSettings.RestrictPublicChannelManagement | default('all') @>"
+                                  RestrictPrivateChannelManagement: "<@ input.configJSON.TeamSettings.RestrictPrivateChannelManagement | default('all') @>"
+                                  RestrictPublicChannelCreation: "<@ input.configJSON.TeamSettings.RestrictPublicChannelCreation | default('all') @>"
+                                  RestrictPrivateChannelCreation: "<@ input.configJSON.TeamSettings.RestrictPrivateChannelCreation | default('all') @>"
+                                  RestrictPublicChannelDeletion: "<@ input.configJSON.TeamSettings.RestrictPublicChannelDeletion | default('all') @>"
+                                  RestrictPrivateChannelDeletion: "<@ input.configJSON.TeamSettings.RestrictPrivateChannelDeletion | default('all') @>"
+                                  RestrictPrivateChannelManageMembers: "<@ input.configJSON.TeamSettings.RestrictPrivateChannelManageMembers | default('all') @>"
+                                  UserStatusAwayTimeout: <@ input.configJSON.TeamSettings.UserStatusAwayTimeout | default(300) @>
+                                  MaxChannelsPerTeam: <@ input.configJSON.TeamSettings.MaxChannelsPerTeam | default(50000) @>
+                                  MaxNotificationsPerChannel: <@ input.configJSON.TeamSettings.MaxNotificationsPerChannel | default(1000) @>
+                                SqlSettings:
+                                  DriverName: "<@ input.configJSON.SqlSettings.DriverName | default('') @>"
+                                  DataSource: "<@ input.configJSON.SqlSettings.DataSource | default('') @>"
+                                  DataSourceReplicas: <@ input.configJSON.SqlSettings.DataSourceReplicas | default([]) @>
+                                  DataSourceSearchReplicas: <@ input.configJSON.SqlSettings.DataSourceSearchReplicas | default([]) @>
+                                  MaxIdleConns: <@ input.configJSON.SqlSettings.MaxIdleConns | default(20) @>
+                                  MaxOpenConns: <@ input.configJSON.SqlSettings.MaxOpenConns | default(35) @>
+                                  Trace: <@ input.configJSON.SqlSettings.Trace | default(false) | tojson @>
+                                  AtRestEncryptKey: "<@ input.configJSON.SqlSettings.AtRestEncryptKey | default('') @>"
+                                  QueryTimeout: <@ input.configJSON.SqlSettings.QueryTimeout | default(30) @>
+                                LogSettings:
+                                  EnableConsole: <@ input.configJSON.LogSettings.EnableConsole | default(true) | tojson @>
+                                  ConsoleLevel: "<@ input.configJSON.LogSettings.ConsoleLevel | default('INFO') @>"
+                                  EnableFile: <@ input.configJSON.LogSettings.EnableFile | default(true) | tojson @>
+                                  FileLevel: "<@ input.configJSON.LogSettings.FileLevel | default('INFO') @>"
+                                  FileFormat: "<@ input.configJSON.LogSettings.FileFormat | default('') @>"
+                                  FileLocation: "<@ input.configJSON.LogSettings.FileLocation | default('') @>"
+                                  EnableWebhookDebugging: <@ input.configJSON.LogSettings.EnableWebhookDebugging | default(true) | tojson @>
+                                  EnableDiagnostics: <@ input.configJSON.LogSettings.EnableDiagnostics | default(true) | tojson @>
+                                PasswordSettings:
+                                  MinimumLength: <@ input.configJSON.PasswordSettings.MinimumLength | default(5) @>
+                                  Lowercase: <@ input.configJSON.PasswordSettings.Lowercase | default(false) | tojson @>
+                                  Number: <@ input.configJSON.PasswordSettings.Number | default(false) | tojson @>
+                                  Uppercase: <@ input.configJSON.PasswordSettings.Uppercase | default(false) | tojson @>
+                                  Symbol: <@ input.configJSON.PasswordSettings.Symbol | default(false) | tojson @>
+                                FileSettings:
+                                  EnableFileAttachments: <@ input.configJSON.FileSettings.EnableFileAttachments | default(true) | tojson @>
+                                  MaxFileSize: <@ input.configJSON.FileSettings.MaxFileSize | default(52428800) @>
+                                  DriverName: "<@ input.configJSON.FileSettings.DriverName | default('local') @>"
+                                  Directory: "<@ input.configJSON.FileSettings.Directory | default('./data/') @>"
+                                  EnablePublicLink: <@ input.configJSON.FileSettings.EnablePublicLink | default(false) | tojson @>
+                                  PublicLinkSalt: "<@ input.configJSON.FileSettings.PublicLinkSalt | default('') @>"
+                                  ThumbnailWidth: <@ input.configJSON.FileSettings.ThumbnailWidth | default(120) @>
+                                  ThumbnailHeight: <@ input.configJSON.FileSettings.ThumbnailHeight | default(100) @>
+                                  PreviewWidth: <@ input.configJSON.FileSettings.PreviewWidth | default(1024) @>
+                                  PreviewHeight: <@ input.configJSON.FileSettings.PreviewHeight | default(0) @>
+                                  ProfileWidth: <@ input.configJSON.FileSettings.ProfileWidth | default(128) @>
+                                  ProfileHeight: <@ input.configJSON.FileSettings.ProfileHeight | default(128) @>
+                                  InitialFont: "<@ input.configJSON.FileSettings.InitialFont | default('luximbi.ttf') @>"
+                                  AmazonS3AccessKeyId: "<@ input.configJSON.FileSettings.AmazonS3AccessKeyId | default('') @>"
+                                  AmazonS3SecretAccessKey: "<@ input.configJSON.FileSettings.AmazonS3SecretAccessKey | default('') @>"
+                                  AmazonS3Bucket: "<@ input.configJSON.FileSettings.AmazonS3Bucket | default('') @>"
+                                  AmazonS3Region: "<@ input.configJSON.FileSettings.AmazonS3Region | default('') @>"
+                                  AmazonS3Endpoint: "<@ input.configJSON.FileSettings.AmazonS3Endpoint | default('s3.amazonaws.com') @>"
+                                  AmazonS3SSL: <@ input.configJSON.FileSettings.AmazonS3SSL | default(false) | tojson @>
+                                  AmazonS3SignV2: <@ input.configJSON.FileSettings.AmazonS3SignV2 | default(false) | tojson @>
+                                EmailSettings:
+                                  EnableSignUpWithEmail: <@ input.configJSON.EmailSettings.EnableSignUpWithEmail | default(true) | tojson @>
+                                  EnableSignInWithEmail: <@ input.configJSON.EmailSettings.EnableSignInWithEmail | default(true) | tojson @>
+                                  EnableSignInWithUsername: <@ input.configJSON.EmailSettings.EnableSignInWithUsername | default(true) | tojson @>
+                                  SendEmailNotifications: <@ input.configJSON.EmailSettings.SendEmailNotifications | default(false) | tojson @>
+                                  RequireEmailVerification: <@ input.configJSON.EmailSettings.RequireEmailVerification | default(false) | tojson @>
+                                  FeedbackName: "<@ input.configJSON.EmailSettings.FeedbackName | default('') @>"
+                                  FeedbackEmail: "<@ input.configJSON.EmailSettings.FeedbackEmail | default('') @>"
+                                  FeedbackOrganization: "<@ input.configJSON.EmailSettings.FeedbackOrganization | default('') @>"
+                                  SMTPUsername: "<@ input.configJSON.EmailSettings.SMTPUsername | default('') @>"
+                                  SMTPPassword: "<@ input.configJSON.EmailSettings.SMTPPassword | default('') @>"
+                                  EnableSMTPAuth: "<@ input.configJSON.EmailSettings.EnableSMTPAuth | default('') @>"
+                                  SMTPServer: "<@ input.configJSON.EmailSettings.SMTPServer | default('') @>"
+                                  SMTPPort: "<@ input.configJSON.EmailSettings.SMTPPort | default('') @>"
+                                  ConnectionSecurity: "<@ input.configJSON.EmailSettings.ConnectionSecurity | default('') @>"
+                                  InviteSalt: "<@ input.configJSON.EmailSettings.InviteSalt | default('') @>"
+                                  SendPushNotifications: <@ input.configJSON.EmailSettings.SendPushNotifications | default(true) | tojson @>
+                                  PushNotificationServer: "<@ input.configJSON.EmailSettings.PushNotificationServer | default('https://push-test.mattermost.com') @>"
+                                  PushNotificationContents: "<@ input.configJSON.EmailSettings.PushNotificationContents | default('generic') @>"
+                                  EnableEmailBatching: <@ input.configJSON.EmailSettings.EnableEmailBatching | default(false) | tojson @>
+                                  EmailBatchingBufferSize: <@ input.configJSON.EmailSettings.EmailBatchingBufferSize | default(256) @>
+                                  EmailBatchingInterval: <@ input.configJSON.EmailSettings.EmailBatchingInterval | default(30) @>
+                                  SkipServerCertificateVerification: <@ input.configJSON.EmailSettings.SkipServerCertificateVerification | default(false) | tojson @>
+                                RateLimitSettings:
+                                  Enable: <@ input.configJSON.RateLimitSettings.Enable | default(false) | tojson @>
+                                  PerSec: <@ input.configJSON.RateLimitSettings.PerSec | default(10) @>
+                                  MaxBurst: <@ input.configJSON.RateLimitSettings.MaxBurst | default(100) @>
+                                  MemoryStoreSize: <@ input.configJSON.RateLimitSettings.MemoryStoreSize | default(10000) @>
+                                  VaryByRemoteAddr: <@ input.configJSON.RateLimitSettings.VaryByRemoteAddr | default(true) | tojson @>
+                                  VaryByHeader: "<@ input.configJSON.RateLimitSettings.VaryByHeader | default('') @>"
+                                PrivacySettings:
+                                  ShowEmailAddress: <@ input.configJSON.PrivacySettings.ShowEmailAddress | default(true) | tojson @>
+                                  ShowFullName: <@ input.configJSON.PrivacySettings.ShowFullName | default(true) | tojson @>
+                                SupportSettings:
+                                  TermsOfServiceLink: "<@ input.configJSON.SupportSettings.TermsOfServiceLink | default('https://about.mattermost.com/default-terms/') @>"
+                                  PrivacyPolicyLink: "<@ input.configJSON.SupportSettings.PrivacyPolicyLink | default('https://about.mattermost.com/default-privacy-policy/') @>"
+                                  AboutLink: "<@ input.configJSON.SupportSettings.AboutLink | default('https://about.mattermost.com/default-about/') @>"
+                                  HelpLink: "<@ input.configJSON.SupportSettings.HelpLink | default('https://about.mattermost.com/default-help/') @>"
+                                  ReportAProblemLink: "<@ input.configJSON.SupportSettings.ReportAProblemLink | default('https://about.mattermost.com/default-report-a-problem/') @>"
+                                  SupportEmail: "<@ input.configJSON.SupportSettings.SupportEmail | default('feedback@mattermost.com') @>"
+                                AnnouncementSettings:
+                                  EnableBanner: <@ input.configJSON.AnnouncementSettings.EnableBanner | default(false) | tojson @>
+                                  BannerText: "<@ input.configJSON.AnnouncementSettings.BannerText | default('') @>"
+                                  BannerColor: "<@ input.configJSON.AnnouncementSettings.BannerColor | default('#f2a93b') @>"
+                                  BannerTextColor: "<@ input.configJSON.AnnouncementSettings.BannerTextColor | default('#333333') @>"
+                                  AllowBannerDismissal: <@ input.configJSON.AnnouncementSettings.AllowBannerDismissal | default(true) | tojson @>
+                                GitLabSettings:
+                                  Enable: <@ input.configJSON.GitLabSettings.Enable | default(false) | tojson @>
+                                  Secret: "<@ input.configJSON.GitLabSettings.Secret | default('') @>"
+                                  Id: "<@ input.configJSON.GitLabSettings.Id | default('') @>"
+                                  Scope: "<@ input.configJSON.GitLabSettings.Scope | default('') @>"
+                                  AuthEndpoint: "<@ input.configJSON.GitLabSettings.AuthEndpoint | default('') @>"
+                                  TokenEndpoint: "<@ input.configJSON.GitLabSettings.TokenEndpoint | default('') @>"
+                                  UserApiEndpoint: "<@ input.configJSON.GitLabSettings.UserApiEndpoint | default('') @>"
+                                LocalizationSettings:
+                                  DefaultServerLocale: "<@ input.configJSON.LocalizationSettings.DefaultServerLocale | default('en') @>"
+                                  DefaultClientLocale: "<@ input.configJSON.LocalizationSettings.DefaultClientLocale | default('en') @>"
+                                  AvailableLocales: "<@ input.configJSON.LocalizationSettings.AvailableLocales | default('') @>"
+                                NativeAppSettings:
+                                  AppDownloadLink: "<@ input.configJSON.NativeAppSettings.AppDownloadLink | default('https://about.mattermost.com/downloads/') @>"
+                                  AndroidAppDownloadLink: "<@ input.configJSON.NativeAppSettings.AndroidAppDownloadLink | default('https://about.mattermost.com/mattermost-android-app/') @>"
+                                  IosAppDownloadLink: "<@ input.configJSON.NativeAppSettings.IosAppDownloadLink | default('https://about.mattermost.com/mattermost-ios-app/') @>"
+                                AnalyticsSettings:
+                                  MaxUsersForStatistics: <@ input.configJSON.AnalyticsSettings.MaxUsersForStatistics | default(2500) @>
+                                WebrtcSettings:
+                                  Enable: <@ input.configJSON.WebrtcSettings.Enable | default(false) | tojson @>
+                                  GatewayWebsocketUrl: "<@ input.configJSON.WebrtcSettings.GatewayWebsocketUrl | default('') @>"
+                                  GatewayAdminUrl: "<@ input.configJSON.WebrtcSettings.GatewayAdminUrl | default('') @>"
+                                  GatewayAdminSecret: "<@ input.configJSON.WebrtcSettings.GatewayAdminSecret | default('') @>"
+                                  StunURI: "<@ input.configJSON.WebrtcSettings.StunURI | default('') @>"
+                                  TurnURI: "<@ input.configJSON.WebrtcSettings.TurnURI | default('') @>"
+                                  TurnUsername: "<@ input.configJSON.WebrtcSettings.TurnUsername | default('') @>"
+                                  TurnSharedKey: "<@ input.configJSON.WebrtcSettings.TurnSharedKey | default('') @>"
+                                DisplaySettings:
+                                  CustomUrlSchemes: <@ input.configJSON.DisplaySettings.CustomUrlSchemes | default([]) @>
+                                  ExperimentalTimezone: <@ input.configJSON.DisplaySettings.ExperimentalTimezone | default(true) | tojson @>
+                                TimezoneSettings:
+                                  SupportedTimezonesPath: "<@ input.configJSON.TimezoneSettings.SupportedTimezonesPath | default('timezones.json') @>"
+                                PluginSettings:
+                                  Enable: <@ input.configJSON.PluginSettings.Enable | default(true) @>
+                                  EnableUploads: <@ input.configJSON.PluginSettings.EnableUploads | default(true) | tojson @>
+                                  Directory: "<@ input.configJSON.PluginSettings.Directory | default('./plugins') @>"
+                                  ClientDirectory: "<@ input.configJSON.PluginSettings.ClientDirectory | default('./client/plugins') @>"
+                                  Plugins: <@ input.configJSON.PluginSettings.Plugins | default({}) @>
+                                  PluginStates: <@ input.configJSON.PluginSettings.PluginStates | default({}) @>
+                            output:
+                              helmRelease:
+                                useHelmReleaseStorage: true
+                              additional:
+                                useHelmTemplateStorage: true  
+                                goTemplate: |
+                                  host: "{{ index .Values.ingress.hosts 0 }}"
+                                  version: "{{ .Values.image.tag }}"
+                      - name: input-parameters
+                        from: "{{steps.prepare-parameters.outputs.artifacts.merged}}"
+                      - name: configuration
+                        raw:
+                          data: "unpackValue: true"
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: mattermost-helm-release
+                      from: helm-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.create-helm-args.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              - - name: resolve-ti-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: mattermost-config
+                      from: ti-artifact
+                      backend: helm-template-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-template-storage}}"
+
+          - name: prepare-parameters
+            inputs:
+              artifacts:
+                - name: input-parameters
+                  path: /yamls/input.yaml
+                - name: additional-parameters
+                  path: /yamls/additionalinput.yaml
+                  optional: true
+                - name: psql
+                  path: /yamls/psql.yaml
+                - name: db
+                  path: /yamls/db.yaml
+                - name: user
+                  path: /yamls/user.yaml
+            container:
+              image: ghcr.io/capactio/infra/merger:2ada6f8
+            outputs:
+              artifacts:
+              - name: merged
+                path: /merged.yaml
+
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/input-ti.yaml
+                - name: backend
+                  path: /tmp/storage-backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/output.yaml
+            container:
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"
+

--- a/pkg/sdk/renderer/argo/testdata/hub/implementation/runner/helm/install-v2.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/implementation/runner/helm/install-v2.yaml
@@ -1,0 +1,169 @@
+metadata:
+  attributes: []
+  description: Install action for Helm Runner
+  displayName: Install
+  documentationURL: https://helm.sh/
+  iconURL:
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+  name: install
+  path: cap.implementation.runner.helm.install
+  prefix: cap.implementation.runner.helm
+  supportURL:
+revision: 0.2.0
+spec:
+  additionalInput:
+    typeInstances:
+      - kubeconfig:
+        typeRef:
+          path: cap.type.containerization.kubernetes.kubeconfig
+          revision: 0.1.0
+        verbs: [ "get" ]
+
+  additionalOutput:
+    typeInstances: []
+  outputTypeInstanceRelations:
+    - typeInstanceName: helm-release
+      uses: []
+  appVersion: 3.x.x
+  implements:
+    - path: cap.core.interface.runner.generic.run
+      revision: 0.1.0
+    - path: cap.interface.runner.helm.install
+      revision: 0.1.0
+  imports:
+    - alias: argo
+      appVersion:
+      interfaceGroupPath: cap.interface.runner.argo
+      methods:
+        - name: run
+          revision: 0.1.0
+  requires:
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.core.type.platform.kubernetes
+            revision: 0.1.0
+          valueConstraints:
+      prefix: cap.core.type.platform
+    - allOf: []
+      anyOf: []
+      oneOf:
+        - typeRef:
+            path: cap.type.helm.release.storage
+            revision: 0.1.0
+          alias: helm-release-storage
+          valueConstraints: {}
+      prefix: cap.core.type.hub.storage
+     
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: helm
+        templates:
+          - name: helm
+            inputs:
+              artifacts:
+                # The input parameters that holds information what should be executed
+                - name: input-parameters
+                - name: runner-context
+                - name: kubeconfig
+                  optional: true
+            outputs:
+              artifacts:
+                - name: helm-release
+                  from: "{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}"
+                - name: additional
+                  from: "{{steps.helm-install.outputs.artifacts.additional}}"
+            steps:
+              - - name: helm-install
+                  template: helm-install
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: runner-context
+                        from: "{{inputs.artifacts.runner-context}}"
+                      - name: kubeconfig
+                        from: "{{inputs.artifacts.kubeconfig}}"
+
+              - - name: resolve-helm-rel-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: helm-release
+                      from: ti-artifact
+                      backend: helm-release-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
+
+          - name: helm-install
+            inputs:
+              artifacts:
+                # The input parameters that holds information what should be executed
+                - name: input-parameters
+                  path: "/runner-args"
+                - name: runner-context
+                  path: "/runner-context"
+                - name: kubeconfig
+                  path: "/kubeconfig-ti"
+                  optional: true
+            outputs:
+              artifacts:
+                - name: helm-release
+                  path: "/helm-release.yaml"
+                - name: additional
+                  path: "/additional.yaml"
+                  optional: true
+            volumes:
+              - name: tmp
+                emptyDir: { }
+            container:
+              image: ghcr.io/capactio/helm-runner:2ada6f8
+              env:
+                - name: RUNNER_OPTIONAL_KUBECONFIG_TI
+                  value: "{{inputs.artifacts.kubeconfig.path}}"
+                - name: RUNNER_CONTEXT_PATH
+                  value: "{{inputs.artifacts.runner-context.path}}"
+                - name: RUNNER_ARGS_PATH
+                  value: "{{inputs.artifacts.input-parameters.path}}"
+                - name: RUNNER_LOGGER_DEV_MODE
+                  value: "true"
+                - name: RUNNER_COMMAND
+                  value: "install"
+                - name: RUNNER_OUTPUT_HELM_RELEASE_FILE_PATH
+                  value: "{{outputs.artifacts.helm-release.path}}"
+                - name: RUNNER_OUTPUT_ADDITIONAL_FILE_PATH
+                  value: "{{outputs.artifacts.additional.path}}"
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/input-ti.yaml
+                - name: backend
+                  path: /tmp/storage-backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/output.yaml
+            container:
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"

--- a/pkg/sdk/renderer/argo/testdata/hub/type/containerization/kubernetes/kubeconfig.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/type/containerization/kubernetes/kubeconfig.yaml
@@ -1,0 +1,33 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: kubeconfig
+  prefix: cap.type.containerization.kubernetes
+  path: cap.type.containerization.kubernetes.kubeconfig
+  displayName: Kubernetes Kubeconfig
+  description: Defines a Kubeconfig
+  supportURL: https://kubernetes.io/
+  documentationURL: https://kubernetes.io/docs/home/
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+spec:
+  jsonSchema: |-
+    {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The schema for Kubernetes Kubeconfig",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "$id": "#/properties/config",
+            "type": "string",
+            "title": "contains Kubernetes Kubeconfig"
+          }
+        },
+        "additionalProperties": false
+      }

--- a/pkg/sdk/renderer/argo/testdata/hub/type/core/storage/neo4j.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/type/core/storage/neo4j.yaml
@@ -1,0 +1,39 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: neo4j
+  prefix: cap.core.type.hub.storage
+  path: cap.core.type.hub.storage.neo4j
+  displayName: Built-in Local Hub storage
+  description: Built-in Local Hub storage in which static data can be stored.
+  documentationURL: https://capact.io/docs
+  supportURL: https://capact.io
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+spec:
+  jsonSchema: |-
+      {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The root schema for built-in Local Hub storage",
+        "required": [
+          "acceptValue",
+          "contextSchema"
+        ],
+        "properties": {
+          "contextSchema": {
+            "$id": "#/properties/contextSchema",
+            "type": "null",
+            "const": null
+          },
+          "acceptValue": {
+            "$id": "#/properties/acceptValue",
+            "type": "boolean",
+            "const": true
+          }
+        },
+        "additionalProperties": false
+      }

--- a/pkg/sdk/renderer/argo/testdata/hub/type/helm/release/storage.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/type/helm/release/storage.yaml
@@ -1,0 +1,79 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: storage
+  prefix: cap.type.helm.release
+  path: cap.type.helm.release.storage
+  displayName: Helm release chart storage
+  description: Describes Helm storage
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  additionalRefs:
+    - cap.core.type.hub.storage
+  jsonSchema: |- 
+    {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The root schema",
+        "required": [
+          "url",
+          "contextSchema",
+          "acceptValue"
+        ],
+        "properties": {
+          "url": {
+            "$id": "#/properties/url",
+            "type": "string",
+            "format": "uri"
+          },
+          "contextSchema": {
+            "const":{
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "required": [
+                "name",
+                "namespace",
+                "chartLocation"
+              ],
+              "properties": {
+                "name": {
+                  "$id": "#/properties/context/properties/name",
+                  "type": "string"
+                },
+                "namespace": {
+                  "$id": "#/properties/context/properties/namespace",
+                  "type": "string"
+                },
+                "chartLocation": {
+                  "$id": "#/properties/context/properties/chartLocation",
+                  "type": "string"
+                },
+                "driver": {
+                  "$id": "#/properties/context/properties/driver",
+                  "type": "string",
+                  "default": "secrets",
+                  "enum": [
+                    "secrets",
+                    "configmaps",
+                    "sql"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "acceptValue": {
+            "$id": "#/properties/acceptValue",
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "additionalProperties": false
+      }

--- a/pkg/sdk/renderer/argo/testdata/hub/type/helm/template/storage.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/type/helm/template/storage.yaml
@@ -1,0 +1,89 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: storage
+  prefix: cap.type.helm.template
+  path: cap.type.helm.template.storage
+  displayName: Helm template chart storage
+  description: Describes Helm template storage
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  additionalRefs:
+    - cap.core.type.hub.storage
+  jsonSchema: |-
+      {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The root schema",
+        "required": [
+          "url",
+          "contextSchema",
+          "acceptValue"
+        ],
+        "properties": {
+          "url": {
+            "$id": "#/properties/url",
+            "type": "string",
+            "format": "uri"
+          },
+          "contextSchema": {
+            "const": {
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "required": [
+                "goTemplate",
+                "release"
+              ],
+              "properties": {
+                "goTemplate": {
+                  "$id": "#/properties/context/properties/goTemplate",
+                  "type": "string"
+                },
+                "release": {
+                  "required": [
+                    "name",
+                    "namespace"
+                  ],
+                  "$id": "#/properties/context/properties/release",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "$id": "#/properties/context/properties/release/properties/name",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "$id": "#/properties/context/properties/release/properties/namespace",
+                      "type": "string"
+                    },
+                    "driver": {
+                      "$id": "#/properties/context/properties/release/properties/driver",
+                      "type": "string",
+                      "default": "secrets",
+                      "enum": [
+                        "secrets",
+                        "configmaps",
+                        "sql"
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "acceptValue": {
+            "$id": "#/properties/acceptValue",
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "additionalProperties": false
+      }

--- a/pkg/sdk/renderer/argo/testdata/hub/typeinstance/helm-release-storage.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/typeinstance/helm-release-storage.yaml
@@ -1,0 +1,21 @@
+---
+id: a35a0c04-6153-4fe9-8d49-9ec35a0e86e
+backend:
+    abstract: true
+    id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+typeRef:
+  path: cap.type.helm.release.storage
+  revision: 0.1.0
+latestResourceVersion:
+  resourceVersion: 1
+  spec:
+    backend:
+      context: null
+    instrumentation: null
+    value:
+      chart:
+        name: helm-storage-backend
+        repo: https://storage.googleapis.com/capactio-latest-charts
+        version: 0.6.0-2ada6f8
+      name: helm-storage-backend-1650977049
+      namespace: capact-system

--- a/pkg/sdk/renderer/argo/testdata/hub/typeinstance/helm-template-storage.yaml
+++ b/pkg/sdk/renderer/argo/testdata/hub/typeinstance/helm-template-storage.yaml
@@ -1,0 +1,21 @@
+---
+id: b1fcdf4c-f3e3-4b90-ba37-f8ca40c620e2
+backend:
+    abstract: true
+    id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+typeRef:
+  path: cap.type.helm.template.storage
+  revision: 0.1.0
+latestResourceVersion:
+  resourceVersion: 1
+  spec:
+    backend:
+      context: null
+    instrumentation: null
+    value:
+      chart:
+        name: helm-storage-backend
+        repo: https://storage.googleapis.com/capactio-latest-charts
+        version: 0.6.0-2ada6f8
+      name: helm-storage-backend-1650977049
+      namespace: capact-system


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- fix storage backend ID for TypeInstance from nested workflow

There was incorrect backend mapping - we find it by the name of output Type Instance relation which is ok where there is no nested workflow. In the nested workflow, we need to find it by the name of the artifact.

## Testing

1. Checkout this PR
2. Create cluster using `DISABLE_MONITORING_INSTALLATION=true USE_TEST_SETUP=true make dev-cluster`
3. Change manifests source to my branch with no backend for psql:
```
kubectl set env deploy/capact-hub-public -n capact-system -c hub-public-populator MANIFESTS_SOURCES="github.com/mkuziemko/hub-manifests?ref=lost_bid"
```
4. Install Helm Storage and [Mattermost](https://capact.io/docs/example/mattermost-installation/)
5. Verify uploaded TypeInstaces. 

## Related issue(s)
- https://github.com/capactio/capact/issues/705
