### PR TITLE
Use a new GitHub token in release job

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.6.0
       - name: Run GoReleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         run: make release-binaries
       - name: Generate release notes
         run: |


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- use a new GitHub token in the release job


`GH_PAT` contains `user:token` where the release job only requires a token to work with. 