### PR TITLE
Add act logs command

### DIFF
--- a/cmd/cli/cmd/action/action.go
+++ b/cmd/cli/cmd/action/action.go
@@ -42,6 +42,7 @@ func NewCmd() *cobra.Command {
 		NewGet(),
 		NewWatch(),
 		NewWait(),
+		NewLogs(),
 	)
 	return root
 }

--- a/cmd/cli/cmd/action/logs.go
+++ b/cmd/cli/cmd/action/logs.go
@@ -1,0 +1,50 @@
+package action
+
+import (
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+
+	"capact.io/capact/internal/cli"
+	"capact.io/capact/internal/cli/heredoc"
+
+	"github.com/spf13/cobra"
+)
+
+// NewLogs returns a new cobra.Command for getting Action's logs.
+// TODO: this should be done via Gateway once the subscription is implemented.
+func NewLogs() *cobra.Command {
+	cmd := commands.NewLogsCommand()
+	cmd.Use = "logs ACTION [POD]"
+	cmd.Short = "Print the Action's logs"
+	cmd.Long = heredoc.Doc(`
+    Print the Action's logs
+
+    NOTE:   An action needs to be created and run in order to run this command.
+            This command calls the Kubernetes API directly. As a result, KUBECONFIG has to be configured
+            with the same cluster as the one which the Gateway points to.`)
+
+	cmd.Example = heredoc.WithCLIName(`
+			# Print the logs of an Action:
+			<cli> logs example
+
+			# Follow the logs of an Action:
+			<cli> logs example --follow
+
+			# Print the logs of single container in a pod
+			<cli> logs example step-pod -c step-pod-container
+
+			# Print the logs of an Action's step:
+			<cli> logs example step-pod
+
+			# Print the logs of the latest executed Action:
+			<cli> logs @latest
+		`, cli.Name)
+
+	client.AddKubectlFlagsToCmd(cmd)
+
+	for _, hide := range argoHiddenFlags {
+		_ = cmd.PersistentFlags().MarkHidden(hide)
+	}
+
+	return cmd
+}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -74,7 +74,7 @@ func NewRoot() *cobra.Command {
 		},
 	}
 
