### PR TITLE
Add support for ctx update and attach id for downloaded TypeInstance

### DIFF
--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -50,7 +50,7 @@ readonly CAPACT_USE_TEST_SETUP="false"
 #
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/capactio/hub-manifests"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/mszostok/os-hub-manifests"
 # The git ref to checkout. It can point to a commit SHA, a branch name, or a tag.
 # If you want to use your forked version, remember to update CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL  respectively.
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="main"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="test-download-id"

--- a/hack/lib/const.sh
+++ b/hack/lib/const.sh
@@ -50,7 +50,7 @@ readonly CAPACT_USE_TEST_SETUP="false"
 #
 
 readonly CAPACT_INCREASE_RESOURCE_LIMITS="true"
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/mszostok/os-hub-manifests"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL="github.com/capactio/hub-manifests"
 # The git ref to checkout. It can point to a commit SHA, a branch name, or a tag.
 # If you want to use your forked version, remember to update CAPACT_HUB_MANIFESTS_SOURCE_REPO_URL  respectively.
-readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="test-download-id"
+readonly CAPACT_HUB_MANIFESTS_SOURCE_REPO_REF="main"

--- a/hub-js/src/local/resolver/mutation/update-type-instances.ts
+++ b/hub-js/src/local/resolver/mutation/update-type-instances.ts
@@ -89,6 +89,10 @@ export async function updateTypeInstances(
         );
         externallyStored.push(out.rollbackInput);
 
