### PR TITLE
Do not compress darwin arm64 binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,11 +29,9 @@ builds:
       - goos: windows
         goarch: arm64
     hooks: &build-hooks
-      # Install upx first, https://github.com/upx/upx/releases
-      # Do not compress darwin arm64 binary as it causes upx to output broken file
-      post: sh -c 'if ! ( grep -q "darwin" <<< "{{ .Path }}" && grep -q "arm64" <<< "{{ .Path }}" ); then upx -9 "{{ .Path }}"; fi'
+      post: ./hack/compress-release-binary.sh {{ .Path }}
     main: ./cmd/cli
-    binary: 'capact'
+    binary: "capact"
     ldflags:
       - -s -w -X  capact.io/capact/cmd/cli/cmd.Version={{.Version}} -X  capact.io/capact/cmd/cli/cmd.Revision={{.ShortCommit}} -X capact.io/capact/cmd/cli/cmd.BuildDate={{.Date}} -X capact.io/capact/cmd/cli/cmd.Branch={{.Branch}}
 
@@ -45,25 +43,25 @@ builds:
     ignore: *build-ignore
     hooks: *build-hooks
     main: ./cmd/populator
-    binary: 'populator'
+    binary: "populator"
 
 archives:
   - id: capact-archive
-    name_template: &archives-name-template '{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    name_template: &archives-name-template "{{ .Binary }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     format: &archives-format binary
     builds:
-    - capact
+      - capact
 
   - id: populator-archive
     name_template: *archives-name-template
     format: *archives-format
     builds:
-    - populator
+      - populator
 
 brews:
   - name: capact
     ids:
-    - capact-archive
+      - capact-archive
     homepage: &homebrew-homepage https://github.com/capactio/homebrew-tap
     description: "Capact CLI is a command-line tool, which manages Capact resources."
     license: "Apache License 2.0"
@@ -71,14 +69,14 @@ brews:
       owner: capactio
       name: homebrew-tap
     commit_author: &homebrew-commit-author
-        name: Capact Bot
-        email: capactbot@capact.io
+      name: Capact Bot
+      email: capactbot@capact.io
     test: |
       system "#{bin}/capact version"
 
   - name: populator
     ids:
-    - populator-archive
+      - populator-archive
     homepage: *homebrew-homepage
     description: "Populator is a command-line tool, which helps to populate various Capact content."
     license: "Apache License 2.0"
@@ -98,7 +96,7 @@ dockers:
       - "ghcr.io/capactio/tools/capact-cli:v{{ .Major }}"
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"
@@ -107,8 +105,8 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 dist: bin
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,8 @@ builds:
         goarch: arm64
     hooks: &build-hooks
       # Install upx first, https://github.com/upx/upx/releases
-      post: upx -9 "{{ .Path }}"
+      # Do not compress darwin arm64 binary as it causes upx to output broken file
+      post: sh -c 'if ! ( grep -q "darwin" <<< "{{ .Path }}" && grep -q "arm64" <<< "{{ .Path }}" ); then upx -9 "{{ .Path }}"; fi'
     main: ./cmd/cli
     binary: 'capact'
     ldflags:

--- a/hack/compress-release-binary.sh
+++ b/hack/compress-release-binary.sh
@@ -14,15 +14,15 @@ main() {
     number_of_arguments=$1
     file_path=$2
 
-    if [[ $number_of_arguments < 1 ]]; then
+    if [[ $number_of_arguments -lt 1 ]]; then
         echo "Path to the binary file not provided"
         exit 1
     fi
 
     # Do not compress darwin arm64 binary as it causes UPX to output broken file
-    if ! ( grep -q "darwin" <<< $file_path && grep -q "arm64" <<< $file_path ); then 
-        upx -9 $file_path
+    if ! ( grep -q "darwin" <<< "$file_path" && grep -q "arm64" <<< "$file_path" ); then 
+        upx -9 "$file_path"
     fi
 }
 
-main $# ${1:-""}
+main $# "${1:-""}"

--- a/hack/compress-release-binary.sh
+++ b/hack/compress-release-binary.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This script compresses binary file built by goreleaser.
+#
+# Requires passing path to the binary file as an argument.
+# Requires UPX to be installed.
+
+# standard bash error handling
+set -o nounset # treat unset variables as an error and exit immediately.
+set -o errexit # exit immediately when a command fails.
+set -E         # needs to be set if we want the ERR trap
+
+main() {
+    number_of_arguments=$1
+    file_path=$2
+
+    if [[ $number_of_arguments < 1 ]]; then
+        echo "Path to the binary file not provided"
+        exit 1
+    fi
+
+    # Do not compress darwin arm64 binary as it causes UPX to output broken file
+    if ! ( grep -q "darwin" <<< $file_path && grep -q "arm64" <<< $file_path ); then 
+        upx -9 $file_path
+    fi
+}
+
+main $# ${1:-""}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add new hack script responsible for compressing binary file built by goreleaser
- It's logic prevents compressing darwin arm64 binary as it causes UPX to create broken file
- Use this script in goreleaser config file as post build hook

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

- Resolves #710 
