### PR TITLE
Use GH_PAT in GoReleaser

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,7 +2,7 @@ name: Make release
 
 # Required secrets:
 # GCS_CREDS - Credentials to Google Cloud Storage for binary and chart releases
-# GH_PAT - GitHub username with personal access token with permissions to make commits to repository, must be in format "<username>:<PAT>"
+# GH_PAT - GitHub username with personal access token with permissions to make commits to repositories, must be in format "<username>:<PAT>"
 
 on:
   workflow_dispatch:
@@ -84,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.6.0
       - name: Run GoReleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: make release-binaries
       - name: Generate release notes
         run: |


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- Use GH_PAT in GoReleaser

## Related issue(s)

I didn't create a new issue but the root cause is a limited scope of privilege for default [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token). Due to that, when we try to push commits to homebrew-tap repositories, it fails. 