+        if (!out.newContext) {
+          continue;
+        }
+
         logger.debug("Backend contexts was changed by external backend", {
           id: item.id,
           oldContext: item.typeInstance.backend?.context,

--- a/hub-js/src/local/storage/service.ts
+++ b/hub-js/src/local/storage/service.ts
@@ -180,7 +180,9 @@ export default class DelegatedStorageService {
    * @param inputs - Describes what should be updated.
    *
    */
-  async Update(...inputs: UpdateInput[]) {
+  async Update(...inputs: UpdateInput[]): Promise<UpdatedContexts> {
+    let mapping: UpdatedContexts = {};
+
     for (const input of inputs) {
       logger.debug("Updating TypeInstance in external backend", {
         typeInstanceId: input.typeInstance.id,
@@ -202,8 +204,19 @@ export default class DelegatedStorageService {
         ownerId: input.typeInstance.ownerID,
       };
 
-      await backend.client.onUpdate(req);
+      const res = await backend.client.onUpdate(req);
+      if (!res.context) {
+        continue;
+      }
+
+      const updateCtx = JSON.parse(res.context.toString());
+      mapping = {
+        ...mapping,
+        [input.typeInstance.id]: updateCtx,
+      };
     }
+
+    return mapping;
   }
 
   /**

--- a/pkg/argo-actions/download_type_instances.go
+++ b/pkg/argo-actions/download_type_instances.go
@@ -55,7 +55,7 @@ func NewDownloadAction(log *zap.Logger, client *hubclient.Client, cfg []Download
 func (d *Download) Do(ctx context.Context) error {
 	for _, config := range d.cfg {
 		d.log.Info("Downloading TypeInstance", zap.String("ID", config.ID), zap.String("Path", config.Path))
-		typeInstance, err := d.client.FindTypeInstance(ctx, config.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields))
+		typeInstance, err := d.client.FindTypeInstance(ctx, config.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields|local.TypeInstanceRootFields))
 		if err != nil {
 			return err
 		}

--- a/pkg/argo-actions/download_type_instances.go
+++ b/pkg/argo-actions/download_type_instances.go
@@ -55,7 +55,7 @@ func NewDownloadAction(log *zap.Logger, client *hubclient.Client, cfg []Download
 func (d *Download) Do(ctx context.Context) error {
 	for _, config := range d.cfg {
 		d.log.Info("Downloading TypeInstance", zap.String("ID", config.ID), zap.String("Path", config.Path))
-		typeInstance, err := d.client.FindTypeInstance(ctx, config.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields|local.TypeInstanceRootFields))
+		typeInstance, err := d.client.FindTypeInstance(ctx, config.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields))
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func (d *Download) Do(ctx context.Context) error {
 		}
 
 		typeInstanceData := DownloadTypeInstanceData{
-			ID:    typeInstance.ID,
+			ID:    config.ID,
 			Value: typeInstance.LatestResourceVersion.Spec.Value,
 		}
 

--- a/pkg/argo-actions/download_type_instances.go
+++ b/pkg/argo-actions/download_type_instances.go
@@ -32,6 +32,7 @@ type Download struct {
 
 // DownloadTypeInstanceData represents the TypeInstance data to download.
 type DownloadTypeInstanceData struct {
+	ID      string      `json:"id"`
 	Value   interface{} `json:"value"`
 	Backend *Backend    `json:"backend,omitempty"`
 }
@@ -63,6 +64,7 @@ func (d *Download) Do(ctx context.Context) error {
 		}
 
 		typeInstanceData := DownloadTypeInstanceData{
+			ID:    typeInstance.ID,
 			Value: typeInstance.LatestResourceVersion.Spec.Value,
 		}
 

--- a/pkg/argo-actions/update_type_instances.go
+++ b/pkg/argo-actions/update_type_instances.go
@@ -12,12 +12,13 @@ import (
 
 	"capact.io/capact/pkg/hub/client/local"
 
-	graphqllocal "capact.io/capact/pkg/hub/api/graphql/local"
-	hubclient "capact.io/capact/pkg/hub/client"
-	"capact.io/capact/pkg/sdk/validation"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"sigs.k8s.io/yaml"
+
+	graphqllocal "capact.io/capact/pkg/hub/api/graphql/local"
+	hubclient "capact.io/capact/pkg/hub/client"
+	"capact.io/capact/pkg/sdk/validation"
 )
 
 // UpdateAction represents the update TypeInstancess action.
@@ -176,14 +177,16 @@ func (u *Update) render(payload []graphqllocal.UpdateTypeInstancesInput, values 
 			return errors.Wrap(err, "while marshaling TypeInstance")
 		}
 
-		unmarshalledTIValue := graphqllocal.UpdateTypeInstanceInput{}
+		unmarshalledTIValue := UploadTypeInstanceData{}
 		err = json.Unmarshal(data, &unmarshalledTIValue)
 		if err != nil {
 			return errors.Wrap(err, "while unmarshaling TypeInstance")
 		}
 
 		if unmarshalledTIValue.Backend != nil {
-			typeInstance.TypeInstance.Backend = unmarshalledTIValue.Backend
+			typeInstance.TypeInstance.Backend = &graphqllocal.UpdateTypeInstanceBackendInput{
+				Context: unmarshalledTIValue.Backend.Context,
+			}
 		}
 
 		includeValue, err := shouldIncludeValue(typeInstance)

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -166,10 +166,12 @@ var _ = Describe("Action", func() {
 			latestRevUpdateTI, err := hubClient.FindTypeInstance(ctx, updateTI2.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateTI).ToNot(BeNil())
-			Expect(latestRevUpdateTI.LatestResourceVersion.Spec.Value).Should(Equal(map[string]interface{}{
-				"key":                    implIndicatorValue,
-				"downloadTypeInstanceId": updateTI2.ID, // proves that the download step inject also TI id.
-			}))
+			Expect(latestRevUpdateTI.LatestResourceVersion.Spec.Value).Should(HaveKeyWithValue(
+				"key", implIndicatorValue,
+			))
+			Expect(latestRevUpdateTI.LatestResourceVersion.Spec.Value).Should(HaveKeyWithValue(
+				"downloadTypeInstanceId", updateTI2.ID, // proves that the download step inject also TI id.
+			))
 		})
 
 		It("should pick Implementation B based on Policy rule", func() {

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -166,10 +166,9 @@ var _ = Describe("Action", func() {
 			latestRevUpdateTI, err := hubClient.FindTypeInstance(ctx, updateTI2.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateTI).ToNot(BeNil())
-			fmt.Println(latestRevUpdateTI.LatestResourceVersion.Spec.Value)
 			Expect(latestRevUpdateTI.LatestResourceVersion.Spec.Value).Should(Equal(map[string]interface{}{
-				"key": implIndicatorValue,
-				"id":  updateTI2.ID, // proves that the download step inject also TI id.
+				"key":                    implIndicatorValue,
+				"downloadTypeInstanceId": updateTI2.ID, // proves that the download step inject also TI id.
 			}))
 		})
 

--- a/test/e2e/action_test.go
+++ b/test/e2e/action_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,6 +18,7 @@ import (
 	hublocalgraphql "capact.io/capact/pkg/hub/api/graphql/local"
 	hubclient "capact.io/capact/pkg/hub/client"
 	"capact.io/capact/pkg/hub/client/local"
+	"capact.io/capact/pkg/sdk/apis/0.0.1/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -161,6 +161,16 @@ var _ = Describe("Action", func() {
 			updateTIOutput := mapToOutputTypeInstanceDetails(updateTI2, expUploadTIBackend)
 			uploadedTIOutput = mapToOutputTypeInstanceDetails(uploadedTI2, expUploadTIBackend)
 			assertOutputTypeInstancesInActionStatus(ctx, engineClient, action.Name, And(ContainElements(updateTIOutput, uploadedTIOutput), HaveLen(2)))
+
+			By("9.3 Update TypeInstance has ID field")
+			latestRevUpdateTI, err := hubClient.FindTypeInstance(ctx, updateTI2.ID, local.WithFields(local.TypeInstanceLatestResourceVersionFields))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateTI).ToNot(BeNil())
+			fmt.Println(latestRevUpdateTI.LatestResourceVersion.Spec.Value)
+			Expect(latestRevUpdateTI.LatestResourceVersion.Spec.Value).Should(Equal(map[string]interface{}{
+				"key": implIndicatorValue,
+				"id":  updateTI2.ID, // proves that the download step inject also TI id.
+			}))
 		})
 
 		It("should pick Implementation B based on Policy rule", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,9 +6,10 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/machinebox/graphql"
 	"testing"
 	"time"
+
+	"github.com/machinebox/graphql"
 
 	enginegraphql "capact.io/capact/pkg/engine/api/graphql"
 	engineclient "capact.io/capact/pkg/engine/client"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add support for ctx update
- Attach id for downloaded TypeInstance
    ```yaml
    backend:
      context:
        provider: dotenv
    id: 60b65fe1-df56-4552-8f67-aa2a86452bd0 # new field
    value:
      key: Implementation A
    ```
    You can use it later to render other TypeInstance:
    ```yaml
    - - name: render-ti
        capact-action: jinja2.template
        arguments:
          artifacts:
            - name: template
              raw:
                data: |
                  backend:
                    context:
                      repositoryDetails:
                        typeInstanceID:  "<@ id @>"
                      write:
                        strategy: merge
                        fileMapping:
                           foo: bar 
            - name: input-parameters
              from: "{{workflow.outputs.artifacts.repo}}"
            - name: configuration
              raw:
                data: ""
    ```
## Testing

### Passing TypeInstance ID

The e2e test proves that it works. 

### Update context

1. Patch backend to simulate update context:
    ```bash
    cat <<EOF | git apply -
    diff --git a/internal/secret-storage-backend/server.go b/internal/secret-storage-backend/server.go
    index d4f171b9..2edf3054 100644
    --- a/internal/secret-storage-backend/server.go
    +++ b/internal/secret-storage-backend/server.go
    @@ -183,7 +183,9 @@ func (h *Handler) OnUpdate(_ context.Context, request *pb.OnUpdateValueAndContex
 		    return nil, err
 	    }
    
    -	return &pb.OnUpdateResponse{}, nil
    +	return &pb.OnUpdateResponse{
    +		Context: []byte("{\"updatekey\": \"updateVal2\"}"),
    +	}, nil
     }
    
     // OnLock handles TypeInstance locking by setting a secret entry in a given provider.
    
    EOF
    ```

2. Run Backend:
    ```bash
    APP_SUPPORTED_PROVIDERS=dotenv APP_LOGGER_DEV_MODE=true go run ./cmd/secret-storage-backend/main.go
    ```

3. Run Local Hub:
    ```bash
    APP_LOGGER_LEVEL="debug" APP_NEO4J_ENDPOINT=bolt://localhost:7687 APP_NEO4J_PASSWORD=okon APP_HUB_MODE=local npm run dev
    ```

4. Create `dotenv` backend:
    ```bash
    cat > /tmp/dotenv-ti.yaml << ENDOFFILE
    typeInstances:
      - alias: aws-backend
        typeRef:
          path: cap.type.aws.secrets-manager.storage
          revision: 0.1.0
        value:
          url: "localhost:50051"
          acceptValue: true
          contextSchema: {
            "type": "object",
            "additionalProperties": true
          }
    ENDOFFILE
    capact typeinstance create -f /tmp/dotenv-ti.yaml -ojson
    ```

5. Create TypeInstance:
    ```graphql
    mutation CreateTypeInstancesWithCtxEmpty {
	    createTypeInstances(
		    in: {
			    typeInstances: [
				    {
					    alias: "static-data"
					    typeRef: { path: "cap.type.static.data", revision: "0.1.0" }
					    value: { key: "test" }
					    backend: { id: <backend_id_from_previous_step> }
				    }
			    ]
			    usesRelations: []
		    }
	    ) {
		    id
		    alias
	    }
    }
    ```

6. Update TypeInstance:
    ```graphql
    mutation UpdateData($typeInstanceID: ID!) {
	    updateTypeInstances(
		    in: [
			    { id: $typeInstanceID, typeInstance: { value: { name: "update v4" } } }
		    ]
	    ) {
		    ...TypeInstance
	    }
    }
    
    fragment TypeInstance on TypeInstance {
	    id
	    createdAt {
		    formatted
	    }
	    typeRef {
		    path
		    revision
	    }
	    lockedBy
	    backend {
		    id
		    abstract
	    }
    
	    latestResourceVersion {
		    ...TypeInstanceResourceVersion
	    }
    }
    
    fragment TypeInstanceResourceVersion on TypeInstanceResourceVersion {
	    resourceVersion
	    createdBy
	    metadata {
		    attributes {
			    path
			    revision
		    }
	    }
	    spec {
		    value
		    backend {
			    context
		    }
	    }
    }
    ```
    
    Variable:
    ```json
    {
	    "typeInstanceID": "ac3b5dfa-d7e6-4579-a5f5-9ae2fe0b22b6"
    }
    ```

## Related issue(s)


- Fix https://github.com/capactio/capact/issues/709