-	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Path to the YAML config file")
+	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "C", "", "Path to the YAML config file")
 	cli.RegisterVerboseModeFlag(rootCmd.PersistentFlags())
 
 	rootCmd.AddCommand(

--- a/cmd/cli/docs/capact.md
+++ b/cmd/cli/docs/capact.md
@@ -51,7 +51,7 @@ capact [flags]
 ### Options
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -h, --help                          help for capact
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```

--- a/cmd/cli/docs/capact_action.md
+++ b/cmd/cli/docs/capact_action.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with target Actions
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 
@@ -25,6 +25,7 @@ This command consists of multiple subcommands to interact with target Actions
 * [capact action create](capact_action_create.md)	 - Creates/renders a new Action with a specified Interface
 * [capact action delete](capact_action_delete.md)	 - Deletes the Action
 * [capact action get](capact_action_get.md)	 - Displays one or multiple Actions
+* [capact action logs](capact_action_logs.md)	 - Print the Action's logs
 * [capact action run](capact_action_run.md)	 - Queues up a specified Action for processing by the workflow engine
 * [capact action wait](capact_action_wait.md)	 - Wait for a specific condition of a given Action
 * [capact action watch](capact_action_watch.md)	 - Watch an Action until it has completed execution

--- a/cmd/cli/docs/capact_action_create.md
+++ b/cmd/cli/docs/capact_action_create.md
@@ -31,7 +31,7 @@ capact action create INTERFACE [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_action_delete.md
+++ b/cmd/cli/docs/capact_action_delete.md
@@ -35,7 +35,7 @@ capact action delete --name-regex='upgrade-*' --namespace=foo
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_action_get.md
+++ b/cmd/cli/docs/capact_action_get.md
@@ -33,7 +33,7 @@ capact action get funny-stallman -ojson
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_action_logs.md
+++ b/cmd/cli/docs/capact_action_logs.md
@@ -1,0 +1,67 @@
+---
+title: capact action logs
+---
+
+## capact action logs
+
+Print the Action's logs
+
+### Synopsis
+
+Print the Action's logs
+
+NOTE:   An action needs to be created and run in order to run this command.
+        This command calls the Kubernetes API directly. As a result, KUBECONFIG has to be configured
+        with the same cluster as the one which the Gateway points to.
+
+```
+capact action logs ACTION [POD] [flags]
+```
+
+### Examples
+
+```
+# Print the logs of an Action:
+capact logs example
+
+# Follow the logs of an Action:
+capact logs example --follow
+
+# Print the logs of single container in a pod
+capact logs example step-pod -c step-pod-container
+
+# Print the logs of an Action's step:
+capact logs example step-pod
+
+# Print the logs of the latest executed Action:
+capact logs @latest
+
+```
+
+### Options
+
+```
+  -c, --container string    Print the logs of this container (default "main")
+  -f, --follow              Specify if the logs should be streamed.
+      --grep string         grep for lines
+  -h, --help                help for logs
+  -n, --namespace string    If present, the namespace scope for this CLI request
+      --no-color            Disable colorized output
+  -p, --previous            Specify if the previously terminated container logs should be returned.
+      --since duration      Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.
+      --since-time string   Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.
+      --tail int            If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime (default -1)
+      --timestamps          Include timestamps on each line in the log output
+```
+
+### Options inherited from parent commands
+
+```
+  -C, --config string                 Path to the YAML config file
+  -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
+```
+
+### SEE ALSO
+
+* [capact action](capact_action.md)	 - This command consists of multiple subcommands to interact with target Actions
+

--- a/cmd/cli/docs/capact_action_run.md
+++ b/cmd/cli/docs/capact_action_run.md
@@ -21,7 +21,7 @@ capact action run ACTION [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_action_wait.md
+++ b/cmd/cli/docs/capact_action_wait.md
@@ -31,7 +31,7 @@ capact act wait --for=phase=READY_TO_RUN example
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_action_watch.md
+++ b/cmd/cli/docs/capact_action_watch.md
@@ -43,7 +43,7 @@ capact action watch @latest
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_alpha.md
+++ b/cmd/cli/docs/capact_alpha.md
@@ -19,7 +19,7 @@ Subcommand for alpha features in the CLI
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_alpha_archive-images.md
+++ b/cmd/cli/docs/capact_alpha_archive-images.md
@@ -19,7 +19,7 @@ Subcommand for various manifest generation operations
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_alpha_archive-images_helm.md
+++ b/cmd/cli/docs/capact_alpha_archive-images_helm.md
@@ -42,7 +42,7 @@ capact alpha archive-images helm --version 0.5.0 --output-stdout | gzip > myimag
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_completion.md
+++ b/cmd/cli/docs/capact_completion.md
@@ -46,7 +46,7 @@ capact completion [bash|zsh|fish|powershell] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_config.md
+++ b/cmd/cli/docs/capact_config.md
@@ -19,7 +19,7 @@ Display or change configuration settings for the Hub
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_config_get-contexts.md
+++ b/cmd/cli/docs/capact_config_get-contexts.md
@@ -27,7 +27,7 @@ capact config get-contexts
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_config_set-context.md
+++ b/cmd/cli/docs/capact_config_set-context.md
@@ -30,7 +30,7 @@ capact config set-context localhost:8080
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment.md
+++ b/cmd/cli/docs/capact_environment.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with a Capact environm
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_create.md
+++ b/cmd/cli/docs/capact_environment_create.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to create a Capact environment
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_create_k3d.md
+++ b/cmd/cli/docs/capact_environment_create_k3d.md
@@ -62,7 +62,7 @@ capact environment create k3d [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_create_kind.md
+++ b/cmd/cli/docs/capact_environment_create_kind.md
@@ -25,7 +25,7 @@ capact environment create kind [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_delete.md
+++ b/cmd/cli/docs/capact_environment_delete.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to delete created Capact environme
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_delete_k3d.md
+++ b/cmd/cli/docs/capact_environment_delete_k3d.md
@@ -21,7 +21,7 @@ capact environment delete k3d [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_environment_delete_kind.md
+++ b/cmd/cli/docs/capact_environment_delete_kind.md
@@ -20,7 +20,7 @@ capact environment delete kind [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub.md
+++ b/cmd/cli/docs/capact_hub.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with Hub server.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub_implementation.md
+++ b/cmd/cli/docs/capact_hub_implementation.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with Implementations s
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub_implementation_get.md
+++ b/cmd/cli/docs/capact_hub_implementation_get.md
@@ -32,7 +32,7 @@ capact hub implementations get cap.interface.database.postgresql.install -oyaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub_interface.md
+++ b/cmd/cli/docs/capact_hub_interface.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with Interfaces stored
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub_interface_browse.md
+++ b/cmd/cli/docs/capact_hub_interface_browse.md
@@ -29,7 +29,7 @@ capact hub interface browse [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_hub_interface_get.md
+++ b/cmd/cli/docs/capact_hub_interface_get.md
@@ -32,7 +32,7 @@ capact hub interfaces get cap.interface.database.postgresql.install -ojson
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_install.md
+++ b/cmd/cli/docs/capact_install.md
@@ -52,7 +52,7 @@ capact install --version @local
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_login.md
+++ b/cmd/cli/docs/capact_login.md
@@ -33,7 +33,7 @@ capact login localhost:8080 -u user
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_logout.md
+++ b/cmd/cli/docs/capact_logout.md
@@ -30,7 +30,7 @@ capact logout localhost:8080
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_manifest.md
+++ b/cmd/cli/docs/capact_manifest.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with OCF manifests
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_manifest_generate.md
+++ b/cmd/cli/docs/capact_manifest_generate.md
@@ -35,7 +35,7 @@ capact manifest generate
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_manifest_generate_attribute.md
+++ b/cmd/cli/docs/capact_manifest_generate_attribute.md
@@ -27,7 +27,7 @@ capact manifest generate attribute cap.attribute.cloud.provider.aws
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_implementation.md
+++ b/cmd/cli/docs/capact_manifest_generate_implementation.md
@@ -19,7 +19,7 @@ Generate new Implementation manifests for various tools.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_implementation_empty.md
+++ b/cmd/cli/docs/capact_manifest_generate_implementation_empty.md
@@ -21,7 +21,7 @@ capact manifest generate implementation empty [MANIFEST_PATH] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_implementation_helm.md
+++ b/cmd/cli/docs/capact_manifest_generate_implementation_helm.md
@@ -27,7 +27,7 @@ capact manifest generate implementation helm [MANIFEST_PATH] [HELM_CHART_NAME] [
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_implementation_terraform.md
+++ b/cmd/cli/docs/capact_manifest_generate_implementation_terraform.md
@@ -40,7 +40,7 @@ capact manifest generate implementation terraform cap.implementation.gcp.cloudsq
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_interface.md
+++ b/cmd/cli/docs/capact_manifest_generate_interface.md
@@ -31,7 +31,7 @@ capact manifest generate interface cap.interface.database.postgresql.install
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_interfacegroup.md
+++ b/cmd/cli/docs/capact_manifest_generate_interfacegroup.md
@@ -27,7 +27,7 @@ capact manifest generate interfacegroup cap.interface.database.postgresql
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_generate_type.md
+++ b/cmd/cli/docs/capact_manifest_generate_type.md
@@ -27,7 +27,7 @@ capact manifest generate type cap.type.database.postgresql.config
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -o, --output string                 Path to the output directory for the generated manifests (default "generated")
       --overwrite                     Overwrite existing manifest files
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)

--- a/cmd/cli/docs/capact_manifest_validate.md
+++ b/cmd/cli/docs/capact_manifest_validate.md
@@ -39,7 +39,7 @@ capact manifest validate -s my/ocf/spec/directory ocf-spec/0.0.1/examples/interf
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_policy.md
+++ b/cmd/cli/docs/capact_policy.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with Policy
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_policy_apply.md
+++ b/cmd/cli/docs/capact_policy_apply.md
@@ -29,7 +29,7 @@ capact policy apply -f /tmp/policy.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_policy_edit.md
+++ b/cmd/cli/docs/capact_policy_edit.md
@@ -28,7 +28,7 @@ capact policy edit
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_policy_get.md
+++ b/cmd/cli/docs/capact_policy_get.md
@@ -21,7 +21,7 @@ capact policy get [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance.md
+++ b/cmd/cli/docs/capact_typeinstance.md
@@ -15,7 +15,7 @@ This command consists of multiple subcommands to interact with target TypeInstan
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance_apply.md
+++ b/cmd/cli/docs/capact_typeinstance_apply.md
@@ -36,7 +36,7 @@ capact typeinstance apply -f /tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance_create.md
+++ b/cmd/cli/docs/capact_typeinstance_create.md
@@ -56,7 +56,7 @@ capact typeinstance create -f ./tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance_delete.md
+++ b/cmd/cli/docs/capact_typeinstance_delete.md
@@ -28,7 +28,7 @@ capact typeinstance delete c49b 4793
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance_edit.md
+++ b/cmd/cli/docs/capact_typeinstance_edit.md
@@ -26,7 +26,7 @@ capact typeinstance edit TYPE_INSTANCE_ID [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_typeinstance_get.md
+++ b/cmd/cli/docs/capact_typeinstance_get.md
@@ -34,7 +34,7 @@ capact typeinstance get c49b 4793 -oyaml --export > /tmp/typeinstances.yaml
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_upgrade.md
+++ b/cmd/cli/docs/capact_upgrade.md
@@ -45,7 +45,7 @@ capact upgrade --version 0.1.0
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 

--- a/cmd/cli/docs/capact_version.md
+++ b/cmd/cli/docs/capact_version.md
@@ -20,7 +20,7 @@ capact version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                 Path to the YAML config file
+  -C, --config string                 Path to the YAML config file
   -v, --verbose int/string[=simple]   Prints more verbose output. Allowed values: 0 - disable, 1 - simple, 2 - trace (default 0 - disable)
 ```
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add act logs command
- I had to change the short form for the `--config` flag. Now it's `-C`. IMO it's better as in k8s world on which we rely for now the `-c` is popular short form for the `--container` flag.


## Testing

1. Checkout PR
2. Build CLI `make build-tool-cli`
3. Login into long-running cluster
4. Create `cap.interface.capactio.examples.greet:0.1.0` Action.
    ```bash
    capact act create cap.interface.capactio.examples.greet --name example
    capact act wait --for=phase=READY_TO_RUN example
    ```
6. Run the Action:
    ```bash
    capact act run example
    ```
7. Stream logs:
    ```bash
    capact act logs example -n default -f
    ```


After it's finished, you can play with other options:
```bash
capact act logs @latest -n default
capact act logs example -n default --timestamps
capact act logs example -n default --grep "Hello"
capact act logs example -n default --since 10m
capact act logs example -n default --since 2s
capact act logs example -n default --no-color
```
## Related issue(s)


- https://github.com/capactio/capact/issues/615 - IMO the issue should not be closed until we change the implementation to become k8s agnostic (via Gateway with GraphQL or REST) 